### PR TITLE
Add Markdown format support with OverType editor (Opus 4.5)

### DIFF
--- a/packages/apps/browser-app/package.json
+++ b/packages/apps/browser-app/package.json
@@ -84,6 +84,7 @@
     "luxon": "^3.7.2",
     "markdown-to-jsx": "^9.6.1",
     "monaco-editor": "0.55.1",
+    "overtype": "^2.1.1",
     "p-map": "^7.0.4",
     "p-timeout": "^7.0.1",
     "react": "^19.2.4",

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/RHFContentField.css.ts
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/RHFContentField.css.ts
@@ -48,6 +48,20 @@ export const StringField = {
       },
     }),
   },
+
+  Markdown: {
+    root: style({
+      display: "flex",
+      flexDirection: "column",
+      marginBlockEnd: vars.spacing._6,
+    }),
+
+    editor: style({
+      minHeight: "150px",
+      borderRadius: vars.borders.radius.md,
+      overflow: "hidden",
+    }),
+  },
 };
 
 export const FileField = {

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/StringField.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/StringField.tsx
@@ -1,6 +1,7 @@
 import { FormatId } from "@superego/schema";
 import Default from "./formats/Default.js";
 import Instant from "./formats/Instant.js";
+import Markdown from "./formats/Markdown.js";
 import PlainDate from "./formats/PlainDate.js";
 import PlainTime from "./formats/PlainTime.js";
 import type Props from "./Props.js";
@@ -34,6 +35,8 @@ function getComponent(typeDefinition: Props["typeDefinition"]) {
       return PlainTime;
     case FormatId.String.Instant:
       return Instant;
+    case FormatId.String.Markdown:
+      return Markdown;
     default:
       return Default;
   }

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.tsx
@@ -1,0 +1,103 @@
+import OverType, { type OverTypeInstance } from "overtype";
+import { useCallback, useEffect, useRef } from "react";
+import { useController } from "react-hook-form";
+import classnames from "../../../../../utils/classnames.js";
+import { FieldError } from "../../../../design-system/forms/forms.js";
+import AnyFieldLabel from "../../AnyFieldLabel.js";
+import * as cs from "../../RHFContentField.css.js";
+import { useUiOptions } from "../../uiOptions.js";
+import type Props from "../Props.js";
+
+export default function Markdown({
+  typeDefinition,
+  isNullable,
+  isListItem,
+  control,
+  name,
+  label,
+}: Props) {
+  const { isReadOnly } = useUiOptions();
+  const { field, fieldState } = useController({ control, name });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<OverTypeInstance | null>(null);
+  const isInternalChange = useRef(false);
+
+  const handleChange = useCallback(
+    (value: string) => {
+      isInternalChange.current = true;
+      field.onChange(value !== "" ? value : null);
+    },
+    [field],
+  );
+
+  useEffect(() => {
+    if (!containerRef.current || editorRef.current) {
+      return;
+    }
+
+    const [editor] = new OverType(containerRef.current, {
+      value: field.value ?? "",
+      toolbar: !isReadOnly,
+      autoResize: true,
+      minHeight: "150px",
+      placeholder: "null",
+      onChange: handleChange,
+      textareaProps: {
+        "aria-label": isListItem ? label : undefined,
+        "aria-invalid": fieldState.invalid || undefined,
+        readOnly: isReadOnly,
+      },
+    });
+
+    editorRef.current = editor ?? null;
+
+    return () => {
+      editorRef.current?.destroy();
+      editorRef.current = null;
+    };
+  }, [field.value, fieldState.invalid, handleChange, isListItem, isReadOnly, label]);
+
+  useEffect(() => {
+    if (editorRef.current && !isInternalChange.current) {
+      const currentValue = editorRef.current.getValue();
+      const newValue = field.value ?? "";
+      if (currentValue !== newValue) {
+        editorRef.current.setValue(newValue);
+      }
+    }
+    isInternalChange.current = false;
+  }, [field.value]);
+
+  useEffect(() => {
+    if (editorRef.current && isReadOnly) {
+      editorRef.current.showPreviewMode();
+    } else if (editorRef.current && !isReadOnly) {
+      editorRef.current.showNormalEditMode();
+    }
+  }, [isReadOnly]);
+
+  return (
+    <div
+      data-data-type={typeDefinition.dataType}
+      data-is-list-item={isListItem}
+      className={classnames(
+        cs.StringField.Markdown.root,
+        isListItem && cs.ListItemField.root,
+      )}
+    >
+      {!isListItem ? (
+        <AnyFieldLabel
+          typeDefinition={typeDefinition}
+          isNullable={isNullable}
+          label={label}
+        />
+      ) : null}
+      <div
+        ref={containerRef}
+        className={cs.StringField.Markdown.editor}
+        onBlur={field.onBlur}
+      />
+      <FieldError>{fieldState.error?.message}</FieldError>
+    </div>
+  );
+}

--- a/packages/core/schema/src/formats/FormatId.ts
+++ b/packages/core/schema/src/formats/FormatId.ts
@@ -3,6 +3,7 @@ export default {
     PlainDate: "dev.superego:String.PlainDate",
     PlainTime: "dev.superego:String.PlainTime",
     Instant: "dev.superego:String.Instant",
+    Markdown: "dev.superego:String.Markdown",
   },
   Number: {
     Integer: "dev.superego:Number.Integer",

--- a/packages/core/schema/src/formats/String.ts
+++ b/packages/core/schema/src/formats/String.ts
@@ -109,4 +109,21 @@ export default [
       ),
     ),
   },
+
+  {
+    dataType: DataType.String,
+    id: FormatId.String.Markdown,
+    name: "Markdown",
+    description:
+      "A string formatted as Markdown, supporting common Markdown syntax for formatting text.",
+    validExamples: [
+      "# Heading",
+      "**bold** and *italic*",
+      "- list item\n- another item",
+      "[link](https://example.com)",
+      "```code block```",
+    ],
+    invalidExamples: [],
+    valibotSchema: v.string(),
+  },
 ] satisfies Format<DataType.String>[];

--- a/packages/core/schema/src/formats/formats.test.ts
+++ b/packages/core/schema/src/formats/formats.test.ts
@@ -14,12 +14,14 @@ Object.values(formats)
           });
         });
       });
-      describe("not valid", () => {
-        format.invalidExamples.forEach((value) => {
-          it(`${JSON.stringify(value)}`, () => {
-            expect(v.is(format.valibotSchema, value)).toBe(false);
+      if (format.invalidExamples.length > 0) {
+        describe("not valid", () => {
+          format.invalidExamples.forEach((value) => {
+            it(`${JSON.stringify(value)}`, () => {
+              expect(v.is(format.valibotSchema, value)).toBe(false);
+            });
           });
         });
-      });
+      }
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6191,6 +6191,7 @@ __metadata:
     luxon: "npm:^3.7.2"
     markdown-to-jsx: "npm:^9.6.1"
     monaco-editor: "npm:0.55.1"
+    overtype: "npm:^2.1.1"
     p-map: "npm:^7.0.4"
     p-timeout: "npm:^7.0.1"
     playwright: "npm:^1.58.1"
@@ -12158,6 +12159,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-actions@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "markdown-actions@npm:1.1.2"
+  checksum: 10c0/67f9853c5fa748f34836f84be965a667fad13b96ebbc8cacb35fce873c669e3b473b1cb3da7694331fdf05e18ce6ef8b46426df4d6a25801df881cb3faf92ea6
+  languageName: node
+  linkType: hard
+
 "markdown-extensions@npm:^2.0.0":
   version: 2.0.0
   resolution: "markdown-extensions@npm:2.0.0"
@@ -13602,6 +13610,15 @@ __metadata:
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 10c0/f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
+  languageName: node
+  linkType: hard
+
+"overtype@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "overtype@npm:2.1.1"
+  dependencies:
+    markdown-actions: "npm:^1.1.2"
+  checksum: 10c0/4905faf60ec5721f80dc4abe5e65823e8c159e271db06bf53e7d0aa6648806e4dce114a86c4ff3386be72e803a58a7c256ab23eff3b712f46e6d2081d6384270
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This PR adds support for Markdown-formatted strings in the schema system, including a rich text editor component powered by the OverType library.

## Key Changes
- **New Markdown Format**: Added `FormatId.String.Markdown` to the schema format definitions with validation and documentation
- **OverType Editor Component**: Implemented a new `Markdown.tsx` component that provides:
  - Rich markdown editing with toolbar support
  - Preview mode for read-only states
  - Automatic resizing based on content
  - Proper accessibility attributes and error handling
  - Synchronization with React Hook Form controller
- **Styling**: Added CSS styles for the markdown editor container and editor element
- **Dependencies**: Added `overtype@^2.1.1` package for markdown editing functionality
- **Test Improvements**: Updated format tests to skip "invalid examples" describe block when no invalid examples exist

## Implementation Details
- The Markdown component uses refs to manage the OverType editor instance lifecycle
- Internal change tracking prevents unnecessary updates when values are changed programmatically
- The editor automatically switches between edit and preview modes based on the `isReadOnly` flag
- Empty values are treated as `null` to maintain consistency with nullable field behavior
- Full accessibility support with proper ARIA labels and invalid state indicators

https://claude.ai/code/session_01ADkGyVVLjt36dj7EXiR76S