### PR TITLE
Add ExcalidrawDrawing JsonObject format support (Codex)#56

### DIFF
--- a/packages/apps/browser-app/src/business-logic/forms/defaults/excalidrawDrawingJsonObject.ts
+++ b/packages/apps/browser-app/src/business-logic/forms/defaults/excalidrawDrawingJsonObject.ts
@@ -1,4 +1,12 @@
-export default function excalidrawDrawingJsonObject() {
+import type { ExcalidrawInitialDataState } from "@excalidraw/excalidraw/types";
+
+export type ExcalidrawDrawingValue = {
+  elements: NonNullable<ExcalidrawInitialDataState["elements"]>;
+  appState: NonNullable<ExcalidrawInitialDataState["appState"]>;
+  files: NonNullable<ExcalidrawInitialDataState["files"]>;
+};
+
+export default function excalidrawDrawingJsonObject(): ExcalidrawDrawingValue {
   return {
     elements: [],
     appState: {},

--- a/packages/apps/browser-app/src/components/design-system/ExcalidrawInput/EagerExcalidrawInput.tsx
+++ b/packages/apps/browser-app/src/components/design-system/ExcalidrawInput/EagerExcalidrawInput.tsx
@@ -1,5 +1,6 @@
 import "@excalidraw/excalidraw/index.css";
 import { Excalidraw } from "@excalidraw/excalidraw";
+import type { ExcalidrawProps } from "@excalidraw/excalidraw/types";
 import { useCallback, useEffect, useRef } from "react";
 import forms from "../../../business-logic/forms/forms.js";
 import * as cs from "./ExcalidrawInput.css.js";
@@ -29,12 +30,8 @@ export default function EagerExcalidrawInput({
       rootRef.current?.focus();
     }
   }, [autoFocus]);
-  const handleChange = useCallback(
-    (
-      elements: unknown[],
-      appState: Record<string, unknown>,
-      files: Record<string, unknown>,
-    ) => {
+  const handleChange = useCallback<NonNullable<ExcalidrawProps["onChange"]>>(
+    (elements, appState, files) => {
       onChange({ elements, appState, files });
     },
     [onChange],

--- a/packages/apps/browser-app/src/components/design-system/ExcalidrawInput/Props.ts
+++ b/packages/apps/browser-app/src/components/design-system/ExcalidrawInput/Props.ts
@@ -1,8 +1,6 @@
-export interface ExcalidrawDrawingValue {
-  elements: unknown[];
-  appState: Record<string, unknown>;
-  files: Record<string, unknown>;
-}
+import type { ExcalidrawDrawingValue } from "../../../business-logic/forms/defaults/excalidrawDrawingJsonObject.js";
+
+export type { ExcalidrawDrawingValue };
 
 export default interface Props {
   value: ExcalidrawDrawingValue | null | undefined;

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/JsonObjectField/JsonObjectField.test.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/JsonObjectField/JsonObjectField.test.tsx
@@ -1,4 +1,5 @@
 import { DataType, FormatId } from "@superego/schema";
+import type { FieldValues } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "../../../../test-utils.js";
@@ -9,7 +10,7 @@ vi.mock("./formats/ExcalidrawDrawing.js", () => ({
 }));
 
 function TestHarness({ format }: { format?: string }) {
-  const { control } = useForm({
+  const { control } = useForm<FieldValues>({
     defaultValues: {
       drawing: {
         __dataType: DataType.JsonObject,

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/JsonObjectField/formats/ExcalidrawDrawing.test.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/JsonObjectField/formats/ExcalidrawDrawing.test.tsx
@@ -1,0 +1,70 @@
+import { DataType } from "@superego/schema";
+import type { FieldValues } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "../../../../../test-utils.js";
+import type ExcalidrawInputProps from "../../../../design-system/ExcalidrawInput/Props.js";
+import ExcalidrawDrawing from "./ExcalidrawDrawing.js";
+
+const excalidrawInputSpy = vi.fn();
+
+vi.mock("../../../../design-system/ExcalidrawInput/ExcalidrawInput.js", () => ({
+  default: (props: ExcalidrawInputProps) => {
+    excalidrawInputSpy(props);
+    return <div data-testid="ExcalidrawInput" />;
+  },
+}));
+
+vi.mock("../../uiOptions.js", () => ({
+  useUiOptions: () => ({ isReadOnly: true }),
+}));
+
+function TestHarness() {
+  const { control } = useForm<FieldValues>({
+    defaultValues: {
+      drawing: {
+        __dataType: DataType.JsonObject,
+        elements: [],
+        appState: {},
+        files: {},
+      },
+    },
+  });
+
+  return (
+    <ExcalidrawDrawing
+      typeDefinition={{ dataType: DataType.JsonObject }}
+      isNullable={false}
+      isListItem={false}
+      control={control}
+      name="drawing"
+      label="Drawing"
+    />
+  );
+}
+
+describe("ExcalidrawDrawing", () => {
+  it("passes the drawing value without __dataType to ExcalidrawInput", () => {
+    // Setup mocks
+    excalidrawInputSpy.mockClear();
+
+    // Setup SUT
+    render(<TestHarness />);
+
+    // Exercise
+    const [props] = excalidrawInputSpy.mock.calls[0] ?? [];
+
+    // Verify
+    expect(props).toEqual(
+      expect.objectContaining({
+        isReadOnly: true,
+        value: {
+          elements: [],
+          appState: {},
+          files: {},
+        },
+      }),
+    );
+    expect(props.value).not.toHaveProperty("__dataType");
+  });
+});


### PR DESCRIPTION
### Motivation
- Add native support for Excalidraw drawings as a `JsonObject` format so drawings can be persisted, validated and edited in the browser UI similar to the existing Tiptap rich-text format. 
- Reuse the existing lazy/eager component pattern used by `TiptapInput` to provide a simple (dumb) Excalidraw input component and a default JSON shape for new values.

### Description
- Add `FormatId.JsonObject.ExcalidrawDrawing` and a corresponding format entry with validation rules to the schema in `packages/core/schema/src/formats/*` so Excalidraw documents are recognized and validated by valibot. 
- Implement a new `ExcalidrawInput` design-system component (lazy `ExcalidrawInput.tsx`, eager `EagerExcalidrawInput.tsx`, `Props.ts`, and CSS) that wraps `@excalidraw/excalidraw` and follows the `TiptapInput` pattern. 
- Wire the new format into the content editor UI by adding `ExcalidrawDrawing` format renderer, updating `JsonObjectField` selection logic, adding styles in `RHFContentField.css.ts`, and adding a default value provider `excalidrawDrawingJsonObject`. 
- Add a unit test `JsonObjectField.test.tsx` that asserts the `ExcalidrawDrawing` format is rendered when configured, and add the `@excalidraw/excalidraw` dependency to `packages/apps/browser-app/package.json`.

### Testing
- Ran schema unit tests with `yarn workspace @superego/schema test --run src/formats/formats.test.ts`, and all tests passed (formats tests, including the new `ExcalidrawDrawing` cases). 
- Ran the browser-app unit test for the new `JsonObjectField` file but the test run failed because Playwright browsers are not installed; Vitest reported an error asking to run `yarn playwright install`. 
- `yarn install` / dependency installation could not complete in the environment due to a network `403` error so `yarn.lock` was not updated and browser integration tests could not be executed; please run `yarn install` (and `yarn playwright install`) in CI or locally before merging. 
- Note: per repository frontend rules, `yarn workspace @superego/browser-app translations:extract-and-compile` should be run and `packages/apps/browser-app/src/translations/it.json` updated if needed after installing dependencies and building translations.

------

[First Codex Task](https://chatgpt.com/codex/tasks/task_e_69856d9ae970832ea215dfe06c107c9a)
[Follow up Codex Task](https://chatgpt.com/codex/tasks/task_e_698591f95c90832e8f54325ae18e54d1)