### PR TITLE
Extract text from tiptap without @tiptap/core

### DIFF
--- a/packages/core/schema/package.json
+++ b/packages/core/schema/package.json
@@ -27,8 +27,6 @@
   },
   "dependencies": {
     "@superego/global-types": "workspace:*",
-    "@tiptap/core": "^3.19.0",
-    "@tiptap/starter-kit": "^3.19.0",
     "luxon": "^3.7.2",
     "remove-markdown": "^0.6.3",
     "valibot": "^1.2.0"

--- a/packages/core/schema/src/index.ts
+++ b/packages/core/schema/src/index.ts
@@ -5,7 +5,7 @@ import {
   isValidPlainTime,
 } from "./utils/dateTimeValidators.js";
 import extractReferencedCollectionIds from "./utils/extractReferencedCollectionIds.js";
-import extractTextChunks from "./utils/extractTextChunks.js";
+import extractTextChunks from "./utils/extractTextChunks/extractTextChunks.js";
 import getRootType from "./utils/getRootType.js";
 import getType from "./utils/getType.js";
 import getTypeDefinitionAtPath from "./utils/getTypeDefinitionAtPath.js";
@@ -29,7 +29,7 @@ export type { default as FileRef } from "./types/FileRef.js";
 export type { default as JsonObject } from "./types/JsonObject.js";
 export type { default as ProtoFile } from "./types/ProtoFile.js";
 export type { default as RHFProtoFile } from "./types/RHFProtoFile.js";
-export type { TextChunks } from "./utils/extractTextChunks.js";
+export type { TextChunks } from "./utils/extractTextChunks/extractTextChunks.js";
 export const valibotSchemas = { schema, content };
 export const utils = {
   getRootType,

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextChunks.test.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextChunks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import DataType from "../DataType.js";
-import FormatId from "../formats/FormatId.js";
-import type Schema from "../Schema.js";
+import DataType from "../../DataType.js";
+import FormatId from "../../formats/FormatId.js";
+import type Schema from "../../Schema.js";
 import extractTextChunks from "./extractTextChunks.js";
 
 describe("extracts text chunks for the supplied document content", () => {

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextChunks.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextChunks.ts
@@ -1,13 +1,12 @@
-import { generateText, type JSONContent } from "@tiptap/core";
-import StarterKit from "@tiptap/starter-kit";
 import removeMarkdown from "remove-markdown";
-import DataType from "../DataType.js";
-import FormatId from "../formats/FormatId.js";
-import type Schema from "../Schema.js";
-import type { AnyTypeDefinition } from "../typeDefinitions.js";
-import type JsonObject from "../types/JsonObject.js";
-import getRootType from "./getRootType.js";
-import getType from "./getType.js";
+import DataType from "../../DataType.js";
+import FormatId from "../../formats/FormatId.js";
+import type Schema from "../../Schema.js";
+import type { AnyTypeDefinition } from "../../typeDefinitions.js";
+import getRootType from "../getRootType.js";
+import getType from "../getType.js";
+import extractTextFromExcalidraw from "./extractTextFromExcalidraw.js";
+import extractTextFromTiptap from "./extractTextFromTiptap.js";
 
 export interface TextChunks {
   [path: string]: string[];
@@ -128,30 +127,4 @@ function addChunk(chunks: TextChunks, path: string, text: string): void {
     chunks[path] = [];
   }
   chunks[path].push(text);
-}
-
-function extractTextFromTiptap(jsonObject: JsonObject): string {
-  const { __dataType, ...tiptapContent } = jsonObject;
-  return generateText(tiptapContent as JSONContent, [StarterKit], {
-    blockSeparator: "\n",
-  });
-}
-
-function extractTextFromExcalidraw({ elements }: JsonObject): string | null {
-  if (!Array.isArray(elements)) {
-    return null;
-  }
-  return elements
-    .map((element: unknown) =>
-      typeof element === "object" &&
-      element != null &&
-      "type" in element &&
-      element.type === "text" &&
-      "text" in element &&
-      typeof element.text === "string"
-        ? element.text
-        : null,
-    )
-    .filter((text) => text !== null)
-    .join(" ");
 }

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextFromExcalidraw.test.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextFromExcalidraw.test.ts
@@ -1,0 +1,170 @@
+import { expect, it } from "vitest";
+import DataType from "../../DataType.js";
+import type JsonObject from "../../types/JsonObject.js";
+import extractTextFromExcalidraw from "./extractTextFromExcalidraw.js";
+
+const testCases: {
+  name: string;
+  input: JsonObject;
+  expected: string | null;
+}[] = [
+  {
+    name: "single text element",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [{ type: "text", text: "hello" }],
+    },
+    expected: "hello",
+  },
+  {
+    name: "multiple text elements",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        { type: "text", text: "hello" },
+        { type: "text", text: "world" },
+      ],
+    },
+    expected: "hello world",
+  },
+  {
+    name: "text elements mixed with non-text elements",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        { type: "rectangle", x: 0, y: 0, width: 100, height: 50 },
+        { type: "text", text: "label" },
+        { type: "ellipse", x: 200, y: 100, width: 80, height: 80 },
+        { type: "text", text: "annotation" },
+        {
+          type: "arrow",
+          points: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      ],
+    },
+    expected: "label annotation",
+  },
+  {
+    name: "no text elements",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        { type: "rectangle", x: 0, y: 0, width: 100, height: 50 },
+        { type: "ellipse", x: 200, y: 100, width: 80, height: 80 },
+        { type: "diamond", x: 50, y: 50, width: 60, height: 60 },
+      ],
+    },
+    expected: "",
+  },
+  {
+    name: "empty elements array",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [],
+    },
+    expected: "",
+  },
+  {
+    name: "missing elements property",
+    input: {
+      __dataType: DataType.JsonObject,
+      appState: { viewBackgroundColor: "#ffffff" },
+    },
+    expected: null,
+  },
+  {
+    name: "elements is not an array",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: "not-an-array",
+    },
+    expected: null,
+  },
+  {
+    name: "text elements with extra properties",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        {
+          type: "text",
+          text: "styled text",
+          fontSize: 20,
+          fontFamily: 1,
+          textAlign: "center",
+          x: 100,
+          y: 200,
+          strokeColor: "#000000",
+          backgroundColor: "transparent",
+        },
+      ],
+    },
+    expected: "styled text",
+  },
+  {
+    name: "element with type text but missing text property",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [{ type: "text" }, { type: "text", text: "valid" }],
+    },
+    expected: "valid",
+  },
+  {
+    name: "element with type text but non-string text property",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        { type: "text", text: 123 },
+        { type: "text", text: "valid" },
+      ],
+    },
+    expected: "valid",
+  },
+  {
+    name: "complex drawing with many element types",
+    input: {
+      __dataType: DataType.JsonObject,
+      elements: [
+        { type: "rectangle", x: 10, y: 10, width: 200, height: 100 },
+        { type: "text", text: "Title", fontSize: 28, textAlign: "center" },
+        {
+          type: "line",
+          points: [
+            [0, 0],
+            [200, 0],
+          ],
+        },
+        { type: "text", text: "Step 1", fontSize: 16 },
+        {
+          type: "arrow",
+          points: [
+            [0, 0],
+            [0, 50],
+          ],
+        },
+        { type: "rectangle", x: 10, y: 200, width: 200, height: 100 },
+        { type: "text", text: "Step 2", fontSize: 16 },
+        {
+          type: "freedraw",
+          points: [
+            [0, 0],
+            [10, 5],
+            [20, 0],
+          ],
+        },
+        { type: "image", fileId: "abc123" },
+      ],
+    },
+    expected: "Title Step 1 Step 2",
+  },
+];
+
+it.each(testCases)("case: $name", ({ input, expected }) => {
+  // Exercise
+  const result = extractTextFromExcalidraw(input);
+
+  // Verify
+  expect(result).toEqual(expected);
+});

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextFromExcalidraw.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextFromExcalidraw.ts
@@ -1,0 +1,22 @@
+import type JsonObject from "../../types/JsonObject.js";
+
+export default function extractTextFromExcalidraw({
+  elements,
+}: JsonObject): string | null {
+  if (!Array.isArray(elements)) {
+    return null;
+  }
+  return elements
+    .map((element: unknown) =>
+      typeof element === "object" &&
+      element != null &&
+      "type" in element &&
+      element.type === "text" &&
+      "text" in element &&
+      typeof element.text === "string"
+        ? element.text
+        : null,
+    )
+    .filter((text) => text !== null)
+    .join(" ");
+}

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextFromTiptap.test.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextFromTiptap.test.ts
@@ -1,0 +1,482 @@
+import { expect, it } from "vitest";
+import DataType from "../../DataType.js";
+import type JsonObject from "../../types/JsonObject.js";
+import extractTextFromTiptap from "./extractTextFromTiptap.js";
+
+const testCases: {
+  name: string;
+  input: JsonObject;
+  expected: string;
+}[] = [
+  {
+    name: "paragraph",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "A simple paragraph." }],
+        },
+      ],
+    },
+    expected: "A simple paragraph.",
+  },
+  {
+    name: "multiple paragraphs",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "First paragraph." }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Second paragraph." }],
+        },
+      ],
+    },
+    expected: "First paragraph. Second paragraph.",
+  },
+  {
+    name: "heading",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Main Title" }],
+        },
+      ],
+    },
+    expected: "Main Title",
+  },
+  {
+    name: "heading followed by paragraph",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Section Title" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Section content here." }],
+        },
+      ],
+    },
+    expected: "Section Title Section content here.",
+  },
+  {
+    name: "blockquote",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "To be or not to be." }],
+            },
+          ],
+        },
+      ],
+    },
+    expected: "To be or not to be.",
+  },
+  {
+    name: "blockquote with multiple paragraphs",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "First quoted line." }],
+            },
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Second quoted line." }],
+            },
+          ],
+        },
+      ],
+    },
+    expected: "First quoted line. Second quoted line.",
+  },
+  {
+    name: "bullet list",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Apples" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Bananas" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Cherries" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    expected: "Apples Bananas Cherries",
+  },
+  {
+    name: "ordered list",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "First step" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Second step" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    expected: "First step Second step",
+  },
+  {
+    name: "code block",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          content: [
+            {
+              type: "text",
+              text: "const x = 1;\nconst y = 2;",
+            },
+          ],
+        },
+      ],
+    },
+    expected: "const x = 1;\nconst y = 2;",
+  },
+  {
+    name: "horizontal rule between paragraphs",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Above the line." }],
+        },
+        { type: "horizontalRule" },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Below the line." }],
+        },
+      ],
+    },
+    expected: "Above the line. Below the line.",
+  },
+  {
+    name: "hard break",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Line one" },
+            { type: "hardBreak" },
+            { type: "text", text: "Line two" },
+          ],
+        },
+      ],
+    },
+    expected: "Line one Line two",
+  },
+  {
+    name: "bold text",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "This is " },
+            {
+              type: "text",
+              marks: [{ type: "bold" }],
+              text: "bold",
+            },
+            { type: "text", text: " text." },
+          ],
+        },
+      ],
+    },
+    expected: "This is bold text.",
+  },
+  {
+    name: "italic text",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "This is " },
+            {
+              type: "text",
+              marks: [{ type: "italic" }],
+              text: "italic",
+            },
+            { type: "text", text: " text." },
+          ],
+        },
+      ],
+    },
+    expected: "This is italic text.",
+  },
+  {
+    name: "strikethrough text",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "This is " },
+            {
+              type: "text",
+              marks: [{ type: "strike" }],
+              text: "struck",
+            },
+            { type: "text", text: " text." },
+          ],
+        },
+      ],
+    },
+    expected: "This is struck text.",
+  },
+  {
+    name: "inline code",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Use the " },
+            {
+              type: "text",
+              marks: [{ type: "code" }],
+              text: "console.log()",
+            },
+            { type: "text", text: " function." },
+          ],
+        },
+      ],
+    },
+    expected: "Use the console.log() function.",
+  },
+  {
+    name: "mixed marks on the same text",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              marks: [{ type: "bold" }, { type: "italic" }],
+              text: "bold and italic",
+            },
+          ],
+        },
+      ],
+    },
+    expected: "bold and italic",
+  },
+  {
+    name: "complex document with multiple block types",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Document Title" }],
+        },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "An introductory paragraph with " },
+            {
+              type: "text",
+              marks: [{ type: "bold" }],
+              text: "bold",
+            },
+            { type: "text", text: " text." },
+          ],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Shopping List" }],
+        },
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Milk" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Eggs" }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "A wise quote." }],
+            },
+          ],
+        },
+        {
+          type: "codeBlock",
+          content: [{ type: "text", text: "console.log('hi');" }],
+        },
+      ],
+    },
+    expected:
+      "Document Title An introductory paragraph with bold text. Shopping List Milk Eggs A wise quote. console.log('hi');",
+  },
+  {
+    name: "empty paragraph",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    },
+    expected: "",
+  },
+  {
+    name: "nested list items",
+    input: {
+      __dataType: DataType.JsonObject,
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Parent item" }],
+                },
+                {
+                  type: "bulletList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Child item" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    expected: "Parent item Child item",
+  },
+];
+
+it.each(testCases)("case: $name", ({ input, expected }) => {
+  // Exercise
+  const result = extractTextFromTiptap(input);
+
+  // Verify
+  expect(result).toEqual(expected);
+});

--- a/packages/core/schema/src/utils/extractTextChunks/extractTextFromTiptap.ts
+++ b/packages/core/schema/src/utils/extractTextChunks/extractTextFromTiptap.ts
@@ -1,0 +1,35 @@
+import type JsonObject from "../../types/JsonObject.js";
+
+export default function extractTextFromTiptap(jsonObject: JsonObject): string {
+  return extractText(jsonObject as unknown as TiptapNode);
+}
+
+interface TiptapNode {
+  type: string;
+  text?: string;
+  content?: TiptapNode[];
+}
+
+const inlineTypes = new Set(["text", "hardBreak"]);
+
+function extractText(node: TiptapNode): string {
+  if (node.type === "text") {
+    return node.text ?? "";
+  }
+
+  if (node.type === "hardBreak") {
+    return " ";
+  }
+
+  if (!Array.isArray(node.content)) {
+    return "";
+  }
+
+  const childTexts = node.content
+    .map((child) => extractText(child))
+    .filter((text) => text !== "");
+  const hasBlockChildren = node.content.some(
+    (child) => !inlineTypes.has(child.type),
+  );
+  return childTexts.join(hasBlockChildren ? " " : "");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8298,8 +8298,6 @@ __metadata:
   dependencies:
     "@fast-check/vitest": "npm:^0.2.4"
     "@superego/global-types": "workspace:*"
-    "@tiptap/core": "npm:^3.19.0"
-    "@tiptap/starter-kit": "npm:^3.19.0"
     "@types/json-schema": "npm:^7.0.15"
     "@types/luxon": "npm:^3.7.1"
     "@types/node": "npm:^25.2.3"


### PR DESCRIPTION
@tiptap/starter-kit imports styles and other things that don't work in the electron preload script, and that in general make it bloated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for text extraction functionality, covering diverse document formats, edge cases, and complex structures to ensure robust behavior.

* **Refactor**
  * Reorganized internal module structure for improved code organization and maintainability.

* **Chores**
  * Removed unnecessary dependencies to optimize package footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->