### PR TITLE
Use CSS field-sizing for textarea auto-resize with JS fallback

### DIFF
--- a/packages/apps/browser-app/src/components/widgets/UserMessageContentInput/UserMessageContentInput.css.ts
+++ b/packages/apps/browser-app/src/components/widgets/UserMessageContentInput/UserMessageContentInput.css.ts
@@ -28,12 +28,12 @@ export const UserMessageContentInput = {
   textArea: style({
     width: "100%",
     maxHeight: vars.spacing._80,
+    fieldSizing: "content",
     fontFamily: vars.typography.fontFamilies.sansSerif,
     fontSize: vars.typography.fontSizes.md,
     border: 0,
     background: vars.colors.background.surface,
     color: vars.colors.text.primary,
-    height: 16.5,
     padding: 0,
     marginBlock: vars.spacing._0_5,
     resize: "none",

--- a/packages/apps/browser-app/src/components/widgets/UserMessageContentInput/useAutoResizeTextArea.ts
+++ b/packages/apps/browser-app/src/components/widgets/UserMessageContentInput/useAutoResizeTextArea.ts
@@ -1,5 +1,11 @@
 import { type RefObject, useEffect } from "react";
 
+// On browsers that support field-sizing (all major browsers except Firefox),
+// auto-resizing is handled by the CSS `field-sizing: content` property, so this
+// hook becomes a no-op. On Firefox, we fall back to the JS-based resize.
+const supportsFieldSizing =
+  typeof CSS !== "undefined" && CSS.supports("field-sizing", "content");
+
 export default function useAutoResizeTextArea(
   textAreaRef: RefObject<HTMLTextAreaElement | null>,
   content: string,
@@ -7,6 +13,7 @@ export default function useAutoResizeTextArea(
   // We want to resize the textarea on content change.
   // biome-ignore lint/correctness/useExhaustiveDependencies: see above.
   useEffect(() => {
+    if (supportsFieldSizing) return;
     if (textAreaRef.current) {
       textAreaRef.current.style.overflowY = "hidden";
       textAreaRef.current.style.height = "auto";


### PR DESCRIPTION
## Summary
Improved textarea auto-resizing by leveraging the CSS `field-sizing: content` property for modern browsers, with a JavaScript-based fallback for Firefox which doesn't yet support this feature.

## Key Changes
- Added feature detection for `field-sizing: content` CSS property support
- Applied `field-sizing: content` to the textarea styling, which automatically handles content-based resizing in supporting browsers
- Modified the `useAutoResizeTextArea` hook to skip JavaScript-based resizing when `field-sizing` is supported, reducing unnecessary DOM manipulation
- Removed the hardcoded `height: 16.5` style in favor of CSS-based auto-sizing

## Implementation Details
- The feature detection checks if the browser's CSS object supports the `field-sizing` property
- On browsers with native support (Chrome, Safari, Edge, etc.), the CSS property handles all resizing automatically
- On Firefox, the hook falls back to the existing JavaScript-based approach that manually adjusts textarea height based on content
- This approach provides better performance on modern browsers while maintaining compatibility with Firefox

https://claude.ai/code/session_012KA2PkTDu7qqmKKRurgEsJ