### PR TITLE
Add input validation decorator and schemas for usecase arguments

### DIFF
--- a/packages/core/backend/src/errors/InputNotValid.ts
+++ b/packages/core/backend/src/errors/InputNotValid.ts
@@ -1,0 +1,10 @@
+import type { ResultError } from "@superego/global-types";
+import type ValidationIssue from "../types/ValidationIssue.js";
+
+type InputNotValid = ResultError<
+  "InputNotValid",
+  {
+    issues: ValidationIssue[];
+  }
+>;
+export default InputNotValid;

--- a/packages/core/backend/src/index.ts
+++ b/packages/core/backend/src/index.ts
@@ -66,6 +66,7 @@ export type { default as DuplicateDocumentDetected } from "./errors/DuplicateDoc
 export type { default as ExecutingJavascriptFunctionFailed } from "./errors/ExecutingJavascriptFunctionFailed.js";
 export type { default as FileNotFound } from "./errors/FileNotFound.js";
 export type { default as FilesNotFound } from "./errors/FilesNotFound.js";
+export type { default as InputNotValid } from "./errors/InputNotValid.js";
 export type { default as MakingContentBlockingKeysFailed } from "./errors/MakingContentBlockingKeysFailed.js";
 export type { default as PackNotFound } from "./errors/PackNotFound.js";
 export type { default as PackNotValid } from "./errors/PackNotValid.js";

--- a/packages/core/executing-backend/src/makers/makeResultError.ts
+++ b/packages/core/executing-backend/src/makers/makeResultError.ts
@@ -43,6 +43,7 @@ import type {
   ExecutingJavascriptFunctionFailed,
   FileNotFound,
   FilesNotFound,
+  InputNotValid,
   MakingContentBlockingKeysFailed,
   PackNotFound,
   PackNotValid,
@@ -103,6 +104,7 @@ type KnownResultError =
   | ExecutingJavascriptFunctionFailed
   | FileNotFound
   | FilesNotFound
+  | InputNotValid
   | MakingContentBlockingKeysFailed
   | PackNotFound
   | PackNotValid

--- a/packages/core/executing-backend/src/usecases/apps/Create.ts
+++ b/packages/core/executing-backend/src/usecases/apps/Create.ts
@@ -20,14 +20,21 @@ import type AppVersionEntity from "../../entities/AppVersionEntity.js";
 import makeApp from "../../makers/makeApp.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 interface AppsCreateOptions {
   appId?: AppId;
 }
 
+const appsCreateOptionsSchema = v.strictObject({
+  appId: v.optional(valibotSchemas.id.app()),
+});
+
 export default class AppsCreate extends Usecase<Backend["apps"]["create"]> {
+  @validateArgs([argSchemas.appDefinition(), appsCreateOptionsSchema])
   async exec(
     { type, name, targetCollectionIds, files }: AppDefinition,
     options: AppsCreateOptions = {},

--- a/packages/core/executing-backend/src/usecases/apps/CreateNewVersion.ts
+++ b/packages/core/executing-backend/src/usecases/apps/CreateNewVersion.ts
@@ -12,17 +12,26 @@ import {
   Id,
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import type AppVersionEntity from "../../entities/AppVersionEntity.js";
 import makeApp from "../../makers/makeApp.js";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertAppVersionExists from "../../utils/assertAppVersionExists.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class AppsCreateNewVersion extends Usecase<
   Backend["apps"]["createNewVersion"]
 > {
+  @validateArgs([
+    valibotSchemas.id.app(),
+    v.array(valibotSchemas.id.collection()),
+    argSchemas.appVersionFiles(),
+  ])
   async exec(
     id: AppId,
     targetCollectionIds: CollectionId[],

--- a/packages/core/executing-backend/src/usecases/apps/Delete.ts
+++ b/packages/core/executing-backend/src/usecases/apps/Delete.ts
@@ -9,11 +9,15 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class AppsDelete extends Usecase<Backend["apps"]["delete"]> {
+  @validateArgs([valibotSchemas.id.app(), v.string()])
   async exec(
     id: AppId,
     commandConfirmation: string,

--- a/packages/core/executing-backend/src/usecases/apps/UpdateName.ts
+++ b/packages/core/executing-backend/src/usecases/apps/UpdateName.ts
@@ -19,10 +19,12 @@ import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
 import assertAppVersionExists from "../../utils/assertAppVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class AppsUpdateName extends Usecase<
   Backend["apps"]["updateName"]
 > {
+  @validateArgs([valibotSchemas.id.app(), v.string()])
   async exec(
     id: AppId,
     name: string,

--- a/packages/core/executing-backend/src/usecases/assistants/ContinueConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/ContinueConversation.ts
@@ -17,22 +17,29 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import type ConversationEntity from "../../entities/ConversationEntity.js";
 import type FileEntity from "../../entities/FileEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import difference from "../../utils/difference.js";
 import isEmpty from "../../utils/isEmpty.js";
 import MessageContentFileUtils from "../../utils/MessageContentFileUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 export default class AssistantsContinueConversation extends Usecase<
   Backend["assistants"]["continueConversation"]
 > {
+  @validateArgs([
+    valibotSchemas.id.conversation(),
+    argSchemas.nonEmptyArray(argSchemas.messageContentPartText()),
+  ])
   async exec(
     id: ConversationId,
     userMessageContent: NonEmptyArray<MessageContentPart.Text>,

--- a/packages/core/executing-backend/src/usecases/assistants/DeleteConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/DeleteConversation.ts
@@ -9,13 +9,17 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class AssistantsDeleteConversation extends Usecase<
   Backend["assistants"]["deleteConversation"]
 > {
+  @validateArgs([valibotSchemas.id.conversation(), v.string()])
   async exec(
     id: ConversationId,
     commandConfirmation: string,

--- a/packages/core/executing-backend/src/usecases/assistants/GetConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/GetConversation.ts
@@ -9,17 +9,20 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 export default class AssistantsGetConversation extends Usecase<
   Backend["assistants"]["getConversation"]
 > {
+  @validateArgs([valibotSchemas.id.conversation()])
   async exec(
     id: ConversationId,
   ): ResultPromise<Conversation, ConversationNotFound | UnexpectedError> {

--- a/packages/core/executing-backend/src/usecases/assistants/ProcessConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/ProcessConversation.ts
@@ -19,8 +19,10 @@ import {
   extractErrorDetails,
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import pMap from "p-map";
+import * as v from "valibot";
 import type Assistant from "../../assistants/Assistant.js";
 import CollectionCreatorAssistant from "../../assistants/CollectionCreatorAssistant/CollectionCreatorAssistant.js";
 import FactotumAssistant from "../../assistants/FactotumAssistant/FactotumAssistant.js";
@@ -31,6 +33,7 @@ import ConversationTextUtils from "../../utils/ConversationTextUtils.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import generateTitle from "../../utils/generateTitle.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionCategoriesList from "../collection-categories/List.js";
 import CollectionsCreateMany from "../collections/CreateMany.js";
 import CollectionsList from "../collections/List.js";
@@ -42,6 +45,7 @@ import FilesGetContent from "../files/GetContent.js";
 import InferenceImplementTypescriptModule from "../inference/ImplementTypescriptModule.js";
 
 export default class AssistantsProcessConversation extends Usecase {
+  @validateArgs([v.strictObject({ id: valibotSchemas.id.conversation() })])
   async exec({
     id,
   }: {

--- a/packages/core/executing-backend/src/usecases/assistants/RecoverConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/RecoverConversation.ts
@@ -13,6 +13,7 @@ import type { Milliseconds, ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import type ConversationEntity from "../../entities/ConversationEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
@@ -21,6 +22,7 @@ import makeResultError from "../../makers/makeResultError.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import last from "../../utils/last.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 const PROCESSING_TIMEOUT: Milliseconds = 5 * 60 * 1000;
@@ -28,6 +30,7 @@ const PROCESSING_TIMEOUT: Milliseconds = 5 * 60 * 1000;
 export default class AssistantsRecoverConversation extends Usecase<
   Backend["assistants"]["recoverConversation"]
 > {
+  @validateArgs([valibotSchemas.id.conversation()])
   async exec(
     id: ConversationId,
   ): ResultPromise<

--- a/packages/core/executing-backend/src/usecases/assistants/RetryLastResponse.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/RetryLastResponse.ts
@@ -12,6 +12,7 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import type ConversationEntity from "../../entities/ConversationEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
@@ -19,11 +20,13 @@ import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 export default class AssistantsRetryLastResponse extends Usecase<
   Backend["assistants"]["retryLastResponse"]
 > {
+  @validateArgs([valibotSchemas.id.conversation()])
   async exec(
     id: ConversationId,
   ): ResultPromise<

--- a/packages/core/executing-backend/src/usecases/assistants/SearchConversations.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/SearchConversations.ts
@@ -5,12 +5,15 @@ import type {
 } from "@superego/backend";
 import type { ResultPromise } from "@superego/global-types";
 import { makeSuccessfulResult } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeConversation from "../../makers/makeConversation.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 export default class AssistantsSearchConversations extends Usecase {
+  @validateArgs([v.string(), v.strictObject({ limit: v.number() })])
   async exec(
     query: string,
     options: { limit: number },

--- a/packages/core/executing-backend/src/usecases/assistants/StartConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/StartConversation.ts
@@ -1,5 +1,5 @@
 import {
-  type AssistantName,
+  AssistantName,
   type Backend,
   BackgroundJobName,
   type Conversation,
@@ -17,21 +17,28 @@ import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import type ConversationEntity from "../../entities/ConversationEntity.js";
 import type FileEntity from "../../entities/FileEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import ConversationUtils from "../../utils/ConversationUtils.js";
 import difference from "../../utils/difference.js";
 import isEmpty from "../../utils/isEmpty.js";
 import MessageContentFileUtils from "../../utils/MessageContentFileUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsList from "../collections/List.js";
 
 export default class AssistantsStartConversation extends Usecase<
   Backend["assistants"]["startConversation"]
 > {
+  @validateArgs([
+    v.enum(AssistantName),
+    argSchemas.nonEmptyArray(argSchemas.messageContentPart()),
+  ])
   async exec(
     assistant: AssistantName,
     userMessageContent: Message.User["content"],

--- a/packages/core/executing-backend/src/usecases/background-jobs/Get.ts
+++ b/packages/core/executing-backend/src/usecases/background-jobs/Get.ts
@@ -9,14 +9,17 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeBackgroundJob from "../../makers/makeBackgroundJob.js";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class BackgroundJobsGet extends Usecase<
   Backend["backgroundJobs"]["get"]
 > {
+  @validateArgs([valibotSchemas.id.backgroundJob()])
   async exec(
     id: BackgroundJobId,
   ): ResultPromise<BackgroundJob, BackgroundJobNotFound | UnexpectedError> {

--- a/packages/core/executing-backend/src/usecases/bazaar/GetPack.ts
+++ b/packages/core/executing-backend/src/usecases/bazaar/GetPack.ts
@@ -10,13 +10,16 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class BazaarGetPack extends Usecase<
   Backend["bazaar"]["getPack"]
 > {
+  @validateArgs([valibotSchemas.id.pack()])
   async exec(id: PackId): ResultPromise<Pack, PackNotFound | UnexpectedError> {
     const pack = packs.find((pack) => pack.id === id);
     if (!pack) {

--- a/packages/core/executing-backend/src/usecases/collection-categories/Create.ts
+++ b/packages/core/executing-backend/src/usecases/collection-categories/Create.ts
@@ -20,16 +20,29 @@ import type CollectionCategoryEntity from "../../entities/CollectionCategoryEnti
 import makeCollectionCategory from "../../makers/makeCollectionCategory.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 interface CollectionCategoriesCreateOptions {
   collectionCategoryId?: CollectionCategoryId;
   skipReferenceCheckForCollectionCategoryIds?: CollectionCategoryId[];
 }
 
+const collectionCategoriesCreateOptionsSchema = v.strictObject({
+  collectionCategoryId: v.optional(valibotSchemas.id.collectionCategory()),
+  skipReferenceCheckForCollectionCategoryIds: v.optional(
+    v.array(valibotSchemas.id.collectionCategory()),
+  ),
+});
+
 export default class CollectionCategoriesCreate extends Usecase<
   Backend["collectionCategories"]["create"]
 > {
+  @validateArgs([
+    argSchemas.collectionCategoryDefinition(),
+    collectionCategoriesCreateOptionsSchema,
+  ])
   async exec(
     definition: CollectionCategoryDefinition,
     options: CollectionCategoriesCreateOptions = {},

--- a/packages/core/executing-backend/src/usecases/collection-categories/Delete.ts
+++ b/packages/core/executing-backend/src/usecases/collection-categories/Delete.ts
@@ -9,13 +9,16 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionCategoriesDelete extends Usecase<
   Backend["collectionCategories"]["delete"]
 > {
+  @validateArgs([valibotSchemas.id.collectionCategory()])
   async exec(
     id: CollectionCategoryId,
   ): ResultPromise<

--- a/packages/core/executing-backend/src/usecases/collection-categories/Update.ts
+++ b/packages/core/executing-backend/src/usecases/collection-categories/Update.ts
@@ -21,10 +21,23 @@ import makeCollectionCategory from "../../makers/makeCollectionCategory.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
+
+const collectionCategoryPatchSchema = v.partial(
+  v.object({
+    name: v.string(),
+    icon: v.nullable(v.string()),
+    parentId: v.nullable(valibotSchemas.id.collectionCategory()),
+  }),
+);
 
 export default class CollectionCategoriesUpdate extends Usecase<
   Backend["collectionCategories"]["update"]
 > {
+  @validateArgs([
+    valibotSchemas.id.collectionCategory(),
+    collectionCategoryPatchSchema,
+  ])
   async exec(
     id: CollectionCategoryId,
     patch: Partial<Pick<CollectionCategory, "name" | "icon" | "parentId">>,

--- a/packages/core/executing-backend/src/usecases/collections/CollectionsAuthenticateOAuth2PKCEConnector.ts
+++ b/packages/core/executing-backend/src/usecases/collections/CollectionsAuthenticateOAuth2PKCEConnector.ts
@@ -13,17 +13,21 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import type CollectionEntity from "../../entities/CollectionEntity.js";
 import makeCollection from "../../makers/makeCollection.js";
 import makeResultError from "../../makers/makeResultError.js";
 import assertCollectionRemoteConnectorExists from "../../utils/assertCollectionRemoteConnectorExists.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsAuthenticateOAuth2PKCEConnector extends Usecase<
   Backend["collections"]["authenticateOAuth2PKCEConnector"]
 > {
+  @validateArgs([valibotSchemas.id.collection(), v.string()])
   async exec(
     id: CollectionId,
     authorizationResponseUrl: string,

--- a/packages/core/executing-backend/src/usecases/collections/Create.ts
+++ b/packages/core/executing-backend/src/usecases/collections/Create.ts
@@ -31,8 +31,10 @@ import type CollectionVersionEntity from "../../entities/CollectionVersionEntity
 import makeCollection from "../../makers/makeCollection.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 interface CollectionsCreateOptions {
   dryRun?: boolean;
@@ -41,9 +43,24 @@ interface CollectionsCreateOptions {
   skipReferenceCheckForAppIds?: AppId[];
 }
 
+const collectionsCreateOptionsSchema = v.strictObject({
+  dryRun: v.optional(v.boolean()),
+  collectionId: v.optional(backedUtilsValibotSchemas.id.collection()),
+  skipReferenceCheckForCollectionIds: v.optional(
+    v.array(backedUtilsValibotSchemas.id.collection()),
+  ),
+  skipReferenceCheckForAppIds: v.optional(
+    v.array(backedUtilsValibotSchemas.id.app()),
+  ),
+});
+
 export default class CollectionsCreate extends Usecase<
   Backend["collections"]["create"]
 > {
+  @validateArgs([
+    argSchemas.collectionDefinition(),
+    collectionsCreateOptionsSchema,
+  ])
   async exec(
     { settings, schema, versionSettings }: CollectionDefinition,
     options: CollectionsCreateOptions = {},

--- a/packages/core/executing-backend/src/usecases/collections/CreateMany.ts
+++ b/packages/core/executing-backend/src/usecases/collections/CreateMany.ts
@@ -19,14 +19,18 @@ import {
   Id,
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import {
   extractProtoCollectionIds,
   makeProtoCollectionIdMapping,
   replaceProtoCollectionIds,
 } from "../../utils/ProtoIdUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import CollectionsCreate from "./Create.js";
 
 interface CollectionsCreateManyOptions {
@@ -35,9 +39,19 @@ interface CollectionsCreateManyOptions {
   skipReferenceCheckForAppIds?: AppId[];
 }
 
+const collectionsCreateManyOptionsSchema = v.strictObject({
+  dryRun: v.optional(v.boolean()),
+  collectionIds: v.optional(v.array(valibotSchemas.id.collection())),
+  skipReferenceCheckForAppIds: v.optional(v.array(valibotSchemas.id.app())),
+});
+
 export default class CollectionsCreateMany extends Usecase<
   Backend["collections"]["createMany"]
 > {
+  @validateArgs([
+    v.array(argSchemas.collectionDefinition()),
+    collectionsCreateManyOptionsSchema,
+  ])
   async exec(
     definitions: CollectionDefinition[],
     options: CollectionsCreateManyOptions = {},

--- a/packages/core/executing-backend/src/usecases/collections/CreateNewVersion.ts
+++ b/packages/core/executing-backend/src/usecases/collections/CreateNewVersion.ts
@@ -40,15 +40,25 @@ import makeCollection from "../../makers/makeCollection.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
 import type ArrayElement from "../../utils/ArrayElement.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import assertDocumentVersionExists from "../../utils/assertDocumentVersionExists.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import DocumentsCreateNewVersion from "../documents/CreateNewVersion.js";
 
 export default class CollectionsCreateNewVersion extends Usecase<
   Backend["collections"]["createNewVersion"]
 > {
+  @validateArgs([
+    sharedUtilsValibotSchemas.id.collection(),
+    sharedUtilsValibotSchemas.id.collectionVersion(),
+    argSchemas.schema(),
+    argSchemas.collectionVersionSettings(),
+    v.nullable(argSchemas.typescriptModule()),
+    v.nullable(argSchemas.remoteConverters()),
+  ])
   async exec(
     id: CollectionId,
     latestVersionId: CollectionVersionId,

--- a/packages/core/executing-backend/src/usecases/collections/Delete.ts
+++ b/packages/core/executing-backend/src/usecases/collections/Delete.ts
@@ -13,10 +13,13 @@ import { utils as schemaUtils } from "@superego/schema";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import AppsDelete from "../apps/Delete.js";
 import AppsList from "../apps/List.js";
 import DocumentsDelete from "../documents/Delete.js";
@@ -24,6 +27,7 @@ import DocumentsDelete from "../documents/Delete.js";
 export default class CollectionsDelete extends Usecase<
   Backend["collections"]["delete"]
 > {
+  @validateArgs([valibotSchemas.id.collection(), v.string()])
   async exec(
     id: CollectionId,
     commandConfirmation: string,

--- a/packages/core/executing-backend/src/usecases/collections/DownSync.ts
+++ b/packages/core/executing-backend/src/usecases/collections/DownSync.ts
@@ -13,7 +13,9 @@ import type { ResultError, ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import type CollectionEntity from "../../entities/CollectionEntity.js";
 import type CollectionVersionEntity from "../../entities/CollectionVersionEntity.js";
 import type RemoteEntity from "../../entities/RemoteEntity.js";
@@ -26,11 +28,13 @@ import assertDocumentVersionExists from "../../utils/assertDocumentVersionExists
 import CollectionUtils from "../../utils/CollectionUtils.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import DocumentsCreate from "../documents/Create.js";
 import DocumentsCreateNewVersion from "../documents/CreateNewVersion.js";
 import DocumentsDelete from "../documents/Delete.js";
 
 export default class CollectionsDownSync extends Usecase {
+  @validateArgs([v.strictObject({ id: valibotSchemas.id.collection() })])
   async exec({
     id,
   }: {

--- a/packages/core/executing-backend/src/usecases/collections/GetOAuth2PKCEConnectorAuthorizationRequestUrl.ts
+++ b/packages/core/executing-backend/src/usecases/collections/GetOAuth2PKCEConnectorAuthorizationRequestUrl.ts
@@ -12,14 +12,17 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeResultError from "../../makers/makeResultError.js";
 import assertCollectionRemoteConnectorExists from "../../utils/assertCollectionRemoteConnectorExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsGetOAuth2PKCEConnectorAuthorizationRequestUrl extends Usecase<
   Backend["collections"]["getOAuth2PKCEConnectorAuthorizationRequestUrl"]
 > {
+  @validateArgs([valibotSchemas.id.collection()])
   async exec(
     id: CollectionId,
   ): ResultPromise<

--- a/packages/core/executing-backend/src/usecases/collections/GetVersion.ts
+++ b/packages/core/executing-backend/src/usecases/collections/GetVersion.ts
@@ -10,14 +10,20 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeCollectionVersion from "../../makers/makeCollectionVersion.js";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsGetVersion extends Usecase<
   Backend["collections"]["getVersion"]
 > {
+  @validateArgs([
+    valibotSchemas.id.collection(),
+    valibotSchemas.id.collectionVersion(),
+  ])
   async exec(
     collectionId: CollectionId,
     collectionVersionId: CollectionVersionId,

--- a/packages/core/executing-backend/src/usecases/collections/SetRemote.ts
+++ b/packages/core/executing-backend/src/usecases/collections/SetRemote.ts
@@ -20,6 +20,7 @@ import { valibotSchemas } from "@superego/schema";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas as sharedUtilsValibotSchemas,
 } from "@superego/shared-utils";
 import * as v from "valibot";
 import type CollectionEntity from "../../entities/CollectionEntity.js";
@@ -27,12 +28,21 @@ import type CollectionVersionEntity from "../../entities/CollectionVersionEntity
 import makeCollection from "../../makers/makeCollection.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsSetRemote extends Usecase<
   Backend["collections"]["setRemote"]
 > {
+  @validateArgs([
+    sharedUtilsValibotSchemas.id.collection(),
+    v.string(),
+    argSchemas.connectorAuthenticationSettings(),
+    v.unknown(),
+    argSchemas.remoteConverters(),
+  ])
   async exec(
     id: CollectionId,
     connectorName: string,

--- a/packages/core/executing-backend/src/usecases/collections/TriggerDownSync.ts
+++ b/packages/core/executing-backend/src/usecases/collections/TriggerDownSync.ts
@@ -15,6 +15,7 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import type CollectionEntity from "../../entities/CollectionEntity.js";
 import makeCollection from "../../makers/makeCollection.js";
@@ -22,10 +23,12 @@ import makeResultError from "../../makers/makeResultError.js";
 import assertCollectionRemoteConnectorExists from "../../utils/assertCollectionRemoteConnectorExists.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsTriggerDownSync extends Usecase<
   Backend["collections"]["triggerDownSync"]
 > {
+  @validateArgs([valibotSchemas.id.collection()])
   async exec(
     id: CollectionId,
   ): ResultPromise<

--- a/packages/core/executing-backend/src/usecases/collections/UpdateLatestVersionSettings.ts
+++ b/packages/core/executing-backend/src/usecases/collections/UpdateLatestVersionSettings.ts
@@ -26,13 +26,25 @@ import makeContentBlockingKeys from "../../makers/makeContentBlockingKeys.js";
 import makeContentSummaries from "../../makers/makeContentSummaries.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionUpdateLatestVersionSettings extends Usecase<
   Backend["collections"]["updateLatestVersionSettings"]
 > {
+  @validateArgs([
+    sharedUtilsValibotSchemas.id.collection(),
+    sharedUtilsValibotSchemas.id.collectionVersion(),
+    v.partial(
+      argSchemas.collectionVersionSettings() as unknown as v.StrictObjectSchema<
+        v.ObjectEntries,
+        undefined
+      >,
+    ) as unknown as v.GenericSchema<Partial<CollectionVersionSettings>>,
+  ])
   async exec(
     id: CollectionId,
     latestVersionId: CollectionVersionId,

--- a/packages/core/executing-backend/src/usecases/collections/UpdateSettings.ts
+++ b/packages/core/executing-backend/src/usecases/collections/UpdateSettings.ts
@@ -20,12 +20,23 @@ import type CollectionEntity from "../../entities/CollectionEntity.js";
 import makeCollection from "../../makers/makeCollection.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class CollectionsUpdateSettings extends Usecase<
   Backend["collections"]["updateSettings"]
 > {
+  @validateArgs([
+    valibotSchemas.id.collection(),
+    v.partial(
+      argSchemas.collectionSettings() as unknown as v.StrictObjectSchema<
+        v.ObjectEntries,
+        undefined
+      >,
+    ) as unknown as v.GenericSchema<Partial<CollectionSettings>>,
+  ])
   async exec(
     id: CollectionId,
     settingsPatch: Partial<CollectionSettings>,

--- a/packages/core/executing-backend/src/usecases/documents/Create.ts
+++ b/packages/core/executing-backend/src/usecases/documents/Create.ts
@@ -30,6 +30,7 @@ import makeContentSummary from "../../makers/makeContentSummary.js";
 import makeDocument from "../../makers/makeDocument.js";
 import makeResultError from "../../makers/makeResultError.js";
 import makeValidationIssues from "../../makers/makeValidationIssues.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import assertDocumentExists from "../../utils/assertDocumentExists.js";
 import ContentDocumentRefUtils from "../../utils/ContentDocumentRefUtils.js";
@@ -37,6 +38,7 @@ import ContentFileUtils from "../../utils/ContentFileUtils.js";
 import difference from "../../utils/difference.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 type ExecReturnValue = ResultPromise<
   Document,
@@ -76,6 +78,7 @@ export default class DocumentsCreate extends Usecase<
           remoteDocument: any;
         },
   ): ExecReturnValue;
+  @validateArgs([argSchemas.documentDefinition(), v.looseObject({})])
   async exec(
     definition: DocumentDefinition,
     options: {

--- a/packages/core/executing-backend/src/usecases/documents/CreateMany.ts
+++ b/packages/core/executing-backend/src/usecases/documents/CreateMany.ts
@@ -20,7 +20,9 @@ import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import assertCollectionVersionExists from "../../utils/assertCollectionVersionExists.js";
 import {
   extractProtoDocumentIds,
@@ -28,6 +30,7 @@ import {
   replaceProtoDocumentIdsAndProtoCollectionIds,
 } from "../../utils/ProtoIdUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import DocumentsCreate from "./Create.js";
 
 interface DocumentsCreateManyOptions {
@@ -39,6 +42,7 @@ interface DocumentsCreateManyOptions {
 export default class DocumentsCreateMany extends Usecase<
   Backend["documents"]["createMany"]
 > {
+  @validateArgs([v.array(argSchemas.documentDefinition()), v.looseObject({})])
   async exec(
     definitions: DocumentDefinition[],
     options?: DocumentsCreateManyOptions,

--- a/packages/core/executing-backend/src/usecases/documents/CreateNewVersion.ts
+++ b/packages/core/executing-backend/src/usecases/documents/CreateNewVersion.ts
@@ -22,6 +22,7 @@ import {
   Id,
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas as sharedUtilsValibotSchemas,
 } from "@superego/shared-utils";
 import * as v from "valibot";
 import type DocumentEntity from "../../entities/DocumentEntity.js";
@@ -39,6 +40,7 @@ import ContentFileUtils from "../../utils/ContentFileUtils.js";
 import difference from "../../utils/difference.js";
 import isEmpty from "../../utils/isEmpty.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 type ExecReturnValue = ResultPromise<
   Document,
@@ -82,6 +84,13 @@ export default class DocumentsCreateNewVersion extends Usecase<
           remoteDocument: any;
         },
   ): ExecReturnValue;
+  @validateArgs([
+    sharedUtilsValibotSchemas.id.collection(),
+    sharedUtilsValibotSchemas.id.document(),
+    sharedUtilsValibotSchemas.id.documentVersion(),
+    v.any(),
+    v.optional(v.any()),
+  ])
   async exec(
     collectionId: CollectionId,
     id: DocumentId,

--- a/packages/core/executing-backend/src/usecases/documents/Delete.ts
+++ b/packages/core/executing-backend/src/usecases/documents/Delete.ts
@@ -14,13 +14,23 @@ import type { DocumentRef } from "@superego/schema";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsDelete extends Usecase<
   Backend["documents"]["delete"]
 > {
+  @validateArgs([
+    valibotSchemas.id.collection(),
+    valibotSchemas.id.document(),
+    v.string(),
+    v.boolean(),
+    v.boolean(),
+  ])
   async exec(
     collectionId: CollectionId,
     id: DocumentId,

--- a/packages/core/executing-backend/src/usecases/documents/Get.ts
+++ b/packages/core/executing-backend/src/usecases/documents/Get.ts
@@ -10,13 +10,16 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeDocument from "../../makers/makeDocument.js";
 import makeResultError from "../../makers/makeResultError.js";
 import assertDocumentVersionExists from "../../utils/assertDocumentVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsGet extends Usecase<Backend["documents"]["get"]> {
+  @validateArgs([valibotSchemas.id.collection(), valibotSchemas.id.document()])
   async exec(
     collectionId: CollectionId,
     id: DocumentId,

--- a/packages/core/executing-backend/src/usecases/documents/GetVersion.ts
+++ b/packages/core/executing-backend/src/usecases/documents/GetVersion.ts
@@ -11,14 +11,21 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeDocumentVersion from "../../makers/makeDocumentVersion.js";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsGetVersion extends Usecase<
   Backend["documents"]["getVersion"]
 > {
+  @validateArgs([
+    valibotSchemas.id.collection(),
+    valibotSchemas.id.document(),
+    valibotSchemas.id.documentVersion(),
+  ])
   async exec(
     collectionId: CollectionId,
     documentId: DocumentId,

--- a/packages/core/executing-backend/src/usecases/documents/List.ts
+++ b/packages/core/executing-backend/src/usecases/documents/List.ts
@@ -11,13 +11,16 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import type DocumentVersionEntity from "../../entities/DocumentVersionEntity.js";
 import makeDocument from "../../makers/makeDocument.js";
 import makeLiteDocument from "../../makers/makeLiteDocument.js";
 import makeResultError from "../../makers/makeResultError.js";
 import assertDocumentVersionExists from "../../utils/assertDocumentVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsList extends Usecase<
   Backend["documents"]["list"]
@@ -29,6 +32,7 @@ export default class DocumentsList extends Usecase<
     collectionId: CollectionId,
     lite: false,
   ): ResultPromise<Document[], CollectionNotFound | UnexpectedError>;
+  @validateArgs([valibotSchemas.id.collection(), v.boolean()])
   async exec(
     collectionId: CollectionId,
     lite = true,

--- a/packages/core/executing-backend/src/usecases/documents/ListVersions.ts
+++ b/packages/core/executing-backend/src/usecases/documents/ListVersions.ts
@@ -10,14 +10,17 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeMinimalDocumentVersion from "../../makers/makeMinimalDocumentVersion.js";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsListVersions extends Usecase<
   Backend["documents"]["listVersions"]
 > {
+  @validateArgs([valibotSchemas.id.collection(), valibotSchemas.id.document()])
   async exec(
     collectionId: CollectionId,
     id: DocumentId,

--- a/packages/core/executing-backend/src/usecases/documents/Search.ts
+++ b/packages/core/executing-backend/src/usecases/documents/Search.ts
@@ -11,14 +11,17 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import pMap from "p-map";
+import * as v from "valibot";
 import makeDocument from "../../makers/makeDocument.js";
 import makeLiteDocument from "../../makers/makeLiteDocument.js";
 import makeResultError from "../../makers/makeResultError.js";
 import assertDocumentExists from "../../utils/assertDocumentExists.js";
 import assertDocumentVersionExists from "../../utils/assertDocumentVersionExists.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class DocumentsSearch extends Usecase<
   Backend["documents"]["search"]
@@ -40,6 +43,12 @@ export default class DocumentsSearch extends Usecase<
     TextSearchResult<Document>[],
     CollectionNotFound | UnexpectedError
   >;
+  @validateArgs([
+    v.nullable(valibotSchemas.id.collection()),
+    v.string(),
+    v.strictObject({ limit: v.number() }),
+    v.boolean(),
+  ])
   async exec(
     collectionId: CollectionId | null,
     query: string,

--- a/packages/core/executing-backend/src/usecases/files/GetContent.ts
+++ b/packages/core/executing-backend/src/usecases/files/GetContent.ts
@@ -8,13 +8,16 @@ import type { ResultPromise } from "@superego/global-types";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
+  valibotSchemas,
 } from "@superego/shared-utils";
 import makeResultError from "../../makers/makeResultError.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class FilesGetContent extends Usecase<
   Backend["files"]["getContent"]
 > {
+  @validateArgs([valibotSchemas.id.file()])
   async exec(
     id: FileId,
   ): ResultPromise<Uint8Array<ArrayBuffer>, FileNotFound | UnexpectedError> {

--- a/packages/core/executing-backend/src/usecases/global-settings/Update.ts
+++ b/packages/core/executing-backend/src/usecases/global-settings/Update.ts
@@ -5,11 +5,22 @@ import type {
 } from "@superego/backend";
 import type { ResultPromise } from "@superego/global-types";
 import { makeSuccessfulResult } from "@superego/shared-utils";
+import * as v from "valibot";
+import * as argSchemas from "../../utils/argSchemas.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class GlobalSettingsUpdate extends Usecase<
   Backend["globalSettings"]["update"]
 > {
+  @validateArgs([
+    v.partial(
+      argSchemas.globalSettings() as unknown as v.StrictObjectSchema<
+        v.ObjectEntries,
+        undefined
+      >,
+    ) as unknown as v.GenericSchema<Partial<GlobalSettings>>,
+  ])
   async exec(
     globalSettingsPatch: Partial<GlobalSettings>,
   ): ResultPromise<GlobalSettings, UnexpectedError> {

--- a/packages/core/executing-backend/src/usecases/inference/ImplementTypescriptModule.ts
+++ b/packages/core/executing-backend/src/usecases/inference/ImplementTypescriptModule.ts
@@ -17,15 +17,36 @@ import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
 } from "@superego/shared-utils";
+import * as v from "valibot";
 import makeResultError from "../../makers/makeResultError.js";
 import InferenceService from "../../requirements/InferenceService.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 const MAX_ATTEMPTS = 5;
+
+const implementTypescriptModuleSpecSchema = v.strictObject({
+  description: v.string(),
+  rules: v.nullable(v.string()),
+  additionalInstructions: v.nullable(v.string()),
+  template: v.string(),
+  libs: v.array(
+    v.strictObject({
+      path: v.string() as v.GenericSchema<`/${string}.ts` | `/${string}.tsx`>,
+      source: v.string(),
+    }),
+  ),
+  startingPoint: v.strictObject({
+    path: v.string() as v.GenericSchema<`/${string}.ts` | `/${string}.tsx`>,
+    source: v.string(),
+  }),
+  userRequest: v.string(),
+});
 
 export default class InferenceImplementTypescriptModule extends Usecase<
   Backend["inference"]["implementTypescriptModule"]
 > {
+  @validateArgs([implementTypescriptModuleSpecSchema])
   async exec({
     description,
     rules,

--- a/packages/core/executing-backend/src/usecases/inference/Stt.ts
+++ b/packages/core/executing-backend/src/usecases/inference/Stt.ts
@@ -1,9 +1,12 @@
 import type { AudioContent, Backend, UnexpectedError } from "@superego/backend";
 import type { ResultPromise } from "@superego/global-types";
 import { makeSuccessfulResult } from "@superego/shared-utils";
+import * as argSchemas from "../../utils/argSchemas.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class InferenceStt extends Usecase<Backend["inference"]["stt"]> {
+  @validateArgs([argSchemas.audioContent()])
   async exec(audio: AudioContent): ResultPromise<string, UnexpectedError> {
     const globalSettings = await this.repos.globalSettings.get();
     const inferenceService = this.inferenceServiceFactory.create(

--- a/packages/core/executing-backend/src/usecases/inference/Tts.ts
+++ b/packages/core/executing-backend/src/usecases/inference/Tts.ts
@@ -1,9 +1,12 @@
 import type { AudioContent, Backend, UnexpectedError } from "@superego/backend";
 import type { ResultPromise } from "@superego/global-types";
 import { makeSuccessfulResult } from "@superego/shared-utils";
+import * as v from "valibot";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 
 export default class InferenceTts extends Usecase<Backend["inference"]["tts"]> {
+  @validateArgs([v.string()])
   async exec(text: string): ResultPromise<AudioContent, UnexpectedError> {
     const globalSettings = await this.repos.globalSettings.get();
     const inferenceService = this.inferenceServiceFactory.create(

--- a/packages/core/executing-backend/src/usecases/packs/Install.ts
+++ b/packages/core/executing-backend/src/usecases/packs/Install.ts
@@ -44,6 +44,7 @@ import {
   makeUnsuccessfulResult,
 } from "@superego/shared-utils";
 import makeResultError from "../../makers/makeResultError.js";
+import * as argSchemas from "../../utils/argSchemas.js";
 import isEmpty from "../../utils/isEmpty.js";
 import {
   extractProtoCollectionIds,
@@ -58,12 +59,14 @@ import {
   replaceProtoDocumentIdsAndProtoCollectionIds,
 } from "../../utils/ProtoIdUtils.js";
 import Usecase from "../../utils/Usecase.js";
+import validateArgs from "../../utils/validateArgs.js";
 import AppsCreate from "../apps/Create.js";
 import CollectionCategoriesCreate from "../collection-categories/Create.js";
 import CollectionsCreate from "../collections/Create.js";
 import DocumentsCreate from "../documents/Create.js";
 
 export default class PacksInstall extends Usecase<Backend["packs"]["install"]> {
+  @validateArgs([argSchemas.pack()])
   async exec(pack: Pack): ResultPromise<
     {
       collectionCategories: CollectionCategory[];

--- a/packages/core/executing-backend/src/utils/argSchemas.ts
+++ b/packages/core/executing-backend/src/utils/argSchemas.ts
@@ -1,0 +1,235 @@
+import type {
+  AppDefinition,
+  AudioContent,
+  CollectionCategoryDefinition,
+  CollectionDefinition,
+  CollectionSettings,
+  CollectionVersionSettings,
+  ConnectorAuthenticationSettings,
+  DocumentDefinition,
+  GlobalSettings,
+  MessageContentPart,
+  NonEmptyArray,
+  Pack,
+  RemoteConverters,
+  TypescriptModule,
+} from "@superego/backend";
+import type { Schema } from "@superego/schema";
+import { valibotSchemas } from "@superego/shared-utils";
+import * as v from "valibot";
+
+export function typescriptModule(): v.GenericSchema<TypescriptModule> {
+  return v.strictObject({
+    source: v.string(),
+    compiled: v.string(),
+  });
+}
+
+export function remoteConverters(): v.GenericSchema<RemoteConverters> {
+  return v.strictObject({
+    fromRemoteDocument: typescriptModule(),
+  });
+}
+
+export function audioContent(): v.GenericSchema<AudioContent> {
+  return v.strictObject({
+    content: v.instance(Uint8Array),
+    contentType: v.string(),
+  });
+}
+
+export function appVersionFiles(): v.GenericSchema<{
+  "/main.tsx": TypescriptModule;
+}> {
+  return v.strictObject({
+    "/main.tsx": typescriptModule(),
+  });
+}
+
+export function appDefinition(): v.GenericSchema<AppDefinition> {
+  return v.strictObject({
+    type: v.string() as v.GenericSchema<AppDefinition["type"]>,
+    name: v.string(),
+    targetCollectionIds: v.array(valibotSchemas.id.collection()),
+    files: appVersionFiles(),
+  });
+}
+
+export function collectionCategoryDefinition(): v.GenericSchema<CollectionCategoryDefinition> {
+  return v.strictObject({
+    name: v.string(),
+    icon: v.nullable(v.string()),
+    parentId: v.nullable(valibotSchemas.id.collectionCategory()),
+  });
+}
+
+export function schema(): v.GenericSchema<Schema> {
+  return v.looseObject({
+    types: v.record(v.string(), v.any()),
+    rootType: v.string(),
+  }) as unknown as v.GenericSchema<Schema>;
+}
+
+export function collectionVersionSettings(): v.GenericSchema<CollectionVersionSettings> {
+  return v.strictObject({
+    contentBlockingKeysGetter: v.nullable(typescriptModule()),
+    contentSummaryGetter: typescriptModule(),
+    defaultDocumentViewUiOptions: v.nullable(v.any()),
+  }) as unknown as v.GenericSchema<CollectionVersionSettings>;
+}
+
+export function collectionSettings(): v.GenericSchema<CollectionSettings> {
+  return v.strictObject({
+    name: v.string(),
+    icon: v.nullable(v.string()),
+    collectionCategoryId: v.nullable(valibotSchemas.id.collectionCategory()),
+    defaultCollectionViewAppId: v.nullable(valibotSchemas.id.app()),
+    description: v.nullable(v.string()),
+    assistantInstructions: v.nullable(v.string()),
+  });
+}
+
+export function collectionDefinition(): v.GenericSchema<CollectionDefinition> {
+  return v.strictObject({
+    settings: collectionSettings(),
+    schema: schema(),
+    versionSettings: collectionVersionSettings(),
+  });
+}
+
+export function documentDefinition(): v.GenericSchema<DocumentDefinition> {
+  return v.strictObject({
+    collectionId: valibotSchemas.id.collection(),
+    content: v.any(),
+    options: v.optional(
+      v.strictObject({
+        skipDuplicateCheck: v.boolean(),
+      }),
+    ),
+  }) as unknown as v.GenericSchema<DocumentDefinition>;
+}
+
+export function connectorAuthenticationSettings(): v.GenericSchema<ConnectorAuthenticationSettings> {
+  return v.looseObject({}) as unknown as v.GenericSchema<ConnectorAuthenticationSettings>;
+}
+
+export function messageContentPart(): v.GenericSchema<MessageContentPart> {
+  return v.looseObject({
+    type: v.string(),
+  }) as unknown as v.GenericSchema<MessageContentPart>;
+}
+
+export function messageContentPartText(): v.GenericSchema<MessageContentPart.Text> {
+  return v.looseObject({
+    type: v.string(),
+    text: v.string(),
+  }) as unknown as v.GenericSchema<MessageContentPart.Text>;
+}
+
+export function nonEmptyArray<T>(
+  item: v.GenericSchema<T>,
+): v.GenericSchema<NonEmptyArray<T>> {
+  return v.pipe(v.array(item), v.minLength(1)) as unknown as v.GenericSchema<
+    NonEmptyArray<T>
+  >;
+}
+
+export function globalSettings(): v.GenericSchema<GlobalSettings> {
+  return v.strictObject({
+    inference: v.looseObject({
+      chatCompletions: v.looseObject({
+        provider: v.looseObject({
+          baseUrl: v.nullable(v.string()),
+          apiKey: v.nullable(v.string()),
+        }),
+        model: v.nullable(v.string()),
+      }),
+      transcriptions: v.looseObject({
+        provider: v.looseObject({
+          baseUrl: v.nullable(v.string()),
+          apiKey: v.nullable(v.string()),
+        }),
+        model: v.nullable(v.string()),
+      }),
+      speech: v.looseObject({
+        provider: v.looseObject({
+          baseUrl: v.nullable(v.string()),
+          apiKey: v.nullable(v.string()),
+        }),
+        model: v.nullable(v.string()),
+        voice: v.nullable(v.string()),
+      }),
+      fileInspection: v.looseObject({
+        provider: v.looseObject({
+          baseUrl: v.nullable(v.string()),
+          apiKey: v.nullable(v.string()),
+        }),
+        model: v.nullable(v.string()),
+      }),
+    }),
+    assistants: v.looseObject({
+      userName: v.nullable(v.string()),
+      developerPrompts: v.looseObject({}),
+    }),
+    appearance: v.looseObject({
+      theme: v.string(),
+    }),
+  }) as unknown as v.GenericSchema<GlobalSettings>;
+}
+
+export function pack(): v.GenericSchema<Pack> {
+  return v.strictObject({
+    id: valibotSchemas.id.pack(),
+    info: v.looseObject({
+      name: v.string(),
+      shortDescription: v.string(),
+      longDescription: v.string(),
+      screenshots: v.array(
+        v.strictObject({
+          mimeType: v.string() as v.GenericSchema<`image/${string}`>,
+          content: v.instance(Uint8Array),
+        }),
+      ),
+    }),
+    collectionCategories: v.array(
+      v.strictObject({
+        name: v.string(),
+        icon: v.nullable(v.string()),
+        parentId: v.nullable(v.string()),
+      }),
+    ),
+    collections: v.array(
+      v.strictObject({
+        settings: v.strictObject({
+          name: v.string(),
+          icon: v.nullable(v.string()),
+          collectionCategoryId: v.nullable(v.string()),
+          defaultCollectionViewAppId: v.nullable(v.string()),
+          description: v.nullable(v.string()),
+          assistantInstructions: v.nullable(v.string()),
+        }),
+        schema: schema(),
+        versionSettings: collectionVersionSettings(),
+      }),
+    ),
+    apps: v.array(
+      v.strictObject({
+        type: v.string(),
+        name: v.string(),
+        targetCollectionIds: v.array(v.string()),
+        files: appVersionFiles(),
+      }),
+    ),
+    documents: v.array(
+      v.strictObject({
+        collectionId: v.string(),
+        content: v.any(),
+        options: v.optional(
+          v.strictObject({
+            skipDuplicateCheck: v.boolean(),
+          }),
+        ),
+      }),
+    ),
+  }) as unknown as v.GenericSchema<Pack>;
+}

--- a/packages/core/executing-backend/src/utils/validateArgs.ts
+++ b/packages/core/executing-backend/src/utils/validateArgs.ts
@@ -1,0 +1,35 @@
+import type { ResultPromise } from "@superego/global-types";
+import { makeUnsuccessfulResult } from "@superego/shared-utils";
+import * as v from "valibot";
+import makeResultError from "../makers/makeResultError.js";
+import makeValidationIssues from "../makers/makeValidationIssues.js";
+
+export default function validateArgs<const Schemas extends v.GenericSchema[]>(
+  schemas: [...Schemas],
+) {
+  return <This>(
+    target: (
+      this: This,
+      ...args: { [K in keyof Schemas]: v.InferOutput<Schemas[K]> }
+    ) => ResultPromise<any, any>,
+    _context: ClassMethodDecoratorContext,
+  ): typeof target => function (
+      this: This,
+      ...args: { [K in keyof Schemas]: v.InferOutput<Schemas[K]> }
+    ): ResultPromise<any, any> {
+      for (let i = 0; i < schemas.length; i++) {
+        if (i >= args.length) break;
+        const result = v.safeParse(schemas[i]!, args[i]);
+        if (!result.success) {
+          return Promise.resolve(
+            makeUnsuccessfulResult(
+              makeResultError("InputNotValid", {
+                issues: makeValidationIssues(result.issues),
+              }),
+            ),
+          );
+        }
+      }
+      return target.call(this, ...args);
+    } as typeof target;
+}

--- a/packages/core/shared-utils/src/valibotSchemas/id.ts
+++ b/packages/core/shared-utils/src/valibotSchemas/id.ts
@@ -1,7 +1,15 @@
 import type {
   AppId,
+  AppVersionId,
+  BackgroundJobId,
   CollectionCategoryId,
   CollectionId,
+  CollectionVersionId,
+  ConversationId,
+  DocumentId,
+  DocumentVersionId,
+  FileId,
+  PackId,
 } from "@superego/backend";
 import * as v from "valibot";
 import Id from "../Id/Id.js";
@@ -17,8 +25,61 @@ function collection(): v.GenericSchema<CollectionId, CollectionId> {
   return v.custom(Id.is.collection);
 }
 
+function collectionVersion(): v.GenericSchema<
+  CollectionVersionId,
+  CollectionVersionId
+> {
+  return v.custom(Id.is.collectionVersion);
+}
+
 function app(): v.GenericSchema<AppId, AppId> {
   return v.custom(Id.is.app);
 }
 
-export default { collectionCategory, collection, app };
+function appVersion(): v.GenericSchema<AppVersionId, AppVersionId> {
+  return v.custom(Id.is.appVersion);
+}
+
+function document(): v.GenericSchema<DocumentId, DocumentId> {
+  return v.custom(Id.is.document);
+}
+
+function documentVersion(): v.GenericSchema<
+  DocumentVersionId,
+  DocumentVersionId
+> {
+  return v.custom(Id.is.documentVersion);
+}
+
+function file(): v.GenericSchema<FileId, FileId> {
+  return v.custom(Id.is.file);
+}
+
+function conversation(): v.GenericSchema<ConversationId, ConversationId> {
+  return v.custom(Id.is.conversation);
+}
+
+function backgroundJob(): v.GenericSchema<BackgroundJobId, BackgroundJobId> {
+  return v.custom(Id.is.backgroundJob);
+}
+
+function pack(): v.GenericSchema<PackId, PackId> {
+  return v.custom(
+    (value): value is PackId =>
+      typeof value === "string" && /^Pack_\S+$/.test(value),
+  );
+}
+
+export default {
+  collectionCategory,
+  collection,
+  collectionVersion,
+  app,
+  appVersion,
+  document,
+  documentVersion,
+  file,
+  conversation,
+  backgroundJob,
+  pack,
+};


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive input validation system for usecase methods using a decorator pattern and centralized Valibot schemas. It adds runtime validation of arguments before execution, improving type safety and error handling across the backend.

## Key Changes

- **New `validateArgs` decorator** (`packages/core/executing-backend/src/utils/validateArgs.ts`): A class method decorator that validates arguments against provided Valibot schemas before method execution. Returns validation errors as `InputNotValid` result errors when validation fails.

- **Centralized argument schemas** (`packages/core/executing-backend/src/utils/argSchemas.ts`): Comprehensive Valibot schema definitions for common domain types including:
  - `typescriptModule()`, `remoteConverters()`, `audioContent()`
  - `appDefinition()`, `collectionDefinition()`, `documentDefinition()`
  - `collectionCategoryDefinition()`, `collectionSettings()`, `collectionVersionSettings()`
  - `globalSettings()`, `pack()`, and supporting schemas

- **Extended ID validators** (`packages/core/shared-utils/src/valibotSchemas/id.ts`): Added schema validators for additional ID types:
  - `collectionVersion()`, `appVersion()`, `document()`, `documentVersion()`
  - `file()`, `conversation()`, `backgroundJob()`, `pack()`

- **New error type** (`packages/core/backend/src/errors/InputNotValid.ts`): Added `InputNotValid` error type for validation failures with detailed issue information.

- **Applied validation to usecases**: Decorated multiple usecase methods with `@validateArgs` including:
  - Collections: `Create`, `CreateMany`, `CreateNewVersion`, `UpdateSettings`, `UpdateLatestVersionSettings`, `SetRemote`, `Delete`, `GetVersion`
  - Collection Categories: `Create`, `Update`, `Delete`
  - Apps: `Create`, `CreateNewVersion`, `Delete`, `UpdateName`
  - Documents: `Create`, `CreateMany`, `CreateNewVersion`, `Delete`, `Get`, `GetVersion`, `List`, `ListVersions`, `Search`
  - Assistants: `StartConversation`, `ContinueConversation`, `DeleteConversation`, `GetConversation`, `ProcessConversation`, `RecoverConversation`, `RetryLastResponse`, `SearchConversations`
  - Inference: `ImplementTypescriptModule`, `Stt`, `Tts`
  - Other: `GlobalSettingsUpdate`, `BackgroundJobsGet`, `BazaarGetPack`, `DocumentsDownSync`, `CollectionsAuthenticateOAuth2PKCEConnector`, `CollectionsGetOAuth2PKCEConnectorAuthorizationRequestUrl`, `CollectionsTriggerDownSync`, `FilesGetContent`, `PacksInstall`

## Implementation Details

- The decorator uses Valibot's `safeParse` for non-throwing validation
- Validation errors are converted to `ValidationIssue` format and wrapped in `InputNotValid` result errors
- Schemas use `strictObject` for most types to prevent unexpected properties
- Some complex types use `looseObject` or `any()` where full validation isn't feasible
- The decorator maintains proper TypeScript typing for validated arguments

https://claude.ai/code/session_01CVof9VGP2GTraV2XKRu7rZ