### PR TITLE
Add support for default values in type definitions

### DIFF
--- a/packages/apps/browser-app/src/business-logic/forms/defaults/typeDefinitionValue.ts
+++ b/packages/apps/browser-app/src/business-logic/forms/defaults/typeDefinitionValue.ts
@@ -10,10 +10,15 @@ export default function typeDefinitionValue(
   schema: Schema,
 ): any {
   switch (typeDefinition.dataType) {
-    case DataType.String:
     case DataType.Enum:
+      if (typeDefinition.default !== undefined) {
+        return typeDefinition.members[typeDefinition.default]!.value;
+      }
+      return null;
+    case DataType.String:
     case DataType.Number:
     case DataType.Boolean:
+      return typeDefinition.default ?? null;
     case DataType.JsonObject:
     case DataType.File:
       return null;

--- a/packages/core/schema/src/SchemaTypescriptSchema.test.ts
+++ b/packages/core/schema/src/SchemaTypescriptSchema.test.ts
@@ -45,6 +45,8 @@ it("exports the Schema type definition", () => {
       dataType: DataType.String;
       /** Id of the format the string value must abide by. */
       format?: string | undefined;
+      /** Default value for this type definition. */
+      default?: string | undefined;
     }
 
     interface EnumMember extends Described {
@@ -65,16 +67,25 @@ it("exports the Schema type definition", () => {
        * - **Must** not contain duplicates.
        */
       membersOrder?: string[] | undefined;
+      /**
+       * Default member for this enum. If specified, **must** be a key present in
+       * {@link members}.
+       */
+      default?: string | undefined;
     }
 
     interface NumberTypeDefinition extends Described {
       dataType: DataType.Number;
       /** Id of the format the number value must abide by. */
       format?: string | undefined;
+      /** Default value for this type definition. */
+      default?: number | undefined;
     }
 
     interface BooleanTypeDefinition extends Described {
       dataType: DataType.Boolean;
+      /** Default value for this type definition. */
+      default?: boolean | undefined;
     }
 
     interface StringLiteralTypeDefinition extends Described {

--- a/packages/core/schema/src/typeDefinitions.ts
+++ b/packages/core/schema/src/typeDefinitions.ts
@@ -8,6 +8,8 @@ export interface StringTypeDefinition extends Described {
   dataType: DataType.String;
   /** Id of the format the string value must abide by. */
   format?: string | undefined;
+  /** Default value for this type definition. */
+  default?: string | undefined;
 }
 
 export interface EnumMember extends Described {
@@ -28,16 +30,25 @@ export interface EnumTypeDefinition extends Described {
    * - **Must** not contain duplicates.
    */
   membersOrder?: string[] | undefined;
+  /**
+   * Default member for this enum. If specified, **must** be a key present in
+   * {@link members}.
+   */
+  default?: string | undefined;
 }
 
 export interface NumberTypeDefinition extends Described {
   dataType: DataType.Number;
   /** Id of the format the number value must abide by. */
   format?: string | undefined;
+  /** Default value for this type definition. */
+  default?: number | undefined;
 }
 
 export interface BooleanTypeDefinition extends Described {
   dataType: DataType.Boolean;
+  /** Default value for this type definition. */
+  default?: boolean | undefined;
 }
 
 export interface StringLiteralTypeDefinition extends Described {

--- a/packages/core/schema/src/valibot-schemas/schema/checks/defaultIsValidMember.ts
+++ b/packages/core/schema/src/valibot-schemas/schema/checks/defaultIsValidMember.ts
@@ -1,0 +1,23 @@
+import * as v from "valibot";
+import type { EnumTypeDefinition } from "../../../typeDefinitions.js";
+import translate from "../../../utils/translate.js";
+import { makeObjectPathItem } from "../utils/issuePathItemMakers.js";
+
+/**
+ * Enum type definition check that ensures that, if `default` is specified, it
+ * is a valid member name.
+ */
+export default v.rawCheck<Readonly<EnumTypeDefinition>>(
+  ({ dataset: { typed, value }, config: { lang }, addIssue }) => {
+    if (typed && value.default !== undefined) {
+      if (!(value.default in value.members)) {
+        addIssue({
+          message: translate(lang, {
+            en: "Must be a valid member name",
+          }),
+          path: [makeObjectPathItem(value, "default")],
+        });
+      }
+    }
+  },
+);

--- a/packages/core/schema/src/valibot-schemas/schema/schema.test.ts
+++ b/packages/core/schema/src/valibot-schemas/schema/schema.test.ts
@@ -518,6 +518,133 @@ describe("Invalid schemas", () => {
       });
     });
 
+    describe("invalid default in enum type definition", () => {
+      test("case: non-existing member", {
+        schema: {
+          types: {
+            Root: {
+              dataType: DataType.Struct,
+              properties: {
+                enum: {
+                  dataType: DataType.Enum,
+                  members: {
+                    A: { value: "A" },
+                    B: { value: "B" },
+                  },
+                  default: "NonExisting",
+                },
+              },
+            },
+          },
+          rootType: "Root",
+        },
+        expectedIssues: [
+          {
+            kind: "validation",
+            message: "Must be a valid member name",
+            path: [
+              { key: "types" },
+              { key: "Root" },
+              { key: "properties" },
+              { key: "enum" },
+              { key: "default" },
+            ],
+          },
+        ],
+      });
+    });
+
+    test("invalid default type in string type definition", {
+      schema: {
+        types: {
+          Root: {
+            dataType: DataType.Struct,
+            properties: {
+              string: {
+                dataType: DataType.String,
+                default: 123,
+              },
+            },
+          },
+        },
+        rootType: "Root",
+      },
+      expectedIssues: [
+        {
+          kind: "schema",
+          message: "Invalid type: Expected string but received 123",
+          path: [
+            { key: "types" },
+            { key: "Root" },
+            { key: "properties" },
+            { key: "string" },
+            { key: "default" },
+          ],
+        },
+      ],
+    });
+
+    test("invalid default type in number type definition", {
+      schema: {
+        types: {
+          Root: {
+            dataType: DataType.Struct,
+            properties: {
+              number: {
+                dataType: DataType.Number,
+                default: "not a number",
+              },
+            },
+          },
+        },
+        rootType: "Root",
+      },
+      expectedIssues: [
+        {
+          kind: "schema",
+          message: 'Invalid type: Expected number but received "not a number"',
+          path: [
+            { key: "types" },
+            { key: "Root" },
+            { key: "properties" },
+            { key: "number" },
+            { key: "default" },
+          ],
+        },
+      ],
+    });
+
+    test("invalid default type in boolean type definition", {
+      schema: {
+        types: {
+          Root: {
+            dataType: DataType.Struct,
+            properties: {
+              boolean: {
+                dataType: DataType.Boolean,
+                default: "not a boolean",
+              },
+            },
+          },
+        },
+        rootType: "Root",
+      },
+      expectedIssues: [
+        {
+          kind: "schema",
+          message:
+            'Invalid type: Expected boolean but received "not a boolean"',
+          path: [
+            { key: "types" },
+            { key: "Root" },
+            { key: "properties" },
+            { key: "boolean" },
+            { key: "default" },
+          ],
+        },
+      ],
+    });
+
     test("invalid accept in file type definition", {
       schema: {
         types: {
@@ -862,6 +989,32 @@ describe("Valid schemas", () => {
               collectionId: "collectionId",
             },
           },
+        },
+      },
+      rootType: "Root",
+    },
+    expectedIssues: [],
+  });
+
+  test("type definitions with defaults", {
+    schema: {
+      types: {
+        Root: {
+          dataType: DataType.Struct,
+          properties: {
+            title: { dataType: DataType.String, default: "Untitled" },
+            priority: { dataType: DataType.Number, default: 0 },
+            archived: { dataType: DataType.Boolean, default: false },
+            stage: { dataType: null, ref: "Stage" },
+          },
+        },
+        Stage: {
+          dataType: DataType.Enum,
+          members: {
+            Backlog: { value: "Backlog" },
+            Done: { value: "Done" },
+          },
+          default: "Backlog",
         },
       },
       rootType: "Root",

--- a/packages/core/schema/src/valibot-schemas/schema/schema.ts
+++ b/packages/core/schema/src/valibot-schemas/schema/schema.ts
@@ -8,6 +8,7 @@ import enumMembers from "../enumMembers/enumMembers.js";
 import identifier from "../identifier/identifier.js";
 import mimeTypeMatcher from "../mimeTypeMatcher/mimeTypeMatcher.js";
 import allReferencedTypesExist from "./checks/allReferencedTypesExist.js";
+import defaultIsValidMember from "./checks/defaultIsValidMember.js";
 import membersOrderIsValid from "./checks/membersOrderIsValid.js";
 import noTopLevelTypeDefinitionRefs from "./checks/noTopLevelTypeDefinitionRefs.js";
 import noUnusedTypes from "./checks/noUnusedTypes.js";
@@ -18,6 +19,7 @@ const StringTypeDefinitionValibotSchema = v.strictObject({
   ...described().entries,
   dataType: v.literal(DataType.String),
   format: v.optional(v.string()),
+  default: v.optional(v.string()),
 });
 
 const EnumTypeDefinitionValibotSchema = v.pipe(
@@ -26,19 +28,23 @@ const EnumTypeDefinitionValibotSchema = v.pipe(
     dataType: v.literal(DataType.Enum),
     members: enumMembers(),
     membersOrder: v.optional(v.array(v.pipe(v.string()))),
+    default: v.optional(v.string()),
   }),
   membersOrderIsValid,
+  defaultIsValidMember,
 );
 
 const NumberTypeDefinitionValibotSchema = v.strictObject({
   ...described().entries,
   dataType: v.literal(DataType.Number),
   format: v.optional(v.string()),
+  default: v.optional(v.number()),
 });
 
 const BooleanTypeDefinitionValibotSchema = v.strictObject({
   ...described().entries,
   dataType: v.literal(DataType.Boolean),
+  default: v.optional(v.boolean()),
 });
 
 const StringLiteralTypeDefinitionValibotSchema = v.strictObject({

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/tasksSchema.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/tasksSchema.ts
@@ -11,6 +11,7 @@ export default {
         Done: { value: "Done" },
       },
       membersOrder: ["Backlog", "Scheduled", "Doing", "Done"],
+      default: "Backlog",
     },
     Task: {
       dataType: DataType.Struct,
@@ -27,8 +28,9 @@ export default {
         },
         priority: {
           dataType: DataType.Number,
+          default: 0,
         },
-        archived: { dataType: DataType.Boolean },
+        archived: { dataType: DataType.Boolean, default: false },
       },
       nullableProperties: ["description", "dueDate"],
     },


### PR DESCRIPTION
## Summary
This PR adds support for specifying default values in type definitions for String, Number, Boolean, and Enum types. Default values are now optional properties that can be set on these type definitions and are validated to ensure type correctness.

## Key Changes
- **Type Definition Updates**: Added optional `default` property to `StringTypeDefinition`, `NumberTypeDefinition`, `BooleanTypeDefinition`, and `EnumTypeDefinition` interfaces in `typeDefinitions.ts`
- **Validation**: Implemented `defaultIsValidMember` check to ensure enum default values reference valid member names
- **Schema Validation**: Updated Valibot schemas to validate default values match their respective types (string defaults for String types, number for Number types, etc.)
- **Default Value Resolution**: Modified `typeDefinitionValue()` to return the default value when specified, with special handling for enums to return the member's actual value
- **Test Coverage**: Added comprehensive test cases for:
  - Invalid enum defaults (non-existing members)
  - Invalid default types (e.g., string default for number type)
  - Valid schemas with defaults across all supported types
- **Example Usage**: Updated the tasks schema example to demonstrate default values in practice

## Implementation Details
- Enum defaults are validated against the `members` object keys to ensure they reference valid enum members
- For enum types, the default value is the member name, which is resolved to the member's actual value when needed
- All default values are optional and backward compatible with existing schemas
- Validation errors provide clear path information for debugging schema issues

https://claude.ai/code/session_01UkCh1zXr37XEHcKSBgrCA3