### PR TITLE
Add default document content feature to collections

### DIFF
--- a/packages/apps/browser-app/src/components/routes/CollectionSettings/UpdateCollectionVersionSettingsForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/CollectionSettings/UpdateCollectionVersionSettingsForm.tsx
@@ -4,7 +4,10 @@ import type {
   DefaultDocumentViewUiOptions,
   TypescriptModule,
 } from "@superego/backend";
-import { codegen } from "@superego/schema";
+import {
+  codegen,
+  valibotSchemas as schemaValibotSchemas,
+} from "@superego/schema";
 import { valibotSchemas as sharedUtilsValibotSchemas } from "@superego/shared-utils";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -19,6 +22,7 @@ import Section from "../../design-system/Section/Section.js";
 import FormStateEffects from "../../widgets/FormStateEffects/FormStateEffects.js";
 import RHFContentBlockingKeysGetterField from "../../widgets/RHFContentBlockingKeysGetterField/RHFContentBlockingKeysGetterField.js";
 import RHFContentSummaryGetterField from "../../widgets/RHFContentSummaryGetterField/RHFContentSummaryGetterField.js";
+import RHFDefaultDocumentContentField from "../../widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.js";
 import RHFDefaultDocumentViewUiOptionsField from "../../widgets/RHFDefaultDocumentViewUiOptionsField/RHFDefaultDocumentViewUiOptionsField.js";
 import RHFSubmitButton from "../../widgets/RHFSubmitButton/RHFSubmitButton.js";
 import * as cs from "./CollectionSettings.css.js";
@@ -26,6 +30,7 @@ import * as cs from "./CollectionSettings.css.js";
 interface FormValues {
   contentBlockingKeysGetter: TypescriptModule | null;
   contentSummaryGetter: TypescriptModule;
+  defaultDocumentContent: any | null;
   defaultDocumentViewUiOptions: DefaultDocumentViewUiOptions | null;
 }
 
@@ -45,6 +50,8 @@ export default function UpdateCollectionVersionSettingsForm({
         collection.latestVersion.settings.contentBlockingKeysGetter,
       contentSummaryGetter:
         collection.latestVersion.settings.contentSummaryGetter,
+      defaultDocumentContent:
+        collection.latestVersion.settings.defaultDocumentContent,
       defaultDocumentViewUiOptions:
         collection.latestVersion.settings.defaultDocumentViewUiOptions,
     },
@@ -55,6 +62,9 @@ export default function UpdateCollectionVersionSettingsForm({
           forms.schemas.typescriptModule(intl),
         ),
         contentSummaryGetter: forms.schemas.typescriptModule(intl),
+        defaultDocumentContent: v.nullable(
+          schemaValibotSchemas.content(collection.latestVersion.schema),
+        ),
         defaultDocumentViewUiOptions: v.nullable(
           sharedUtilsValibotSchemas.defaultDocumentViewUiOptions(
             collection.latestVersion.schema,
@@ -74,11 +84,13 @@ export default function UpdateCollectionVersionSettingsForm({
       const {
         contentBlockingKeysGetter,
         contentSummaryGetter,
+        defaultDocumentContent,
         defaultDocumentViewUiOptions,
       } = data.latestVersion.settings;
       reset({
         contentBlockingKeysGetter,
         contentSummaryGetter,
+        defaultDocumentContent,
         defaultDocumentViewUiOptions,
       });
     }
@@ -114,6 +126,17 @@ export default function UpdateCollectionVersionSettingsForm({
           name="contentSummaryGetter"
           schema={collection.latestVersion.schema}
           schemaTypescriptLib={schemaTypescriptLib}
+        />
+      </Section>
+      <Section
+        title={intl.formatMessage({
+          defaultMessage: "Default document content",
+        })}
+        level={3}
+      >
+        <RHFDefaultDocumentContentField
+          control={control}
+          name="defaultDocumentContent"
         />
       </Section>
       <Section

--- a/packages/apps/browser-app/src/components/routes/CreateCollectionManual/CreateCollectionForm/CreateCollectionForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/CreateCollectionManual/CreateCollectionForm/CreateCollectionForm.tsx
@@ -84,6 +84,7 @@ export default function CreateCollectionForm() {
       versionSettings: {
         contentBlockingKeysGetter,
         contentSummaryGetter,
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });

--- a/packages/apps/browser-app/src/components/routes/CreateDocument/CreateDocumentForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/CreateDocument/CreateDocumentForm.tsx
@@ -36,8 +36,13 @@ export default function CreateDocumentForm({
     useState<DuplicateDocumentDetected | null>(null);
   const [pendingContent, setPendingContent] = useState<any>(null);
 
+  const defaultDocumentContent =
+    collection.latestVersion.settings.defaultDocumentContent;
   const { control, handleSubmit } = useForm<any>({
-    defaultValues: forms.defaults.schemaValue(schema),
+    defaultValues:
+      defaultDocumentContent !== null
+        ? forms.utils.RHFContent.toRHFContent(defaultDocumentContent, schema)
+        : forms.defaults.schemaValue(schema),
     mode: "onSubmit",
     resolver: standardSchemaResolver(valibotSchemas.content(schema, "rhf")),
   });

--- a/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/CreateNewCollectionVersionForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/CreateNewCollectionVersionForm.tsx
@@ -21,6 +21,7 @@ import FormStateEffects from "../../../widgets/FormStateEffects/FormStateEffects
 import ContentBlockingKeysTab from "./ContentBlockingKeysTab.js";
 import ContentSummaryTab from "./ContentSummaryTab.js";
 import type CreateNewCollectionVersionFormValues from "./CreateNewCollectionVersionFormValues.js";
+import DefaultDocumentContentTab from "./DefaultDocumentContentTab.js";
 import DefaultDocumentViewUiOptionsTab from "./DefaultDocumentViewUiOptionsTab.js";
 import MigrationTab from "./MigrationTab.js";
 import RemoteConvertersTab from "./RemoteConvertersTab.js";
@@ -52,6 +53,8 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
           collection.latestVersion.settings.contentBlockingKeysGetter,
         contentSummaryGetter:
           collection.latestVersion.settings.contentSummaryGetter,
+        defaultDocumentContent:
+          collection.latestVersion.settings.defaultDocumentContent,
         defaultDocumentViewUiOptions:
           collection.latestVersion.settings.defaultDocumentViewUiOptions,
         migration: CollectionUtils.hasRemote(collection)
@@ -75,6 +78,9 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
               forms.schemas.typescriptModule(intl),
             ),
             contentSummaryGetter: forms.schemas.typescriptModule(intl),
+            defaultDocumentContent: v.nullable(
+              valibotSchemas.content(currentSchema),
+            ),
             defaultDocumentViewUiOptions: v.nullable(
               sharedUtilsValibotSchemas.defaultDocumentViewUiOptions(
                 currentSchema,
@@ -95,6 +101,7 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
       {
         contentBlockingKeysGetter: values.contentBlockingKeysGetter,
         contentSummaryGetter: values.contentSummaryGetter,
+        defaultDocumentContent: values.defaultDocumentContent,
         defaultDocumentViewUiOptions: values.defaultDocumentViewUiOptions,
       },
       values.migration,
@@ -219,10 +226,21 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
           },
           {
             title: (
+              <TabTitle hasErrors={!!formState.errors.defaultDocumentContent}>
+                <FormattedMessage defaultMessage="4. Default content" />
+              </TabTitle>
+            ),
+            panel: (
+              <DefaultDocumentContentTab control={control} schema={schema} />
+            ),
+            isDisabled: !(isSchemaDirty && isSchemaValid),
+          },
+          {
+            title: (
               <TabTitle
                 hasErrors={!!formState.errors.defaultDocumentViewUiOptions}
               >
-                <FormattedMessage defaultMessage="4. UI options" />
+                <FormattedMessage defaultMessage="5. UI options" />
               </TabTitle>
             ),
             panel: (
@@ -237,7 +255,7 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
             ? {
                 title: (
                   <TabTitle hasErrors={!!formState.errors.remoteConverters}>
-                    <FormattedMessage defaultMessage="5. Remote converters" />
+                    <FormattedMessage defaultMessage="6. Remote converters" />
                   </TabTitle>
                 ),
                 panel: (
@@ -256,7 +274,7 @@ export default function CreateNewCollectionVersionForm({ collection }: Props) {
             ? {
                 title: (
                   <TabTitle hasErrors={!!formState.errors.migration}>
-                    <FormattedMessage defaultMessage="5. Migration" />
+                    <FormattedMessage defaultMessage="6. Migration" />
                   </TabTitle>
                 ),
                 panel: (

--- a/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/CreateNewCollectionVersionFormValues.ts
+++ b/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/CreateNewCollectionVersionFormValues.ts
@@ -9,6 +9,7 @@ export default interface CreateNewCollectionVersionFormValues {
   schema: Schema;
   contentBlockingKeysGetter: TypescriptModule | null;
   contentSummaryGetter: TypescriptModule;
+  defaultDocumentContent: any | null;
   defaultDocumentViewUiOptions: DefaultDocumentViewUiOptions | null;
   migration: TypescriptModule | null;
   remoteConverters: RemoteConverters | null;

--- a/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/DefaultDocumentContentTab.tsx
+++ b/packages/apps/browser-app/src/components/routes/CreateNewCollectionVersion/CreateNewCollectionVersionForm/DefaultDocumentContentTab.tsx
@@ -1,0 +1,21 @@
+import type { Schema } from "@superego/schema";
+import type { Control } from "react-hook-form";
+import RHFDefaultDocumentContentField from "../../../widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.js";
+import type CreateNewCollectionVersionFormValues from "./CreateNewCollectionVersionFormValues.js";
+
+interface Props {
+  control: Control<
+    CreateNewCollectionVersionFormValues,
+    any,
+    CreateNewCollectionVersionFormValues
+  >;
+  schema: string | Schema;
+}
+export default function DefaultDocumentContentTab({ control, schema }: Props) {
+  return typeof schema !== "string" ? (
+    <RHFDefaultDocumentContentField
+      control={control}
+      name="defaultDocumentContent"
+    />
+  ) : null;
+}

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/ToolResult/SuggestCollectionsDefinitions/SuggestCollectionsDefinitions.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/ToolResult/SuggestCollectionsDefinitions/SuggestCollectionsDefinitions.tsx
@@ -46,6 +46,7 @@ export default function SuggestCollectionsDefinitions({
             toolResult.artifacts.collections[index]!.contentBlockingKeysGetter,
           contentSummaryGetter:
             toolResult.artifacts.collections[index]!.contentSummaryGetter,
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       })),

--- a/packages/apps/browser-app/src/components/widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.css.ts
+++ b/packages/apps/browser-app/src/components/widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.css.ts
@@ -1,0 +1,41 @@
+import { style } from "@vanilla-extract/css";
+import { vars } from "../../../themes.css.js";
+
+export const RHFDefaultDocumentContentField = {
+  root: style({
+    display: "flex",
+    flexDirection: "column",
+    gap: vars.spacing._6,
+  }),
+
+  switchGroup: style({
+    display: "flex",
+    flexDirection: "column",
+    gap: vars.spacing._2,
+  }),
+
+  switchDescription: style({
+    display: "block",
+  }),
+
+  codeInputGroup: style({
+    display: "flex",
+    flexDirection: "column",
+    gap: vars.spacing._2,
+    selectors: {
+      '&[data-disabled="true"]': {
+        color: vars.colors.text.secondary,
+      },
+    },
+  }),
+
+  errorLine: style({
+    marginBlockEnd: vars.spacing._1,
+  }),
+
+  inlineCode: style({
+    background: vars.colors.semantic.error.background,
+    color: vars.colors.semantic.error.text,
+    fontSize: vars.typography.fontSizes.xs,
+  }),
+};

--- a/packages/apps/browser-app/src/components/widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFDefaultDocumentContentField/RHFDefaultDocumentContentField.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useState } from "react";
+import { FieldErrorContext } from "react-aria-components";
+import { type Control, useController } from "react-hook-form";
+import { FormattedMessage } from "react-intl";
+import forms from "../../../business-logic/forms/forms.js";
+import { vars } from "../../../themes.css.js";
+import classnames from "../../../utils/classnames.js";
+import {
+  Description,
+  FieldError,
+  Label,
+  Switch,
+} from "../../design-system/forms/forms.js";
+import InlineCode from "../../design-system/InlineCode/InlineCode.js";
+import CodeInput from "../CodeInput/CodeInput.js";
+import * as cs from "./RHFDefaultDocumentContentField.css.js";
+
+interface Props {
+  control: Control<any>;
+  name: string;
+  label?: string | undefined;
+  isDisabled?: boolean | undefined;
+  isReadOnly?: boolean | undefined;
+  autoFocus?: boolean | undefined;
+  className?: string | undefined;
+}
+export default function RHFDefaultDocumentContentField({
+  control,
+  name,
+  label,
+  isDisabled,
+  isReadOnly,
+  autoFocus,
+  className,
+}: Props) {
+  const { field, fieldState } = useController({ control, name });
+  const isEnabled = field.value !== null;
+  const handleSwitchChange = (isSelected: boolean) =>
+    field.onChange(isSelected ? {} : null);
+  const [jsonValue, setJsonValue] = useState(() =>
+    typeof field.value === "string"
+      ? field.value
+      : JSON.stringify(field.value, null, 2),
+  );
+  const errors = forms.utils.flattenError(fieldState.error);
+  const handleChange = useCallback(
+    (newValue: string) => {
+      setJsonValue(newValue);
+      if (newValue === "") {
+        field.onChange(null);
+      } else {
+        try {
+          field.onChange(JSON.parse(newValue));
+        } catch {
+          field.onChange(newValue);
+        }
+      }
+    },
+    [field.onChange],
+  );
+  return (
+    <div
+      className={classnames(cs.RHFDefaultDocumentContentField.root, className)}
+    >
+      <div
+        className={cs.RHFDefaultDocumentContentField.switchGroup}
+        data-disabled={isDisabled ? "true" : undefined}
+      >
+        <Switch
+          isSelected={isEnabled}
+          onChange={handleSwitchChange}
+          isDisabled={isDisabled}
+        >
+          <FormattedMessage defaultMessage="Enable default document content" />
+        </Switch>
+        <Description
+          className={cs.RHFDefaultDocumentContentField.switchDescription}
+        >
+          <FormattedMessage defaultMessage="Set default values for new documents created in this collection. The content must match the collection schema." />
+        </Description>
+      </div>
+      {isEnabled ? (
+        <div
+          data-disabled={isDisabled}
+          className={cs.RHFDefaultDocumentContentField.codeInputGroup}
+        >
+          {label ? <Label>{label}</Label> : null}
+          <CodeInput
+            language="json"
+            value={jsonValue}
+            onChange={handleChange}
+            ariaLabel={label}
+            filePath="/defaultDocumentContent.json"
+            onBlur={field.onBlur}
+            autoFocus={autoFocus}
+            isInvalid={fieldState.invalid}
+            isDisabled={isDisabled}
+            isReadOnly={isReadOnly}
+            maxHeight={vars.spacing._160}
+            ref={field.ref}
+          />
+          <FieldErrorContext
+            value={{
+              isInvalid: fieldState.invalid,
+              validationErrors: errors.length > 0 ? [errors[0]!.message] : [],
+              validationDetails: {} as any,
+            }}
+          >
+            <FieldError>
+              {typeof field.value === "string" ? (
+                <FormattedMessage defaultMessage="Not a valid JSON string" />
+              ) : (
+                errors.map(({ path, message }) => (
+                  <div
+                    key={path}
+                    className={cs.RHFDefaultDocumentContentField.errorLine}
+                  >
+                    <FormattedMessage defaultMessage="At" />{" "}
+                    <InlineCode
+                      className={cs.RHFDefaultDocumentContentField.inlineCode}
+                    >
+                      {path}
+                    </InlineCode>
+                    {": "}
+                    {message}
+                  </div>
+                ))
+              )}
+            </FieldError>
+          </FieldErrorContext>
+          <Description>
+            <FormattedMessage defaultMessage="Defines the default content for new documents in this collection." />
+          </Description>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/apps/browser-app/src/translations/compiled/en.json
+++ b/packages/apps/browser-app/src/translations/compiled/en.json
@@ -926,16 +926,22 @@
       "value": " » Create New Version"
     }
   ],
+  "CreateNewCollectionVersionForm.tsx_/q1jgk": [
+    {
+      "type": 0,
+      "value": "6. Migration"
+    }
+  ],
   "CreateNewCollectionVersionForm.tsx_2n41AE": [
     {
       "type": 0,
       "value": "New collection version created"
     }
   ],
-  "CreateNewCollectionVersionForm.tsx_FQCqoH": [
+  "CreateNewCollectionVersionForm.tsx_B8ejT5": [
     {
       "type": 0,
-      "value": "5. Migration"
+      "value": "5. UI options"
     }
   ],
   "CreateNewCollectionVersionForm.tsx_HxoW8w": [
@@ -944,10 +950,16 @@
       "value": "3. Content summary"
     }
   ],
-  "CreateNewCollectionVersionForm.tsx_dISRjb": [
+  "CreateNewCollectionVersionForm.tsx_N7Izrw": [
     {
       "type": 0,
-      "value": "4. UI options"
+      "value": "6. Remote converters"
+    }
+  ],
+  "CreateNewCollectionVersionForm.tsx_hYwzDX": [
+    {
+      "type": 0,
+      "value": "4. Default content"
     }
   ],
   "CreateNewCollectionVersionForm.tsx_jacE9I": [
@@ -960,12 +972,6 @@
     {
       "type": 0,
       "value": "2. Deduplication"
-    }
-  ],
-  "CreateNewCollectionVersionForm.tsx_sSfm9D": [
-    {
-      "type": 0,
-      "value": "5. Remote converters"
     }
   ],
   "CreateNewDocumentVersion.tsx_p5+z7U": [
@@ -3322,6 +3328,36 @@
       "value": "p"
     }
   ],
+  "RHFDefaultDocumentContentField.tsx_9CnsYv": [
+    {
+      "type": 0,
+      "value": "Not a valid JSON string"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_A89PQ/": [
+    {
+      "type": 0,
+      "value": "At"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_Lz0uen": [
+    {
+      "type": 0,
+      "value": "Set default values for new documents created in this collection. The content must match the collection schema."
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_fzzo03": [
+    {
+      "type": 0,
+      "value": "Enable default document content"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_yZecZ3": [
+    {
+      "type": 0,
+      "value": "Defines the default content for new documents in this collection."
+    }
+  ],
   "RHFDefaultDocumentViewUiOptionsField.tsx_9CnsYv": [
     {
       "type": 0,
@@ -4520,6 +4556,12 @@
     {
       "type": 0,
       "value": "Save collection version settings"
+    }
+  ],
+  "UpdateCollectionVersionSettingsForm.tsx_wH+PSV": [
+    {
+      "type": 0,
+      "value": "Default document content"
     }
   ],
   "UpdateGlobalSettingsForm.tsx_2GURQY": [

--- a/packages/apps/browser-app/src/translations/compiled/it.json
+++ b/packages/apps/browser-app/src/translations/compiled/it.json
@@ -918,16 +918,22 @@
       "value": " » Crea nuova versione"
     }
   ],
+  "CreateNewCollectionVersionForm.tsx_/q1jgk": [
+    {
+      "type": 0,
+      "value": "6. Migrazione"
+    }
+  ],
   "CreateNewCollectionVersionForm.tsx_2n41AE": [
     {
       "type": 0,
       "value": "Creata nuova versione della collezione"
     }
   ],
-  "CreateNewCollectionVersionForm.tsx_FQCqoH": [
+  "CreateNewCollectionVersionForm.tsx_B8ejT5": [
     {
       "type": 0,
-      "value": "5. Migrazione"
+      "value": "5. Opzioni UI"
     }
   ],
   "CreateNewCollectionVersionForm.tsx_HxoW8w": [
@@ -936,10 +942,16 @@
       "value": "3. Sommario dei contenuti"
     }
   ],
-  "CreateNewCollectionVersionForm.tsx_dISRjb": [
+  "CreateNewCollectionVersionForm.tsx_N7Izrw": [
     {
       "type": 0,
-      "value": "4. Opzioni UI"
+      "value": "6. Convertitori remoti"
+    }
+  ],
+  "CreateNewCollectionVersionForm.tsx_hYwzDX": [
+    {
+      "type": 0,
+      "value": "4. Contenuto predefinito"
     }
   ],
   "CreateNewCollectionVersionForm.tsx_jacE9I": [
@@ -952,12 +964,6 @@
     {
       "type": 0,
       "value": "2. Deduplicazione"
-    }
-  ],
-  "CreateNewCollectionVersionForm.tsx_sSfm9D": [
-    {
-      "type": 0,
-      "value": "5. Convertitori remoti"
     }
   ],
   "CreateNewDocumentVersion.tsx_p5+z7U": [
@@ -3300,6 +3306,36 @@
       "value": "p"
     }
   ],
+  "RHFDefaultDocumentContentField.tsx_9CnsYv": [
+    {
+      "type": 0,
+      "value": "Stringa JSON non valida"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_A89PQ/": [
+    {
+      "type": 0,
+      "value": "A"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_Lz0uen": [
+    {
+      "type": 0,
+      "value": "Imposta valori predefiniti per i nuovi documenti creati in questa raccolta. Il contenuto deve corrispondere allo schema della raccolta."
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_fzzo03": [
+    {
+      "type": 0,
+      "value": "Abilita contenuto predefinito del documento"
+    }
+  ],
+  "RHFDefaultDocumentContentField.tsx_yZecZ3": [
+    {
+      "type": 0,
+      "value": "Definisce il contenuto predefinito per i nuovi documenti in questa raccolta."
+    }
+  ],
   "RHFDefaultDocumentViewUiOptionsField.tsx_9CnsYv": [
     {
       "type": 0,
@@ -4498,6 +4534,12 @@
     {
       "type": 0,
       "value": "Salva le impostazioni della versione della collezione"
+    }
+  ],
+  "UpdateCollectionVersionSettingsForm.tsx_wH+PSV": [
+    {
+      "type": 0,
+      "value": "Contenuto predefinito del documento"
     }
   ],
   "UpdateGlobalSettingsForm.tsx_2GURQY": [

--- a/packages/apps/browser-app/src/translations/en.json
+++ b/packages/apps/browser-app/src/translations/en.json
@@ -392,26 +392,29 @@
   "CreateNewCollectionVersion.tsx_WgkS3f": {
     "defaultMessage": "{collection} » Create New Version"
   },
+  "CreateNewCollectionVersionForm.tsx_/q1jgk": {
+    "defaultMessage": "6. Migration"
+  },
   "CreateNewCollectionVersionForm.tsx_2n41AE": {
     "defaultMessage": "New collection version created"
   },
-  "CreateNewCollectionVersionForm.tsx_FQCqoH": {
-    "defaultMessage": "5. Migration"
+  "CreateNewCollectionVersionForm.tsx_B8ejT5": {
+    "defaultMessage": "5. UI options"
   },
   "CreateNewCollectionVersionForm.tsx_HxoW8w": {
     "defaultMessage": "3. Content summary"
   },
-  "CreateNewCollectionVersionForm.tsx_dISRjb": {
-    "defaultMessage": "4. UI options"
+  "CreateNewCollectionVersionForm.tsx_N7Izrw": {
+    "defaultMessage": "6. Remote converters"
+  },
+  "CreateNewCollectionVersionForm.tsx_hYwzDX": {
+    "defaultMessage": "4. Default content"
   },
   "CreateNewCollectionVersionForm.tsx_jacE9I": {
     "defaultMessage": "1. Schema"
   },
   "CreateNewCollectionVersionForm.tsx_oL/+8Y": {
     "defaultMessage": "2. Deduplication"
-  },
-  "CreateNewCollectionVersionForm.tsx_sSfm9D": {
-    "defaultMessage": "5. Remote converters"
   },
   "CreateNewDocumentVersion.tsx_p5+z7U": {
     "defaultMessage": "{collection} » Created new document version"
@@ -1175,6 +1178,21 @@
   "RHFContentSummaryGetterField.tsx_BmNFs6": {
     "defaultMessage": "<p> The <b>content summary</b> of a document is a<code>Record'<name: string, value: string | number | boolean | null>' </code>—derived from the document's content—that contains its most important bits of information. The properties of the record are displayed when showing a \"summary view\" of the document; for example, in tables, where each property becomes a column. </p> <p> <b>Content summary getter</b> is the TypeScript function that derives the summary from the document content. </p> <p> The property names of the summary object can be prefixed by attributes that configure the behavior of the UIs that render the summary. For example, when rendering a table of documents, <code>'{position:0,sortable:true,default-sort:asc}' First Name</code> makes <code>First Name</code> the first column, makes it sortable, and sets the column as the default sort order of the table. </p>"
   },
+  "RHFDefaultDocumentContentField.tsx_9CnsYv": {
+    "defaultMessage": "Not a valid JSON string"
+  },
+  "RHFDefaultDocumentContentField.tsx_A89PQ/": {
+    "defaultMessage": "At"
+  },
+  "RHFDefaultDocumentContentField.tsx_Lz0uen": {
+    "defaultMessage": "Set default values for new documents created in this collection. The content must match the collection schema."
+  },
+  "RHFDefaultDocumentContentField.tsx_fzzo03": {
+    "defaultMessage": "Enable default document content"
+  },
+  "RHFDefaultDocumentContentField.tsx_yZecZ3": {
+    "defaultMessage": "Defines the default content for new documents in this collection."
+  },
   "RHFDefaultDocumentViewUiOptionsField.tsx_9CnsYv": {
     "defaultMessage": "Not a valid JSON string"
   },
@@ -1516,6 +1534,9 @@
   },
   "UpdateCollectionVersionSettingsForm.tsx_qTBVbt": {
     "defaultMessage": "Save collection version settings"
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_wH+PSV": {
+    "defaultMessage": "Default document content"
   },
   "UpdateGlobalSettingsForm.tsx_2GURQY": {
     "defaultMessage": "Appearance"

--- a/packages/apps/browser-app/src/translations/it.json
+++ b/packages/apps/browser-app/src/translations/it.json
@@ -14,12 +14,6 @@
   "Ask.tsx_oZLZvb": {
     "defaultMessage": "Come posso aiutarti?"
   },
-  "AssistantsSettings.tsx_mTE6Ss": {
-    "defaultMessage": "Prompt per sviluppatori di Collection Creator"
-  },
-  "AssistantsSettings.tsx_qmPVim": {
-    "defaultMessage": "Prompt per sviluppatori di Factotum"
-  },
   "AssistantsSettings.tsx_MyqNS6": {
     "defaultMessage": "Nome: Sigmund. Nascita: 6 maggio 1856"
   },
@@ -28,6 +22,12 @@
   },
   "AssistantsSettings.tsx_c2z6MR": {
     "defaultMessage": "Su di te"
+  },
+  "AssistantsSettings.tsx_mTE6Ss": {
+    "defaultMessage": "Prompt per sviluppatori di Collection Creator"
+  },
+  "AssistantsSettings.tsx_qmPVim": {
+    "defaultMessage": "Prompt per sviluppatori di Factotum"
   },
   "AssistantsSettings.tsx_xIOlmn": {
     "defaultMessage": "Le tue preferenze"
@@ -110,6 +110,12 @@
   "BackgroundJobsTable.tsx_tzMNF3": {
     "defaultMessage": "Stato"
   },
+  "BooleanField.tsx_KKkUks": {
+    "defaultMessage": "Vero"
+  },
+  "BooleanField.tsx_rxqs5U": {
+    "defaultMessage": "Falso"
+  },
   "Boutique.tsx_J4ocUB": {
     "defaultMessage": "Boutique"
   },
@@ -125,12 +131,6 @@
   "BoutiquePack.tsx_AHlDyN": {
     "defaultMessage": "Boutique » {packId}"
   },
-  "BooleanField.tsx_KKkUks": {
-    "defaultMessage": "Vero"
-  },
-  "BooleanField.tsx_rxqs5U": {
-    "defaultMessage": "Falso"
-  },
   "BrowserApp.tsx_w1vfWS": {
     "defaultMessage": "Errore durante il caricamento dell'app"
   },
@@ -142,6 +142,15 @@
   },
   "BucketTimelineNode.tsx_eF7IVx": {
     "defaultMessage": "{label} ({count} versioni)"
+  },
+  "Capabilities.tsx_HjTr28": {
+    "defaultMessage": "Supporta la comprensione delle immagini"
+  },
+  "Capabilities.tsx_KihMPW": {
+    "defaultMessage": "Supporta la comprensione audio"
+  },
+  "Capabilities.tsx_xRp25e": {
+    "defaultMessage": "Supporta la comprensione PDF"
   },
   "Carousel.tsx_F+ukuP": {
     "defaultMessage": "Immagine successiva"
@@ -263,11 +272,11 @@
   "Conversation.tsx_9eR0Qp": {
     "defaultMessage": "Elimina conversazione"
   },
-  "Conversation.tsx_eq3LES": {
-    "defaultMessage": "🤖 Conversazioni » {conversation}"
-  },
   "Conversation.tsx_A4DzYS": {
     "defaultMessage": "Mostra le tool call"
+  },
+  "Conversation.tsx_eq3LES": {
+    "defaultMessage": "🤖 Conversazioni » {conversation}"
   },
   "Conversation.tsx_oZLZvb": {
     "defaultMessage": "Come posso aiutarti?"
@@ -383,26 +392,29 @@
   "CreateNewCollectionVersion.tsx_WgkS3f": {
     "defaultMessage": "{collection} » Crea nuova versione"
   },
+  "CreateNewCollectionVersionForm.tsx_/q1jgk": {
+    "defaultMessage": "6. Migrazione"
+  },
   "CreateNewCollectionVersionForm.tsx_2n41AE": {
     "defaultMessage": "Creata nuova versione della collezione"
   },
-  "CreateNewCollectionVersionForm.tsx_FQCqoH": {
-    "defaultMessage": "5. Migrazione"
+  "CreateNewCollectionVersionForm.tsx_B8ejT5": {
+    "defaultMessage": "5. Opzioni UI"
   },
   "CreateNewCollectionVersionForm.tsx_HxoW8w": {
     "defaultMessage": "3. Sommario dei contenuti"
   },
-  "CreateNewCollectionVersionForm.tsx_dISRjb": {
-    "defaultMessage": "4. Opzioni UI"
+  "CreateNewCollectionVersionForm.tsx_N7Izrw": {
+    "defaultMessage": "6. Convertitori remoti"
+  },
+  "CreateNewCollectionVersionForm.tsx_hYwzDX": {
+    "defaultMessage": "4. Contenuto predefinito"
   },
   "CreateNewCollectionVersionForm.tsx_jacE9I": {
     "defaultMessage": "1. Schema"
   },
   "CreateNewCollectionVersionForm.tsx_oL/+8Y": {
     "defaultMessage": "2. Deduplicazione"
-  },
-  "CreateNewCollectionVersionForm.tsx_sSfm9D": {
-    "defaultMessage": "5. Convertitori remoti"
   },
   "CreateNewDocumentVersion.tsx_p5+z7U": {
     "defaultMessage": "{collection} » Nuova versione del documento creata"
@@ -497,21 +509,6 @@
   "DeleteConversationModalForm.tsx_lml5ZH": {
     "defaultMessage": "Conferma comando"
   },
-  "ModalContent.tsx_47FYwb": {
-    "defaultMessage": "Annulla"
-  },
-  "ModalContent.tsx_K3r6DQ": {
-    "defaultMessage": "Elimina"
-  },
-  "ModalContent.tsx_cpePvc": {
-    "defaultMessage": "Elimina il documento \"{documentName}\""
-  },
-  "ModalContent.tsx_lml5ZH": {
-    "defaultMessage": "Conferma comando"
-  },
-  "ModalContent.tsx_qjTjxw": {
-    "defaultMessage": "<p> Eliminando il documento cancellerai definitivamente il documento, tutte le sue versioni e tutti i suoi file. </p> <p> Se sei sicuro di voler eliminare il documento, scrivi <i>delete</i> nel campo sottostante. </p>"
-  },
   "Document.tsx_AB6IO/": {
     "defaultMessage": "Vai al documento remoto"
   },
@@ -545,11 +542,11 @@
   "DocumentInfoModal.tsx_gm5+Hy": {
     "defaultMessage": "ID collezione:"
   },
-  "DocumentInfoModal.tsx_i3P6ZD": {
-    "defaultMessage": "Creato il:"
-  },
   "DocumentInfoModal.tsx_h6SlY+": {
     "defaultMessage": "ID documento remoto:"
+  },
+  "DocumentInfoModal.tsx_i3P6ZD": {
+    "defaultMessage": "Creato il:"
   },
   "DocumentInfoModal.tsx_nY1/sq": {
     "defaultMessage": "ID versione documento remoto:"
@@ -890,11 +887,11 @@
   "Header.tsx_zpIkYq": {
     "defaultMessage": "Crea categoria di collezioni"
   },
-  "Hero.tsx_OpKKos": {
-    "defaultMessage": "Ciao!"
-  },
   "Hero.tsx_BrZb1S": {
     "defaultMessage": "Il software che si adatta a te"
+  },
+  "Hero.tsx_OpKKos": {
+    "defaultMessage": "Ciao!"
   },
   "Hero.tsx_q4FNnF": {
     "defaultMessage": "Superego"
@@ -962,56 +959,8 @@
   "IncompatibilityWarning.tsx_s36xxK": {
     "defaultMessage": "Avviso di incompatibilità"
   },
-  "Capabilities.tsx_HjTr28": {
-    "defaultMessage": "Supporta la comprensione delle immagini"
-  },
-  "Capabilities.tsx_KihMPW": {
-    "defaultMessage": "Supporta la comprensione audio"
-  },
-  "Capabilities.tsx_xRp25e": {
-    "defaultMessage": "Supporta la comprensione PDF"
-  },
   "InferenceSettings.tsx_P817ae": {
     "defaultMessage": "Configura un <b>fornitore di inferenza</b> per abilitare l'assistente. Un modello con capacità di comprensione audio è necessario per la funzione \"parla\"."
-  },
-  "Model.tsx_G/yZLu": {
-    "defaultMessage": "Rimuovi"
-  },
-  "Model.tsx_HAlOn1": {
-    "defaultMessage": "Nome"
-  },
-  "Model.tsx_qlcuNQ": {
-    "defaultMessage": "ID"
-  },
-  "ModelActionMenu.tsx_SikIJG": {
-    "defaultMessage": "(precedentemente usato)"
-  },
-  "Provider.tsx_G/yZLu": {
-    "defaultMessage": "Rimuovi"
-  },
-  "Provider.tsx_HAlOn1": {
-    "defaultMessage": "Nome"
-  },
-  "Provider.tsx_KTNoOq": {
-    "defaultMessage": "Chiave API"
-  },
-  "Provider.tsx_MbbFzn": {
-    "defaultMessage": "Driver"
-  },
-  "Provider.tsx_blWvag": {
-    "defaultMessage": "Modelli"
-  },
-  "Provider.tsx_dqWH5L": {
-    "defaultMessage": "URL di base"
-  },
-  "Provider.tsx_zUO6Ii": {
-    "defaultMessage": "Aggiungi modello"
-  },
-  "Providers.tsx_+goFsL": {
-    "defaultMessage": "Aggiungi provider"
-  },
-  "Providers.tsx_IL1Uey": {
-    "defaultMessage": "Provider"
   },
   "InstallPackModal.tsx_+Toiai": {
     "defaultMessage": "saranno installati."
@@ -1082,6 +1031,36 @@
   "MigrationTab.tsx_i8zErH": {
     "defaultMessage": "Scrivi una funzione di migrazione per convertire i documenti dallo schema precedente a quello aggiornato."
   },
+  "ModalContent.tsx_47FYwb": {
+    "defaultMessage": "Annulla"
+  },
+  "ModalContent.tsx_K3r6DQ": {
+    "defaultMessage": "Elimina"
+  },
+  "ModalContent.tsx_cpePvc": {
+    "defaultMessage": "Elimina il documento \"{documentName}\""
+  },
+  "ModalContent.tsx_lml5ZH": {
+    "defaultMessage": "Conferma comando"
+  },
+  "ModalContent.tsx_qjTjxw": {
+    "defaultMessage": "<p> Eliminando il documento cancellerai definitivamente il documento, tutte le sue versioni e tutti i suoi file. </p> <p> Se sei sicuro di voler eliminare il documento, scrivi <i>delete</i> nel campo sottostante. </p>"
+  },
+  "Model.tsx_G/yZLu": {
+    "defaultMessage": "Rimuovi"
+  },
+  "Model.tsx_HAlOn1": {
+    "defaultMessage": "Nome"
+  },
+  "Model.tsx_qlcuNQ": {
+    "defaultMessage": "ID"
+  },
+  "ModelActionMenu.tsx_SikIJG": {
+    "defaultMessage": "(precedentemente usato)"
+  },
+  "ModelSelect.tsx_rhSI1/": {
+    "defaultMessage": "Modello"
+  },
   "NullifyFieldAction.tsx_MLa9CL": {
     "defaultMessage": "Imposta {fieldLabel} su null"
   },
@@ -1100,11 +1079,11 @@
   "PackEntityCounts.tsx_pKXETD": {
     "defaultMessage": "{collectionsCount, plural, one {# collezione} other {# collezioni}}"
   },
-  "PackMainPanel.tsx_OYAe1w": {
-    "defaultMessage": "Boutique » {packName}"
-  },
   "PackMainPanel.tsx_HUc4Bb": {
     "defaultMessage": "Mostra/nascondi anteprima collezioni"
+  },
+  "PackMainPanel.tsx_OYAe1w": {
+    "defaultMessage": "Boutique » {packName}"
   },
   "PackMainPanel.tsx_hgmRAL": {
     "defaultMessage": "Pack personalizzati » {packName}"
@@ -1154,6 +1133,33 @@
   "PrimarySidebarPanel.tsx_xmcVZ0": {
     "defaultMessage": "Cerca"
   },
+  "Provider.tsx_G/yZLu": {
+    "defaultMessage": "Rimuovi"
+  },
+  "Provider.tsx_HAlOn1": {
+    "defaultMessage": "Nome"
+  },
+  "Provider.tsx_KTNoOq": {
+    "defaultMessage": "Chiave API"
+  },
+  "Provider.tsx_MbbFzn": {
+    "defaultMessage": "Driver"
+  },
+  "Provider.tsx_blWvag": {
+    "defaultMessage": "Modelli"
+  },
+  "Provider.tsx_dqWH5L": {
+    "defaultMessage": "URL di base"
+  },
+  "Provider.tsx_zUO6Ii": {
+    "defaultMessage": "Aggiungi modello"
+  },
+  "Providers.tsx_+goFsL": {
+    "defaultMessage": "Aggiungi provider"
+  },
+  "Providers.tsx_IL1Uey": {
+    "defaultMessage": "Provider"
+  },
   "RHFContentBlockingKeysGetterField.tsx_83T8Y+": {
     "defaultMessage": "Getter delle content blocking keys"
   },
@@ -1171,6 +1177,21 @@
   },
   "RHFContentSummaryGetterField.tsx_BmNFs6": {
     "defaultMessage": "<p> Il <b>sommario dei contenuti</b> di un documento è un <code>Record'<name: string, value: string | number | boolean | null>'</code>, derivato dal contenuto del documento, che raccoglie le informazioni più importanti. Le proprietà del record vengono mostrate quando si visualizza una \"vista sommario\" del documento; ad esempio nelle tabelle, dove ogni proprietà diventa una colonna. </p> <p> Il <b>content summary getter</b> è la funzione TypeScript che ricava il sommario dal contenuto del documento. </p> <p> I nomi delle proprietà dell'oggetto sommario possono essere preceduti da attributi che configurano il comportamento delle interfacce che lo mostrano. Ad esempio, quando si renderizza una tabella di documenti, <code>'{position:0,sortable:true,default-sort:asc}' Nome</code> rende <code>Nome</code> la prima colonna, la rende ordinabile e imposta la colonna come ordinamento predefinito della tabella. </p>"
+  },
+  "RHFDefaultDocumentContentField.tsx_9CnsYv": {
+    "defaultMessage": "Stringa JSON non valida"
+  },
+  "RHFDefaultDocumentContentField.tsx_A89PQ/": {
+    "defaultMessage": "A"
+  },
+  "RHFDefaultDocumentContentField.tsx_Lz0uen": {
+    "defaultMessage": "Imposta valori predefiniti per i nuovi documenti creati in questa raccolta. Il contenuto deve corrispondere allo schema della raccolta."
+  },
+  "RHFDefaultDocumentContentField.tsx_fzzo03": {
+    "defaultMessage": "Abilita contenuto predefinito del documento"
+  },
+  "RHFDefaultDocumentContentField.tsx_yZecZ3": {
+    "defaultMessage": "Definisce il contenuto predefinito per i nuovi documenti in questa raccolta."
   },
   "RHFDefaultDocumentViewUiOptionsField.tsx_9CnsYv": {
     "defaultMessage": "Stringa JSON non valida"
@@ -1195,6 +1216,24 @@
   },
   "RHFSchemaField.tsx_IBR6nN": {
     "defaultMessage": "Definisce la \"forma\" del contenuto dei documenti in questa collezione."
+  },
+  "ReasoningEffortSelect.tsx_2X1lvg": {
+    "defaultMessage": "Sforzo di ragionamento"
+  },
+  "ReasoningEffortSelect.tsx_450Fty": {
+    "defaultMessage": "Nessuno"
+  },
+  "ReasoningEffortSelect.tsx_477I0g": {
+    "defaultMessage": "Basso"
+  },
+  "ReasoningEffortSelect.tsx_AxMhQr": {
+    "defaultMessage": "Alto"
+  },
+  "ReasoningEffortSelect.tsx_kDEj60": {
+    "defaultMessage": "Extra alto"
+  },
+  "ReasoningEffortSelect.tsx_ovJ26C": {
+    "defaultMessage": "Medio"
   },
   "Remote.tsx_s8FZNF": {
     "defaultMessage": "<p> Puoi sincronizzare una collezione con un'origine dati esterna (un <b>remoto</b>). Quando configuri un remoto, diventa la <i>fonte di verità</i> per quella collezione. </p> <p> La collezione non è necessariamente una replica esatta del remoto. I documenti prelevati dal remoto vengono trasformati per rispettare lo schema della tua collezione tramite la mappatura <code>fromRemoteDocument</code> e puoi filtrare quali documenti remoti vengono sincronizzati. </p> <p> Per configurare un remoto, configura un <i>connettore</i> verso l'origine dati esterna. </p> <p> Alcuni connettori supportano solo la <b>sincronizzazione dal</b> remoto, rendendo la collezione in sola lettura. Altri supportano anche la <b>sincronizzazione verso</b> il remoto, così le creazioni, gli aggiornamenti e le eliminazioni nella collezione vengono propagate al remoto. </p> <p> Ulteriori informazioni su <a>https://superego.dev/connectors</a>. </p>"
@@ -1397,6 +1436,234 @@
   "SuggestCollectionsDefinitions.tsx_wNj/kt": {
     "defaultMessage": "Errore durante la creazione delle collezioni"
   },
+  "ThinkingTime.tsx_O5Mn+P": {
+    "defaultMessage": "{model} ha pensato per {time}"
+  },
+  "TimeInputWithMilliseconds.tsx_/w7Rru": {
+    "defaultMessage": "Millisecondi"
+  },
+  "Title.tsx_8yzKPa": {
+    "defaultMessage": "Crea documenti"
+  },
+  "Title.tsx_9Hs+7t": {
+    "defaultMessage": "Crea grafico da {collections}"
+  },
+  "Title.tsx_LOghU6": {
+    "defaultMessage": "Riuscito"
+  },
+  "Title.tsx_RG9Nzq": {
+    "defaultMessage": "Ottieni lo schema TypeScript per {collection}"
+  },
+  "Title.tsx_T0B1v2": {
+    "defaultMessage": "Esegui la funzione TypeScript su {collections}"
+  },
+  "Title.tsx_XnBm2q": {
+    "defaultMessage": "Nessuna risposta"
+  },
+  "Title.tsx_fBfv7E": {
+    "defaultMessage": "Crea mappa da {collections}"
+  },
+  "Title.tsx_foZAHu": {
+    "defaultMessage": "Chiama strumento: {tool}"
+  },
+  "Title.tsx_oHtaJ1": {
+    "defaultMessage": "Crea tabella dei documenti da {collections}"
+  },
+  "Title.tsx_vXCeIi": {
+    "defaultMessage": "Fallito"
+  },
+  "Title.tsx_vlxsWA": {
+    "defaultMessage": "Crea una nuova versione del documento in {collection}"
+  },
+  "Toast.tsx_Lv0zJu": {
+    "defaultMessage": "Dettagli"
+  },
+  "Toast.tsx_rbrahO": {
+    "defaultMessage": "Chiudi"
+  },
+  "TokenUsage.tsx_6nAVv6": {
+    "defaultMessage": "Messaggio + {toolCallCount, plural, one {# chiamata strumento} other {# chiamate strumento}}"
+  },
+  "TokenUsage.tsx_MJ2jZQ": {
+    "defaultMessage": "Totale"
+  },
+  "TokenUsage.tsx_Wk7BO4": {
+    "defaultMessage": "{totalTokens} token"
+  },
+  "TokenUsage.tsx_fBG/Ge": {
+    "defaultMessage": "Costo"
+  },
+  "TokenUsage.tsx_fio5op": {
+    "defaultMessage": "Output"
+  },
+  "TokenUsage.tsx_it6Lig": {
+    "defaultMessage": "Input"
+  },
+  "ToolCallResult.tsx_yq9SNC": {
+    "defaultMessage": "Questa chiamata non ha alcun risultato."
+  },
+  "TrayFile.tsx_G/yZLu": {
+    "defaultMessage": "Rimuovi"
+  },
+  "UpdateCollectionSettingsForm.tsx_1W2oHf": {
+    "defaultMessage": "Istruzioni dell'assistente"
+  },
+  "UpdateCollectionSettingsForm.tsx_HAlOn1": {
+    "defaultMessage": "Nome"
+  },
+  "UpdateCollectionSettingsForm.tsx_Q8Qw5B": {
+    "defaultMessage": "Descrizione"
+  },
+  "UpdateCollectionSettingsForm.tsx_kk4TVW": {
+    "defaultMessage": "Icona"
+  },
+  "UpdateCollectionSettingsForm.tsx_muqizb": {
+    "defaultMessage": "Salva impostazioni"
+  },
+  "UpdateCollectionSettingsForm.tsx_qmIyad": {
+    "defaultMessage": "Istruzioni specifiche per questa collezione da passare all'assistente."
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_AERMcJ": {
+    "defaultMessage": "Sommario dei contenuti"
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_U64U7V": {
+    "defaultMessage": "Opzioni UI della vista documento"
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_dPkbhX": {
+    "defaultMessage": "Deduplicazione"
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_qTBVbt": {
+    "defaultMessage": "Salva le impostazioni della versione della collezione"
+  },
+  "UpdateCollectionVersionSettingsForm.tsx_wH+PSV": {
+    "defaultMessage": "Contenuto predefinito del documento"
+  },
+  "UpdateGlobalSettingsForm.tsx_2GURQY": {
+    "defaultMessage": "Aspetto"
+  },
+  "UpdateGlobalSettingsForm.tsx_jvrMfo": {
+    "defaultMessage": "Assistenti"
+  },
+  "UpdateGlobalSettingsForm.tsx_n0wQL1": {
+    "defaultMessage": "Inferenza"
+  },
+  "UpdateGlobalSettingsForm.tsx_pbF7L9": {
+    "defaultMessage": "Errore durante il salvataggio delle impostazioni globali"
+  },
+  "UpdateNameModalForm.tsx_47FYwb": {
+    "defaultMessage": "Annulla"
+  },
+  "UpdateNameModalForm.tsx_BWpuKl": {
+    "defaultMessage": "Aggiorna"
+  },
+  "UpdateNameModalForm.tsx_HAlOn1": {
+    "defaultMessage": "Nome"
+  },
+  "UpdateNameModalForm.tsx_J1XXSx": {
+    "defaultMessage": "La mia fantastica app"
+  },
+  "UpdateNameModalForm.tsx_btR6aV": {
+    "defaultMessage": "Aggiorna il nome dell'app"
+  },
+  "UserMessage.tsx_J3ca41": {
+    "defaultMessage": "Riproduci"
+  },
+  "UserMessage.tsx_Wf1OoY": {
+    "defaultMessage": "Trascrizione audio in corso..."
+  },
+  "UserMessage.tsx_tFFMkF": {
+    "defaultMessage": "Pausa"
+  },
+  "UserMessageContentInput.tsx_8MXjTC": {
+    "defaultMessage": "Configura l'assistente per iniziare a chattare"
+  },
+  "UserMessageContentInput.tsx_XE7R4v": {
+    "defaultMessage": "Invia messaggio all'assistente"
+  },
+  "UserMessageContentInput.tsx_yvK6cX": {
+    "defaultMessage": "Le tue collezioni sono cambiate dopo questa conversazione. Non può essere continuata."
+  },
+  "Welcome.tsx_C3+BqB": {
+    "defaultMessage": "Per iniziare:"
+  },
+  "Welcome.tsx_NZjpCr": {
+    "defaultMessage": "<settingsLink>Configura l'assistente AI</settingsLink>."
+  },
+  "Welcome.tsx_mD6yYG": {
+    "defaultMessage": "<createCollectionLink>Crea la tua prima collezione</createCollectionLink>, o <boutiqueLink>installane una già pronta</boutiqueLink> dal Boutique."
+  },
+  "Welcome.tsx_mNIlLz": {
+    "defaultMessage": "<createAppLink>Crea la tua prima app</createAppLink>."
+  },
+  "downloadFile.ts_sG8Krh": {
+    "defaultMessage": "Download del file non riuscito"
+  },
+  "formatDuration.ts_26OSN4": {
+    "defaultMessage": "{minutes, plural, one {1 minuto} other {# minuti}} {seconds} secondi"
+  },
+  "formatDuration.ts_lf6GDO": {
+    "defaultMessage": "{seconds, number, ::.##} secondi"
+  },
+  "getDownSyncAction.tsx_IJWuS/": {
+    "defaultMessage": "Ultima sincronizzazione {lastSucceededAt, date, ::MMM d, HH:mm}"
+  },
+  "getDownSyncAction.tsx_RRA+40": {
+    "defaultMessage": "Autenticati con {remote}"
+  },
+  "getDownSyncAction.tsx_dKtz/9": {
+    "defaultMessage": "Sincronizza"
+  },
+  "getDownSyncAction.tsx_eOnwqs": {
+    "defaultMessage": "Sincronizzazione in corso"
+  },
+  "getDownSyncAction.tsx_mG35sa": {
+    "defaultMessage": "Ultima sincronizzazione non riuscita"
+  },
+  "getIntlMessages.ts_/GCoTA": {
+    "defaultMessage": "Cancella"
+  },
+  "getIntlMessages.ts_1nnRAQ": {
+    "defaultMessage": "Si è verificato un errore durante il rendering del grafico."
+  },
+  "getIntlMessages.ts_8mRNBD": {
+    "defaultMessage": "Mese precedente"
+  },
+  "getIntlMessages.ts_FUqf3/": {
+    "defaultMessage": "Si è verificato un errore durante il rendering della mappa."
+  },
+  "getIntlMessages.ts_J1XXSx": {
+    "defaultMessage": "La mia fantastica app"
+  },
+  "getIntlMessages.ts_PqmLVn": {
+    "defaultMessage": "Mese successivo"
+  },
+  "getIntlMessages.ts_PyA0WU": {
+    "defaultMessage": "Puoi vibe-codare l'app chiedendo all'assistente."
+  },
+  "getIntlMessages.ts_UfI09W": {
+    "defaultMessage": "Si è verificato un errore durante l'importazione dell'app."
+  },
+  "getIntlMessages.ts_XBQLkj": {
+    "defaultMessage": "Oppure puoi scrivere tu stesso il codice passando alla vista codice."
+  },
+  "getIntlMessages.ts_bzhBew": {
+    "defaultMessage": "Si è verificato un errore durante il rendering dell'app."
+  },
+  "getIntlMessages.ts_eIxrAW": {
+    "defaultMessage": "Questa app ha accesso alle seguenti collezioni:"
+  },
+  "getIntlMessages.ts_hPMG1H": {
+    "defaultMessage": "In questa sezione puoi vedere l'anteprima live della tua app."
+  },
+  "getIntlMessages.ts_r5pj/5": {
+    "defaultMessage": "Trascina"
+  },
+  "getIntlMessages.ts_rbrahO": {
+    "defaultMessage": "Chiudi"
+  },
+  "getIntlMessages.ts_zWgbGg": {
+    "defaultMessage": "Oggi"
+  },
   "getStatusText.ts_+cQcX2": {
     "defaultMessage": "creazione di mappe da usare nella risposta"
   },
@@ -1504,252 +1771,6 @@
   },
   "getStatusText.ts_uf3oCA": {
     "defaultMessage": "creazione di nuovi documenti"
-  },
-  "ThinkingTime.tsx_O5Mn+P": {
-    "defaultMessage": "{model} ha pensato per {time}"
-  },
-  "TimeInputWithMilliseconds.tsx_/w7Rru": {
-    "defaultMessage": "Millisecondi"
-  },
-  "Title.tsx_8yzKPa": {
-    "defaultMessage": "Crea documenti"
-  },
-  "Title.tsx_9Hs+7t": {
-    "defaultMessage": "Crea grafico da {collections}"
-  },
-  "Title.tsx_LOghU6": {
-    "defaultMessage": "Riuscito"
-  },
-  "Title.tsx_RG9Nzq": {
-    "defaultMessage": "Ottieni lo schema TypeScript per {collection}"
-  },
-  "Title.tsx_T0B1v2": {
-    "defaultMessage": "Esegui la funzione TypeScript su {collections}"
-  },
-  "Title.tsx_XnBm2q": {
-    "defaultMessage": "Nessuna risposta"
-  },
-  "Title.tsx_fBfv7E": {
-    "defaultMessage": "Crea mappa da {collections}"
-  },
-  "Title.tsx_foZAHu": {
-    "defaultMessage": "Chiama strumento: {tool}"
-  },
-  "Title.tsx_oHtaJ1": {
-    "defaultMessage": "Crea tabella dei documenti da {collections}"
-  },
-  "Title.tsx_vXCeIi": {
-    "defaultMessage": "Fallito"
-  },
-  "Title.tsx_vlxsWA": {
-    "defaultMessage": "Crea una nuova versione del documento in {collection}"
-  },
-  "Toast.tsx_Lv0zJu": {
-    "defaultMessage": "Dettagli"
-  },
-  "Toast.tsx_rbrahO": {
-    "defaultMessage": "Chiudi"
-  },
-  "TokenUsage.tsx_MJ2jZQ": {
-    "defaultMessage": "Totale"
-  },
-  "TokenUsage.tsx_Wk7BO4": {
-    "defaultMessage": "{totalTokens} token"
-  },
-  "TokenUsage.tsx_fBG/Ge": {
-    "defaultMessage": "Costo"
-  },
-  "TokenUsage.tsx_fio5op": {
-    "defaultMessage": "Output"
-  },
-  "TokenUsage.tsx_it6Lig": {
-    "defaultMessage": "Input"
-  },
-  "TokenUsage.tsx_6nAVv6": {
-    "defaultMessage": "Messaggio + {toolCallCount, plural, one {# chiamata strumento} other {# chiamate strumento}}"
-  },
-  "ToolCallResult.tsx_yq9SNC": {
-    "defaultMessage": "Questa chiamata non ha alcun risultato."
-  },
-  "TrayFile.tsx_G/yZLu": {
-    "defaultMessage": "Rimuovi"
-  },
-  "UpdateCollectionSettingsForm.tsx_1W2oHf": {
-    "defaultMessage": "Istruzioni dell'assistente"
-  },
-  "UpdateCollectionSettingsForm.tsx_HAlOn1": {
-    "defaultMessage": "Nome"
-  },
-  "UpdateCollectionSettingsForm.tsx_Q8Qw5B": {
-    "defaultMessage": "Descrizione"
-  },
-  "UpdateCollectionSettingsForm.tsx_kk4TVW": {
-    "defaultMessage": "Icona"
-  },
-  "UpdateCollectionSettingsForm.tsx_muqizb": {
-    "defaultMessage": "Salva impostazioni"
-  },
-  "UpdateCollectionSettingsForm.tsx_qmIyad": {
-    "defaultMessage": "Istruzioni specifiche per questa collezione da passare all'assistente."
-  },
-  "UpdateCollectionVersionSettingsForm.tsx_AERMcJ": {
-    "defaultMessage": "Sommario dei contenuti"
-  },
-  "UpdateCollectionVersionSettingsForm.tsx_U64U7V": {
-    "defaultMessage": "Opzioni UI della vista documento"
-  },
-  "UpdateCollectionVersionSettingsForm.tsx_dPkbhX": {
-    "defaultMessage": "Deduplicazione"
-  },
-  "UpdateCollectionVersionSettingsForm.tsx_qTBVbt": {
-    "defaultMessage": "Salva le impostazioni della versione della collezione"
-  },
-  "UpdateGlobalSettingsForm.tsx_2GURQY": {
-    "defaultMessage": "Aspetto"
-  },
-  "UpdateGlobalSettingsForm.tsx_jvrMfo": {
-    "defaultMessage": "Assistenti"
-  },
-  "UpdateGlobalSettingsForm.tsx_n0wQL1": {
-    "defaultMessage": "Inferenza"
-  },
-  "UpdateGlobalSettingsForm.tsx_pbF7L9": {
-    "defaultMessage": "Errore durante il salvataggio delle impostazioni globali"
-  },
-  "UpdateNameModalForm.tsx_47FYwb": {
-    "defaultMessage": "Annulla"
-  },
-  "UpdateNameModalForm.tsx_BWpuKl": {
-    "defaultMessage": "Aggiorna"
-  },
-  "UpdateNameModalForm.tsx_HAlOn1": {
-    "defaultMessage": "Nome"
-  },
-  "UpdateNameModalForm.tsx_J1XXSx": {
-    "defaultMessage": "La mia fantastica app"
-  },
-  "UpdateNameModalForm.tsx_btR6aV": {
-    "defaultMessage": "Aggiorna il nome dell'app"
-  },
-  "UserMessage.tsx_J3ca41": {
-    "defaultMessage": "Riproduci"
-  },
-  "UserMessage.tsx_Wf1OoY": {
-    "defaultMessage": "Trascrizione audio in corso..."
-  },
-  "UserMessage.tsx_tFFMkF": {
-    "defaultMessage": "Pausa"
-  },
-  "UserMessageContentInput.tsx_8MXjTC": {
-    "defaultMessage": "Configura l'assistente per iniziare a chattare"
-  },
-  "UserMessageContentInput.tsx_XE7R4v": {
-    "defaultMessage": "Invia messaggio all'assistente"
-  },
-  "ModelSelect.tsx_rhSI1/": {
-    "defaultMessage": "Modello"
-  },
-  "ReasoningEffortSelect.tsx_2X1lvg": {
-    "defaultMessage": "Sforzo di ragionamento"
-  },
-  "ReasoningEffortSelect.tsx_450Fty": {
-    "defaultMessage": "Nessuno"
-  },
-  "ReasoningEffortSelect.tsx_477I0g": {
-    "defaultMessage": "Basso"
-  },
-  "ReasoningEffortSelect.tsx_AxMhQr": {
-    "defaultMessage": "Alto"
-  },
-  "ReasoningEffortSelect.tsx_kDEj60": {
-    "defaultMessage": "Extra alto"
-  },
-  "ReasoningEffortSelect.tsx_ovJ26C": {
-    "defaultMessage": "Medio"
-  },
-  "UserMessageContentInput.tsx_yvK6cX": {
-    "defaultMessage": "Le tue collezioni sono cambiate dopo questa conversazione. Non può essere continuata."
-  },
-  "Welcome.tsx_C3+BqB": {
-    "defaultMessage": "Per iniziare:"
-  },
-  "Welcome.tsx_NZjpCr": {
-    "defaultMessage": "<settingsLink>Configura l'assistente AI</settingsLink>."
-  },
-  "Welcome.tsx_mD6yYG": {
-    "defaultMessage": "<createCollectionLink>Crea la tua prima collezione</createCollectionLink>, o <boutiqueLink>installane una già pronta</boutiqueLink> dal Boutique."
-  },
-  "Welcome.tsx_mNIlLz": {
-    "defaultMessage": "<createAppLink>Crea la tua prima app</createAppLink>."
-  },
-  "downloadFile.ts_sG8Krh": {
-    "defaultMessage": "Download del file non riuscito"
-  },
-  "formatDuration.ts_26OSN4": {
-    "defaultMessage": "{minutes, plural, one {1 minuto} other {# minuti}} {seconds} secondi"
-  },
-  "formatDuration.ts_lf6GDO": {
-    "defaultMessage": "{seconds, number, ::.##} secondi"
-  },
-  "getDownSyncAction.tsx_IJWuS/": {
-    "defaultMessage": "Ultima sincronizzazione {lastSucceededAt, date, ::MMM d, HH:mm}"
-  },
-  "getDownSyncAction.tsx_RRA+40": {
-    "defaultMessage": "Autenticati con {remote}"
-  },
-  "getDownSyncAction.tsx_dKtz/9": {
-    "defaultMessage": "Sincronizza"
-  },
-  "getDownSyncAction.tsx_eOnwqs": {
-    "defaultMessage": "Sincronizzazione in corso"
-  },
-  "getDownSyncAction.tsx_mG35sa": {
-    "defaultMessage": "Ultima sincronizzazione non riuscita"
-  },
-  "getIntlMessages.ts_/GCoTA": {
-    "defaultMessage": "Cancella"
-  },
-  "getIntlMessages.ts_1nnRAQ": {
-    "defaultMessage": "Si è verificato un errore durante il rendering del grafico."
-  },
-  "getIntlMessages.ts_8mRNBD": {
-    "defaultMessage": "Mese precedente"
-  },
-  "getIntlMessages.ts_FUqf3/": {
-    "defaultMessage": "Si è verificato un errore durante il rendering della mappa."
-  },
-  "getIntlMessages.ts_J1XXSx": {
-    "defaultMessage": "La mia fantastica app"
-  },
-  "getIntlMessages.ts_PqmLVn": {
-    "defaultMessage": "Mese successivo"
-  },
-  "getIntlMessages.ts_PyA0WU": {
-    "defaultMessage": "Puoi vibe-codare l'app chiedendo all'assistente."
-  },
-  "getIntlMessages.ts_UfI09W": {
-    "defaultMessage": "Si è verificato un errore durante l'importazione dell'app."
-  },
-  "getIntlMessages.ts_XBQLkj": {
-    "defaultMessage": "Oppure puoi scrivere tu stesso il codice passando alla vista codice."
-  },
-  "getIntlMessages.ts_bzhBew": {
-    "defaultMessage": "Si è verificato un errore durante il rendering dell'app."
-  },
-  "getIntlMessages.ts_eIxrAW": {
-    "defaultMessage": "Questa app ha accesso alle seguenti collezioni:"
-  },
-  "getIntlMessages.ts_hPMG1H": {
-    "defaultMessage": "In questa sezione puoi vedere l'anteprima live della tua app."
-  },
-  "getIntlMessages.ts_r5pj/5": {
-    "defaultMessage": "Trascina"
-  },
-  "getIntlMessages.ts_rbrahO": {
-    "defaultMessage": "Chiudi"
-  },
-  "getIntlMessages.ts_zWgbGg": {
-    "defaultMessage": "Oggi"
   },
   "openFileWithNativeApp.ts_Blh3UZ": {
     "defaultMessage": "Apertura del file non riuscita"

--- a/packages/apps/cli/src/commands/devenv/check/checkCollection.ts
+++ b/packages/apps/cli/src/commands/devenv/check/checkCollection.ts
@@ -43,7 +43,22 @@ export default async function checkCollection(
   }
   const schema = readJsonFile(schemaPath) as Schema;
 
-  // 3. defaultDocumentViewUiOptions.json (optional)
+  // 3. defaultDocumentContent.json (optional)
+  const defaultDocumentContentPath = join(
+    collectionDir,
+    "defaultDocumentContent.json",
+  );
+  if (existsSync(defaultDocumentContentPath)) {
+    results.push(
+      checkJsonValidation(
+        `${collectionName}/defaultDocumentContent.json`,
+        defaultDocumentContentPath,
+        schemaValibotSchemas.content(schema),
+      ),
+    );
+  }
+
+  // 4. defaultDocumentViewUiOptions.json (optional)
   const defaultDocumentViewUiOptionsPath = join(
     collectionDir,
     "defaultDocumentViewUiOptions.json",
@@ -58,7 +73,7 @@ export default async function checkCollection(
     );
   }
 
-  // 4. generated types
+  // 5. generated types
   const generatedTypes = codegen(schema);
   results.push(
     checkGeneratedTypes(
@@ -72,7 +87,7 @@ export default async function checkCollection(
     source: generatedTypes,
   };
 
-  // 5. contentSummaryGetter.ts
+  // 6. contentSummaryGetter.ts
   const contentSummaryGetterPath = join(
     collectionDir,
     "contentSummaryGetter.ts",
@@ -94,7 +109,7 @@ export default async function checkCollection(
     });
   }
 
-  // 6. contentBlockingKeysGetter.ts (optional)
+  // 7. contentBlockingKeysGetter.ts (optional)
   const contentBlockingKeysGetterPath = join(
     collectionDir,
     "contentBlockingKeysGetter.ts",

--- a/packages/apps/cli/src/commands/devenv/create/agent-instructions/AGENTS.md
+++ b/packages/apps/cli/src/commands/devenv/create/agent-instructions/AGENTS.md
@@ -34,6 +34,7 @@ into a single `pack.mpk` file.
     content
   - `contentBlockingKeysGetter.ts` - (optional) Function to derive
     duplicate-detection keys
+  - `defaultDocumentContent.json` - (optional) Default content for new documents
   - `defaultDocumentViewUiOptions.json` - (optional) Custom UI layout for the
     document view
 - `demo-documents/` - (optional) Demo documents for previewing

--- a/packages/apps/cli/src/commands/devenv/utils/compilePack.ts
+++ b/packages/apps/cli/src/commands/devenv/utils/compilePack.ts
@@ -108,6 +108,26 @@ export default async function compilePack(
       );
     }
 
+    // defaultDocumentContent.json (optional)
+    let defaultDocumentContent = null;
+    const defaultDocumentContentPath = join(
+      collectionDir,
+      "defaultDocumentContent.json",
+    );
+    if (existsSync(defaultDocumentContentPath)) {
+      const contentData = readJsonFile(defaultDocumentContentPath);
+      const contentResult = v.safeParse(
+        schemaValibotSchemas.content(schema),
+        contentData,
+      );
+      if (!contentResult.success) {
+        throw new Error(
+          `${collectionName}/defaultDocumentContent.json validation failed:\n${contentResult.issues.map((i) => i.message).join("\n")}`,
+        );
+      }
+      defaultDocumentContent = contentResult.output;
+    }
+
     // defaultDocumentViewUiOptions.json (optional)
     let defaultDocumentViewUiOptions = null;
     const defaultDocumentViewUiOptionsPath = join(
@@ -145,6 +165,7 @@ export default async function compilePack(
       versionSettings: {
         contentSummaryGetter,
         contentBlockingKeysGetter,
+        defaultDocumentContent,
         defaultDocumentViewUiOptions,
       },
     });

--- a/packages/core/backend/src/Backend.ts
+++ b/packages/core/backend/src/Backend.ts
@@ -33,6 +33,7 @@ import type ConnectorSettingsNotValid from "./errors/ConnectorSettingsNotValid.j
 import type ContentBlockingKeysGetterNotValid from "./errors/ContentBlockingKeysGetterNotValid.js";
 import type ContentSummaryGetterNotValid from "./errors/ContentSummaryGetterNotValid.js";
 import type ConversationNotFound from "./errors/ConversationNotFound.js";
+import type DefaultDocumentContentNotValid from "./errors/DefaultDocumentContentNotValid.js";
 import type DefaultDocumentViewUiOptionsNotValid from "./errors/DefaultDocumentViewUiOptionsNotValid.js";
 import type DocumentContentNotValid from "./errors/DocumentContentNotValid.js";
 import type DocumentIsReferenced from "./errors/DocumentIsReferenced.js";
@@ -147,6 +148,7 @@ export default interface Backend {
       | ReferencedCollectionsNotFound
       | ContentBlockingKeysGetterNotValid
       | ContentSummaryGetterNotValid
+      | DefaultDocumentContentNotValid
       | DefaultDocumentViewUiOptionsNotValid
       | UnexpectedError
     >;
@@ -162,6 +164,7 @@ export default interface Backend {
       | ReferencedCollectionsNotFound
       | ContentBlockingKeysGetterNotValid
       | ContentSummaryGetterNotValid
+      | DefaultDocumentContentNotValid
       | DefaultDocumentViewUiOptionsNotValid
       | UnexpectedError
     >;
@@ -246,6 +249,7 @@ export default interface Backend {
       | ReferencedCollectionsNotFound
       | ContentSummaryGetterNotValid
       | ContentBlockingKeysGetterNotValid
+      | DefaultDocumentContentNotValid
       | DefaultDocumentViewUiOptionsNotValid
       | CollectionMigrationNotValid
       | RemoteConvertersNotValid
@@ -264,6 +268,7 @@ export default interface Backend {
       | ContentBlockingKeysGetterNotValid
       | MakingContentBlockingKeysFailed
       | ContentSummaryGetterNotValid
+      | DefaultDocumentContentNotValid
       | DefaultDocumentViewUiOptionsNotValid
       | UnexpectedError
     >;
@@ -571,6 +576,7 @@ export default interface Backend {
       | ReferencedCollectionsNotFound
       | ContentBlockingKeysGetterNotValid
       | ContentSummaryGetterNotValid
+      | DefaultDocumentContentNotValid
       | DefaultDocumentViewUiOptionsNotValid
       | AppNameNotValid
       | CollectionNotFound

--- a/packages/core/backend/src/errors/DefaultDocumentContentNotValid.ts
+++ b/packages/core/backend/src/errors/DefaultDocumentContentNotValid.ts
@@ -1,0 +1,14 @@
+import type { ResultError } from "@superego/global-types";
+import type CollectionId from "../ids/CollectionId.js";
+import type CollectionVersionId from "../ids/CollectionVersionId.js";
+import type ValidationIssue from "../types/ValidationIssue.js";
+
+type DefaultDocumentContentNotValid = ResultError<
+  "DefaultDocumentContentNotValid",
+  {
+    collectionId: CollectionId | null;
+    collectionVersionId: CollectionVersionId | null;
+    issues: ValidationIssue[];
+  }
+>;
+export default DefaultDocumentContentNotValid;

--- a/packages/core/backend/src/index.ts
+++ b/packages/core/backend/src/index.ts
@@ -58,6 +58,7 @@ export type { default as ContentSummaryGetterNotValid } from "./errors/ContentSu
 export type { default as ContentSummaryNotValid } from "./errors/ContentSummaryNotValid.js";
 export type { default as ConversationNotFound } from "./errors/ConversationNotFound.js";
 export type { default as ConversationStatusNotProcessing } from "./errors/ConversationStatusNotProcessing.js";
+export type { default as DefaultDocumentContentNotValid } from "./errors/DefaultDocumentContentNotValid.js";
 export type { default as DefaultDocumentViewUiOptionsNotValid } from "./errors/DefaultDocumentViewUiOptionsNotValid.js";
 export type { default as DocumentContentNotValid } from "./errors/DocumentContentNotValid.js";
 export type { default as DocumentIsReferenced } from "./errors/DocumentIsReferenced.js";

--- a/packages/core/backend/src/types/CollectionVersionSettings.ts
+++ b/packages/core/backend/src/types/CollectionVersionSettings.ts
@@ -9,5 +9,6 @@ export default interface CollectionVersionSettings {
    */
   contentBlockingKeysGetter: TypescriptModule | null;
   contentSummaryGetter: TypescriptModule;
+  defaultDocumentContent: any | null;
   defaultDocumentViewUiOptions: DefaultDocumentViewUiOptions | null;
 }

--- a/packages/core/executing-backend/src/assistants/CollectionCreatorAssistant/tools/SuggestCollectionsDefinitions.ts
+++ b/packages/core/executing-backend/src/assistants/CollectionCreatorAssistant/tools/SuggestCollectionsDefinitions.ts
@@ -72,6 +72,7 @@ export default {
         versionSettings: {
           contentBlockingKeysGetter: null,
           contentSummaryGetter: stubContentSummaryGetter,
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       })),
@@ -85,6 +86,7 @@ export default {
         createManyResult.error.name === "AppNotFound" ||
         createManyResult.error.name === "ContentBlockingKeysGetterNotValid" ||
         createManyResult.error.name === "ContentSummaryGetterNotValid" ||
+        createManyResult.error.name === "DefaultDocumentContentNotValid" ||
         createManyResult.error.name === "DefaultDocumentViewUiOptionsNotValid")
     ) {
       throw new UnexpectedAssistantError(

--- a/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/collection-versions.ts
+++ b/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/collection-versions.ts
@@ -13,6 +13,7 @@ const schema: Schema = {
 const settings: CollectionVersionSettings = {
   contentBlockingKeysGetter: null,
   contentSummaryGetter: { source: "", compiled: "" },
+  defaultDocumentContent: null,
   defaultDocumentViewUiOptions: null,
 };
 
@@ -81,6 +82,7 @@ export default rd<GetDependencies>("Collection versions", (deps) => {
           source: "updatedSource",
           compiled: "updatedCompiled",
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     };

--- a/packages/core/executing-backend/src/usecases/collections/Create.ts
+++ b/packages/core/executing-backend/src/usecases/collections/Create.ts
@@ -10,6 +10,7 @@ import type {
   CollectionSettingsNotValid,
   ContentBlockingKeysGetterNotValid,
   ContentSummaryGetterNotValid,
+  DefaultDocumentContentNotValid,
   DefaultDocumentViewUiOptionsNotValid,
   ReferencedCollectionsNotFound,
   UnexpectedError,
@@ -56,6 +57,7 @@ export default class CollectionsCreate extends Usecase<
     | ReferencedCollectionsNotFound
     | ContentBlockingKeysGetterNotValid
     | ContentSummaryGetterNotValid
+    | DefaultDocumentContentNotValid
     | DefaultDocumentViewUiOptionsNotValid
     | UnexpectedError
   > {
@@ -198,6 +200,23 @@ export default class CollectionsCreate extends Usecase<
       );
     }
 
+    // Validate defaultDocumentContent.
+    if (versionSettings.defaultDocumentContent !== null) {
+      const contentValidationResult = v.safeParse(
+        schemaValibotSchemas.content(resolvedSchema),
+        versionSettings.defaultDocumentContent,
+      );
+      if (!contentValidationResult.success) {
+        return makeUnsuccessfulResult(
+          makeResultError("DefaultDocumentContentNotValid", {
+            collectionId: null,
+            collectionVersionId: null,
+            issues: makeValidationIssues(contentValidationResult.issues),
+          }),
+        );
+      }
+    }
+
     // Validate defaultDocumentViewUiOptions.
     if (versionSettings.defaultDocumentViewUiOptions !== null) {
       const uiOptionsValidationResult = v.safeParse(
@@ -240,6 +259,7 @@ export default class CollectionsCreate extends Usecase<
       settings: {
         contentBlockingKeysGetter: versionSettings.contentBlockingKeysGetter,
         contentSummaryGetter: versionSettings.contentSummaryGetter,
+        defaultDocumentContent: versionSettings.defaultDocumentContent,
         defaultDocumentViewUiOptions:
           versionSettings.defaultDocumentViewUiOptions,
       },

--- a/packages/core/executing-backend/src/usecases/collections/CreateMany.ts
+++ b/packages/core/executing-backend/src/usecases/collections/CreateMany.ts
@@ -10,6 +10,7 @@ import type {
   CollectionSettingsNotValid,
   ContentBlockingKeysGetterNotValid,
   ContentSummaryGetterNotValid,
+  DefaultDocumentContentNotValid,
   DefaultDocumentViewUiOptionsNotValid,
   ReferencedCollectionsNotFound,
   UnexpectedError,
@@ -50,6 +51,7 @@ export default class CollectionsCreateMany extends Usecase<
     | ReferencedCollectionsNotFound
     | ContentBlockingKeysGetterNotValid
     | ContentSummaryGetterNotValid
+    | DefaultDocumentContentNotValid
     | DefaultDocumentViewUiOptionsNotValid
     | UnexpectedError
   > {

--- a/packages/core/executing-backend/src/usecases/collections/CreateNewVersion.ts
+++ b/packages/core/executing-backend/src/usecases/collections/CreateNewVersion.ts
@@ -11,6 +11,7 @@ import {
   type CollectionVersionSettings,
   type ContentBlockingKeysGetterNotValid,
   type ContentSummaryGetterNotValid,
+  type DefaultDocumentContentNotValid,
   type DefaultDocumentViewUiOptionsNotValid,
   DocumentVersionCreator,
   type ReferencedCollectionsNotFound,
@@ -64,6 +65,7 @@ export default class CollectionsCreateNewVersion extends Usecase<
     | ReferencedCollectionsNotFound
     | ContentBlockingKeysGetterNotValid
     | ContentSummaryGetterNotValid
+    | DefaultDocumentContentNotValid
     | DefaultDocumentViewUiOptionsNotValid
     | CollectionMigrationNotValid
     | RemoteConvertersNotValid
@@ -171,6 +173,23 @@ export default class CollectionsCreateNewVersion extends Usecase<
           ],
         }),
       );
+    }
+
+    // Validate settings.defaultDocumentContent.
+    if (settings.defaultDocumentContent !== null) {
+      const contentValidationResult = v.safeParse(
+        valibotSchemas.content(resolvedSchema),
+        settings.defaultDocumentContent,
+      );
+      if (!contentValidationResult.success) {
+        return makeUnsuccessfulResult(
+          makeResultError("DefaultDocumentContentNotValid", {
+            collectionId: id,
+            collectionVersionId: latestVersion.id,
+            issues: makeValidationIssues(contentValidationResult.issues),
+          }),
+        );
+      }
     }
 
     // Validate settings.defaultDocumentViewUiOptions.
@@ -286,6 +305,7 @@ export default class CollectionsCreateNewVersion extends Usecase<
       settings: {
         contentSummaryGetter: settings.contentSummaryGetter,
         contentBlockingKeysGetter: settings.contentBlockingKeysGetter,
+        defaultDocumentContent: settings.defaultDocumentContent,
         defaultDocumentViewUiOptions: settings.defaultDocumentViewUiOptions,
       },
       migration: migration,

--- a/packages/core/executing-backend/src/usecases/collections/UpdateLatestVersionSettings.ts
+++ b/packages/core/executing-backend/src/usecases/collections/UpdateLatestVersionSettings.ts
@@ -8,11 +8,13 @@ import type {
   CollectionVersionSettings,
   ContentBlockingKeysGetterNotValid,
   ContentSummaryGetterNotValid,
+  DefaultDocumentContentNotValid,
   DefaultDocumentViewUiOptionsNotValid,
   MakingContentBlockingKeysFailed,
   UnexpectedError,
 } from "@superego/backend";
 import type { ResultPromise } from "@superego/global-types";
+import { valibotSchemas as schemaValibotSchemas } from "@superego/schema";
 import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
@@ -44,6 +46,7 @@ export default class CollectionUpdateLatestVersionSettings extends Usecase<
     | ContentBlockingKeysGetterNotValid
     | MakingContentBlockingKeysFailed
     | ContentSummaryGetterNotValid
+    | DefaultDocumentContentNotValid
     | DefaultDocumentViewUiOptionsNotValid
     | UnexpectedError
   > {
@@ -109,6 +112,25 @@ export default class CollectionUpdateLatestVersionSettings extends Usecase<
       }
     }
 
+    // Validate defaultDocumentContent.
+    if (settingsPatch.defaultDocumentContent !== undefined) {
+      if (settingsPatch.defaultDocumentContent !== null) {
+        const contentValidationResult = v.safeParse(
+          schemaValibotSchemas.content(latestVersion.schema),
+          settingsPatch.defaultDocumentContent,
+        );
+        if (!contentValidationResult.success) {
+          return makeUnsuccessfulResult(
+            makeResultError("DefaultDocumentContentNotValid", {
+              collectionId: id,
+              collectionVersionId: latestVersion.id,
+              issues: makeValidationIssues(contentValidationResult.issues),
+            }),
+          );
+        }
+      }
+    }
+
     // Validate defaultDocumentViewUiOptions.
     if (settingsPatch.defaultDocumentViewUiOptions !== undefined) {
       if (settingsPatch.defaultDocumentViewUiOptions !== null) {
@@ -140,6 +162,10 @@ export default class CollectionUpdateLatestVersionSettings extends Usecase<
         contentSummaryGetter:
           settingsPatch.contentSummaryGetter ??
           latestVersion.settings.contentSummaryGetter,
+        defaultDocumentContent:
+          settingsPatch.defaultDocumentContent !== undefined
+            ? settingsPatch.defaultDocumentContent
+            : latestVersion.settings.defaultDocumentContent,
         defaultDocumentViewUiOptions:
           settingsPatch.defaultDocumentViewUiOptions !== undefined
             ? settingsPatch.defaultDocumentViewUiOptions

--- a/packages/core/executing-backend/src/usecases/packs/Install.ts
+++ b/packages/core/executing-backend/src/usecases/packs/Install.ts
@@ -18,6 +18,7 @@ import type {
   ConnectorDoesNotSupportUpSyncing,
   ContentBlockingKeysGetterNotValid,
   ContentSummaryGetterNotValid,
+  DefaultDocumentContentNotValid,
   DefaultDocumentViewUiOptionsNotValid,
   Document,
   DocumentContentNotValid,
@@ -82,6 +83,7 @@ export default class PacksInstall extends Usecase<Backend["packs"]["install"]> {
     | ReferencedCollectionsNotFound
     | ContentBlockingKeysGetterNotValid
     | ContentSummaryGetterNotValid
+    | DefaultDocumentContentNotValid
     | DefaultDocumentViewUiOptionsNotValid
     | AppNameNotValid
     | CollectionNotFound

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.ts
@@ -16,6 +16,7 @@ export default {
   },
   schema: fuelLogsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { FuelLog } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/health/cycleDayLogs.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/health/cycleDayLogs.ts
@@ -15,6 +15,7 @@ export default {
   },
   schema: cycleDayLogsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { CycleDayLog } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/health/foods.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/health/foods.ts
@@ -14,6 +14,7 @@ Use 100g as serving size if not specified.
   },
   schema: foodsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { Food } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/health/meals.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/health/meals.ts
@@ -15,6 +15,7 @@ Default serving sizes come from the Foods collection if not specified.
   },
   schema: mealsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/health/weighIns.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/health/weighIns.ts
@@ -15,6 +15,7 @@ export default {
   },
   schema: weighInsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/accounts.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/accounts.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: accountsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { Account } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.ts
@@ -16,6 +16,7 @@ export default {
   },
   schema: expensesSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/holdings.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/holdings.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: holdingsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { Holding } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/securities.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/securities.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: securitiesSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { Security } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/calendar.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/calendar.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: calendarEntriesSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/contacts.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/contacts.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: contactsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: {
       source: `
 import type { Contact } from "./CollectionSchema.js";

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/drawings.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/drawings.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: drawingsSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/notes.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/notes.ts
@@ -12,6 +12,7 @@ export default {
   },
   schema: notesSchema,
   versionSettings: {
+    defaultDocumentContent: null,
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/tasks.ts
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/productivity/tasks.ts
@@ -12,6 +12,14 @@ export default {
   },
   schema: tasksSchema,
   versionSettings: {
+    defaultDocumentContent: {
+      title: "",
+      description: null,
+      stage: "Backlog",
+      dueDate: null,
+      priority: 0,
+      archived: false,
+    },
     contentBlockingKeysGetter: null,
     contentSummaryGetter: {
       source: `

--- a/packages/tests/assistants-e2e-tests/src/utils/FactotumObject.ts
+++ b/packages/tests/assistants-e2e-tests/src/utils/FactotumObject.ts
@@ -65,6 +65,7 @@ class FactotumObject {
           compiled:
             'export default function getValue() { return { name: "name" }; }',
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });

--- a/packages/tests/backend-e2e-tests/src/suites/apps.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/apps.ts
@@ -90,6 +90,7 @@ export default rd<GetDependencies>("Apps", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -309,6 +310,7 @@ export default rd<GetDependencies>("Apps", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -469,6 +471,7 @@ export default rd<GetDependencies>("Apps", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/assistants.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/assistants.ts
@@ -323,6 +323,7 @@ export default rd<GetDependencies>("Assistants", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -618,6 +619,7 @@ export default rd<GetDependencies>("Assistants", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -683,6 +685,7 @@ export default rd<GetDependencies>("Assistants", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -891,6 +894,7 @@ export default rd<GetDependencies>("Assistants", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/background-jobs.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/background-jobs.ts
@@ -88,6 +88,7 @@ export default rd<GetDependencies>("Background Jobs", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -197,6 +198,7 @@ export default rd<GetDependencies>("Background Jobs", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/collection-categories.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/collection-categories.ts
@@ -468,6 +468,7 @@ export default rd<GetDependencies>("Collection categories", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/collections.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/collections.ts
@@ -38,6 +38,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -87,6 +88,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -128,6 +130,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -168,6 +171,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -215,6 +219,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             source: "",
             compiled: "export function getContentSummary() {}",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -267,6 +272,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -323,6 +329,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: {
             fullWidth: false,
             alwaysCollapsePrimarySidebar: false,
@@ -396,6 +403,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -439,6 +447,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -462,6 +471,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
             migration: null,
@@ -518,6 +528,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -545,6 +556,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
             migration: null,
@@ -610,6 +622,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -654,6 +667,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -705,6 +719,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -748,6 +763,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -790,6 +806,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -839,6 +856,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               source: "",
               compiled: "export function getContentSummary() {}",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -893,6 +911,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -951,6 +970,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: {
               fullWidth: false,
               alwaysCollapsePrimarySidebar: false,
@@ -1026,6 +1046,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1083,6 +1104,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1128,6 +1150,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1153,6 +1176,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                   compiled:
                     "export default function getContentSummary() { return {}; }",
                 },
+                defaultDocumentContent: null,
                 defaultDocumentViewUiOptions: null,
               },
               migration: null,
@@ -1207,6 +1231,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1230,6 +1255,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1255,6 +1281,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                   compiled:
                     "export default function getContentSummary() { return {}; }",
                 },
+                defaultDocumentContent: null,
                 defaultDocumentViewUiOptions: null,
               },
               migration: null,
@@ -1288,6 +1315,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                   compiled:
                     "export default function getContentSummary() { return {}; }",
                 },
+                defaultDocumentContent: null,
                 defaultDocumentViewUiOptions: null,
               },
               migration: null,
@@ -1359,6 +1387,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1393,6 +1422,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         },
@@ -1483,6 +1513,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1536,6 +1567,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1582,6 +1614,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1642,6 +1675,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1770,6 +1804,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1834,6 +1869,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1925,6 +1961,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2031,6 +2068,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2125,6 +2163,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2229,6 +2268,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2321,6 +2361,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2415,6 +2456,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2517,6 +2559,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2643,6 +2686,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2747,6 +2791,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2820,6 +2865,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2928,6 +2974,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3008,6 +3055,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3082,6 +3130,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3190,6 +3239,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3282,6 +3332,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3364,6 +3415,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3472,6 +3524,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3571,6 +3624,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3675,6 +3729,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3792,6 +3847,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -3922,6 +3978,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4071,6 +4128,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4212,6 +4270,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4420,6 +4479,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4528,6 +4588,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
         {
           contentBlockingKeysGetter: null,
           contentSummaryGetter: { source: "", compiled: "" },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "" },
@@ -4568,6 +4629,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4585,6 +4647,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
         {
           contentBlockingKeysGetter: null,
           contentSummaryGetter: { source: "", compiled: "" },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "" },
@@ -4629,6 +4692,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4645,6 +4709,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
         {
           contentBlockingKeysGetter: null,
           contentSummaryGetter: { source: "", compiled: "" },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "" },
@@ -4693,6 +4758,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4724,6 +4790,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         {
@@ -4770,6 +4837,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4789,6 +4857,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             source: "",
             compiled: "export function getContentSummary() {}",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "" },
@@ -4845,6 +4914,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -4872,6 +4942,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: {
             fullWidth: false,
             alwaysCollapsePrimarySidebar: false,
@@ -4967,6 +5038,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5001,6 +5073,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "export function migrate() {}" },
@@ -5054,6 +5127,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5074,6 +5148,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         null,
@@ -5122,6 +5197,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5142,6 +5218,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "export function migrate() {}" },
@@ -5190,6 +5267,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5210,6 +5288,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         { source: "", compiled: "export default function migrate() {}" },
@@ -5297,6 +5376,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5331,6 +5411,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         null,
@@ -5412,6 +5493,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5446,6 +5528,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         null,
@@ -5500,6 +5583,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5526,6 +5610,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           {
@@ -5585,6 +5670,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5611,6 +5697,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           {
@@ -5709,6 +5796,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5751,6 +5839,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           null,
@@ -5852,6 +5941,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -5899,6 +5989,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           null,
@@ -5974,6 +6065,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6013,6 +6105,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           migration,
@@ -6043,6 +6136,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                   "export default function getContentSummary() { return {}; }",
                 source: "",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
             migration: migration,
@@ -6153,6 +6247,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6219,6 +6314,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 "export default function getContentSummary() { return {}; }",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
           null,
@@ -6319,6 +6415,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6371,6 +6468,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6437,6 +6535,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6503,6 +6602,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6519,6 +6619,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               source: "",
               compiled: "export function getContentSummary() {}",
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         );
@@ -6573,6 +6674,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6584,6 +6686,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
           createResult.data.id,
           createResult.data.latestVersion.id,
           {
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: {
               fullWidth: false,
               alwaysCollapsePrimarySidebar: false,
@@ -6644,6 +6747,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6661,6 +6765,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
               compiled:
                 'export default function getContentSummary() { return { "key": "value"}; }',
             },
+            defaultDocumentContent: null,
             defaultDocumentViewUiOptions: null,
           },
         );
@@ -6679,6 +6784,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
                 compiled:
                   'export default function getContentSummary() { return { "key": "value"}; }',
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -6724,6 +6830,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6800,6 +6907,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6882,6 +6990,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6932,6 +7041,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -6967,6 +7077,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7021,6 +7132,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7053,6 +7165,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7124,6 +7237,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7182,6 +7296,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7260,6 +7375,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7284,6 +7400,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7308,6 +7425,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7376,6 +7494,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7430,6 +7549,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7477,6 +7597,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -7508,6 +7629,7 @@ export default rd<GetDependencies>("Collections", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
         migration,

--- a/packages/tests/backend-e2e-tests/src/suites/documents.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/documents.ts
@@ -94,6 +94,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -163,6 +164,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -223,6 +225,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -282,6 +285,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -351,6 +355,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -414,6 +419,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -477,6 +483,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -550,6 +557,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -643,6 +651,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -708,6 +717,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -779,6 +789,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -848,6 +859,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -919,6 +931,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -983,6 +996,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1073,6 +1087,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1158,6 +1173,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1253,6 +1269,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1338,6 +1355,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1401,6 +1419,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1470,6 +1489,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1538,6 +1558,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1617,6 +1638,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1686,6 +1708,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1786,6 +1809,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1840,6 +1864,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -1941,6 +1966,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2028,6 +2054,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2108,6 +2135,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2186,6 +2214,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2246,6 +2275,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2297,6 +2327,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2357,6 +2388,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2446,6 +2478,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2512,6 +2545,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2565,6 +2599,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2619,6 +2654,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2676,6 +2712,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2760,6 +2797,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2813,6 +2851,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2873,6 +2912,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2902,6 +2942,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2958,6 +2999,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });
@@ -2987,6 +3029,7 @@ export default rd<GetDependencies>("Documents", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/files.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/files.ts
@@ -53,6 +53,7 @@ export default rd<GetDependencies>("Files", (deps) => {
             compiled:
               "export default function getContentSummary() { return {}; }",
           },
+          defaultDocumentContent: null,
           defaultDocumentViewUiOptions: null,
         },
       });

--- a/packages/tests/backend-e2e-tests/src/suites/packs.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/packs.ts
@@ -79,6 +79,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -145,6 +146,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -220,6 +222,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -376,6 +379,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: {
                 fullWidth: false,
                 alwaysCollapsePrimarySidebar: false,
@@ -440,6 +444,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -566,6 +571,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -627,6 +633,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -696,6 +703,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -770,6 +778,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -897,6 +906,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -940,6 +950,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -979,6 +990,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },
@@ -1227,6 +1239,7 @@ export default rd<GetDependencies>("Packs", (deps) => {
                 compiled:
                   "export default function getContentSummary() { return {}; }",
               },
+              defaultDocumentContent: null,
               defaultDocumentViewUiOptions: null,
             },
           },

--- a/packages/tests/browser-app-e2e-tests/src/scenarios/005-use-markdown-input-for-document-properties.test.ts
+++ b/packages/tests/browser-app-e2e-tests/src/scenarios/005-use-markdown-input-for-document-properties.test.ts
@@ -40,6 +40,7 @@ test("005. Use markdown input for document properties", async ({ page }) => {
           compiled:
             "export default function getContentSummary() { return {}; }",
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });

--- a/packages/tests/browser-app-e2e-tests/src/scenarios/006-use-tiptap-input-for-document-properties.test.ts
+++ b/packages/tests/browser-app-e2e-tests/src/scenarios/006-use-tiptap-input-for-document-properties.test.ts
@@ -40,6 +40,7 @@ test("006. Use TipTap input for document properties", async ({ page }) => {
           compiled:
             "export default function getContentSummary() { return {}; }",
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });

--- a/packages/tests/browser-app-e2e-tests/src/scenarios/007-use-excalidraw-input-for-document-properties.test.ts
+++ b/packages/tests/browser-app-e2e-tests/src/scenarios/007-use-excalidraw-input-for-document-properties.test.ts
@@ -38,6 +38,7 @@ test("007. Use Excalidraw input for document properties", async ({ page }) => {
           compiled:
             "export default function getContentSummary() { return {}; }",
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });

--- a/packages/tests/browser-app-e2e-tests/src/scenarios/008-use-geojson-input-for-document-properties.test.ts
+++ b/packages/tests/browser-app-e2e-tests/src/scenarios/008-use-geojson-input-for-document-properties.test.ts
@@ -48,6 +48,7 @@ test("008. Use GeoJSON input for document properties", async ({ page }) => {
           compiled:
             "export default function getContentSummary() { return {}; }",
         },
+        defaultDocumentContent: null,
         defaultDocumentViewUiOptions: null,
       },
     });


### PR DESCRIPTION
## Summary
This PR introduces a new "default document content" feature that allows users to set default values for new documents created in a collection. This feature is configurable per collection version and validates the default content against the collection's schema.

## Key Changes

- **New UI Component**: Added `RHFDefaultDocumentContentField` component with toggle and JSON editor for managing default document content
- **New Tab**: Added `DefaultDocumentContentTab` in the collection version creation form (step 4, between "Content summary" and "UI options")
- **Backend Validation**: Created `DefaultDocumentContentNotValid` error type for schema validation failures
- **Schema Integration**: Integrated default content validation using valibot schemas to ensure content matches collection schema
- **Form Integration**: Updated `CreateNewCollectionVersionForm` and `UpdateCollectionVersionSettingsForm` to include the new field
- **CLI Support**: Added validation and compilation support for `defaultDocumentContent.json` files in collection definitions
- **Test Updates**: Updated all test suites to include `defaultDocumentContent: null` in collection version settings
- **Boutique Packs**: Updated example packs to include default document content (with actual defaults for the tasks collection)
- **Document Creation**: Modified `CreateDocumentForm` to use default content when creating new documents

## Implementation Details

- The feature uses a toggle switch to enable/disable default content, with a JSON editor for configuration
- Default content is optional (can be null) and only applied when explicitly enabled
- Validation ensures the default content conforms to the collection's schema before saving
- The form field handles both string and object representations of JSON content
- Error messages provide clear feedback on validation issues with specific field paths
- Translations added for Italian and English languages

https://claude.ai/code/session_0123M12Rd8S2We6FpCczcuip