### PR TITLE
Improve transcription prompt for non-English audio

### DIFF
--- a/packages/ai/multi-driver-inference-service/src/OpenResponses/OpenResponsesInferenceService.ts
+++ b/packages/ai/multi-driver-inference-service/src/OpenResponses/OpenResponsesInferenceService.ts
@@ -73,7 +73,7 @@ export default class OpenResponsesInferenceService implements InferenceService {
           content: [
             {
               type: MessageContentPartType.Text,
-              text: "Transcribe the following audio. Output only the transcription, without any additional commentary.",
+              text: "Transcribe the following audio. Identify the language being spoken and transcribe in that language. Output only the transcription, without any additional commentary.",
             },
             { type: MessageContentPartType.Audio, audio },
           ],


### PR DESCRIPTION
Instruct the LLM to identify the language being spoken and transcribe in that language, instead of defaulting to English.

Closes #115

https://claude.ai/code/session_0147aGjmRoNQC8fWP8gPuNC3