### PR TITLE
[codex] Add Turso wasm data repositories

### DIFF
--- a/packages/data/turso-data-repositories/package.json
+++ b/packages/data/turso-data-repositories/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@superego/turso-data-repositories",
+  "version": "2026.3.8",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "NODE_OPTIONS=\"--disable-warning=ExperimentalWarning\" vitest --reporter=verbose"
+  },
+  "dependencies": {
+    "@emnapi/core": "^1.10.0",
+    "@emnapi/runtime": "^1.10.0",
+    "@msgpack/msgpack": "^3.1.3",
+    "@superego/backend": "workspace:*",
+    "@superego/executing-backend": "workspace:*",
+    "@superego/schema": "workspace:*",
+    "@tursodatabase/database-wasm": "0.6.0",
+    "es-toolkit": "^1.46.1",
+    "flexsearch": "^0.8.212",
+    "jsondiffpatch": "^0.7.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.8.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/data/turso-data-repositories/src/AsyncSqliteDatabase.ts
+++ b/packages/data/turso-data-repositories/src/AsyncSqliteDatabase.ts
@@ -1,0 +1,49 @@
+import type { Database as TursoDatabase } from "@tursodatabase/database-wasm/bundle";
+
+type TursoStatement = Awaited<ReturnType<TursoDatabase["prepare"]>>;
+
+export default class AsyncSqliteDatabase {
+  constructor(private db: TursoDatabase) {}
+
+  get inTransaction() {
+    return this.db.inTransaction;
+  }
+
+  prepare(query: string) {
+    return new AsyncSqliteStatement(query, this.db);
+  }
+
+  exec(query: string): Promise<void> {
+    return this.db.exec(query);
+  }
+
+  close(): Promise<void> {
+    return this.db.close();
+  }
+}
+
+class AsyncSqliteStatement {
+  constructor(
+    private query: string,
+    private db: TursoDatabase,
+  ) {}
+
+  async run(...parameters: unknown[]) {
+    const statement = await this.prepare();
+    return statement.run(...parameters);
+  }
+
+  async get(...parameters: unknown[]) {
+    const statement = await this.prepare();
+    return statement.get(...parameters);
+  }
+
+  async all(...parameters: unknown[]) {
+    const statement = await this.prepare();
+    return statement.all(...parameters);
+  }
+
+  private prepare(): Promise<TursoStatement> {
+    return this.db.prepare(this.query);
+  }
+}

--- a/packages/data/turso-data-repositories/src/SqliteDataRepositories.ts
+++ b/packages/data/turso-data-repositories/src/SqliteDataRepositories.ts
@@ -1,0 +1,91 @@
+import type { GlobalSettings } from "@superego/backend";
+import type {
+  BackgroundJobRepository,
+  DataRepositories,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "./AsyncSqliteDatabase.js";
+import SqliteAppRepository from "./repositories/SqliteAppRepository.js";
+import SqliteAppVersionRepository from "./repositories/SqliteAppVersionRepository.js";
+import SqliteBackgroundJobRepository from "./repositories/SqliteBackgroundJobRepository.js";
+import SqliteCollectionCategoryRepository from "./repositories/SqliteCollectionCategoryRepository.js";
+import SqliteCollectionRepository from "./repositories/SqliteCollectionRepository.js";
+import SqliteCollectionVersionRepository from "./repositories/SqliteCollectionVersionRepository.js";
+import SqliteConversationRepository from "./repositories/SqliteConversationRepository.js";
+import SqliteConversationTextSearchIndex, {
+  type SearchTextIndexState as ConversationSearchTextIndexState,
+} from "./repositories/SqliteConversationTextSearchIndex.js";
+import SqliteDocumentRepository from "./repositories/SqliteDocumentRepository.js";
+import SqliteDocumentTextSearchIndex, {
+  type SearchTextIndexState as DocumentSearchTextIndexState,
+} from "./repositories/SqliteDocumentTextSearchIndex.js";
+import SqliteDocumentVersionRepository from "./repositories/SqliteDocumentVersionRepository.js";
+import SqliteFileRepository from "./repositories/SqliteFileRepository.js";
+import SqliteGlobalSettingsRepository from "./repositories/SqliteGlobalSettingsRepository.js";
+
+export default class SqliteDataRepositories implements DataRepositories {
+  app: SqliteAppRepository;
+  appVersion: SqliteAppVersionRepository;
+  backgroundJob: BackgroundJobRepository;
+  collectionCategory: SqliteCollectionCategoryRepository;
+  collection: SqliteCollectionRepository;
+  collectionVersion: SqliteCollectionVersionRepository;
+  conversation: SqliteConversationRepository;
+  conversationTextSearchIndex: SqliteConversationTextSearchIndex;
+  document: SqliteDocumentRepository;
+  documentVersion: SqliteDocumentVersionRepository;
+  file: SqliteFileRepository;
+  documentTextSearchIndex: SqliteDocumentTextSearchIndex;
+  globalSettings: SqliteGlobalSettingsRepository;
+
+  constructor(
+    private db: AsyncSqliteDatabase,
+    defaultGlobalSettings: GlobalSettings,
+    searchTextIndexStates: {
+      conversation: ConversationSearchTextIndexState;
+      document: DocumentSearchTextIndexState;
+    },
+    onTransactionSucceeded: (callback: () => void) => void,
+  ) {
+    this.app = new SqliteAppRepository(db);
+    this.appVersion = new SqliteAppVersionRepository(db);
+    this.backgroundJob = new SqliteBackgroundJobRepository(db);
+    this.collectionCategory = new SqliteCollectionCategoryRepository(db);
+    this.collection = new SqliteCollectionRepository(db);
+    this.collectionVersion = new SqliteCollectionVersionRepository(db);
+    this.conversation = new SqliteConversationRepository(db);
+    this.conversationTextSearchIndex = new SqliteConversationTextSearchIndex(
+      db,
+      searchTextIndexStates.conversation,
+      onTransactionSucceeded,
+    );
+    this.document = new SqliteDocumentRepository(db);
+    this.documentVersion = new SqliteDocumentVersionRepository(db);
+    this.file = new SqliteFileRepository(db);
+    this.documentTextSearchIndex = new SqliteDocumentTextSearchIndex(
+      db,
+      searchTextIndexStates.document,
+      onTransactionSucceeded,
+    );
+    this.globalSettings = new SqliteGlobalSettingsRepository(
+      db,
+      defaultGlobalSettings,
+    );
+  }
+
+  async export(path: string): Promise<void> {
+    throw new Error(
+      `Database export is not supported by the Turso WASM driver: ${path}`,
+    );
+  }
+
+  async createSavepoint(): Promise<string> {
+    const name = crypto.randomUUID();
+    await this.db.prepare(`SAVEPOINT "${name}"`).run();
+    return name;
+  }
+
+  async rollbackToSavepoint(name: string): Promise<void> {
+    await this.db.prepare(`ROLLBACK TRANSACTION TO SAVEPOINT "${name}"`).run();
+    await this.db.prepare(`RELEASE SAVEPOINT "${name}"`).run();
+  }
+}

--- a/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.test.ts
+++ b/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AssistantName, Theme } from "@superego/backend";
+import { registerDataRepositoriesTests } from "@superego/executing-backend/tests";
+import { afterAll, beforeAll } from "vitest";
+import TursoDataRepositoriesManager from "./TursoDataRepositoriesManager.js";
+
+const databasesTmpDir = join(
+  tmpdir(),
+  "superego-turso-data-repositories-tests",
+);
+
+beforeAll(() => {
+  mkdirSync(databasesTmpDir, { recursive: true });
+});
+afterAll(() => {
+  rmSync(databasesTmpDir, { force: true, recursive: true });
+});
+
+registerDataRepositoriesTests(() => {
+  const dataRepositoriesManager = new TursoDataRepositoriesManager({
+    fileName: join(databasesTmpDir, `${crypto.randomUUID()}.sqlite`),
+    defaultGlobalSettings: {
+      appearance: { theme: Theme.Auto },
+      inference: {
+        providers: [],
+        defaultInferenceOptions: {
+          completion: null,
+          transcription: null,
+          fileInspection: null,
+        },
+      },
+      assistants: {
+        userInfo: null,
+        userPreferences: null,
+        developerPrompts: {
+          [AssistantName.Factotum]: null,
+          [AssistantName.CollectionCreator]: null,
+        },
+      },
+    },
+  });
+  dataRepositoriesManager.runMigrations();
+  return { dataRepositoriesManager };
+});

--- a/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.ts
+++ b/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.ts
@@ -1,0 +1,97 @@
+import type { GlobalSettings } from "@superego/backend";
+import type {
+  DataRepositories,
+  DataRepositoriesManager,
+} from "@superego/executing-backend";
+import { connect } from "@tursodatabase/database-wasm/bundle";
+import AsyncSqliteDatabase from "./AsyncSqliteDatabase.js";
+import migrate from "./migrations/migrate.js";
+import SqliteConversationTextSearchIndex from "./repositories/SqliteConversationTextSearchIndex.js";
+import SqliteDocumentTextSearchIndex from "./repositories/SqliteDocumentTextSearchIndex.js";
+import SqliteDataRepositories from "./SqliteDataRepositories.js";
+
+export default class TursoDataRepositoriesManager implements DataRepositoriesManager {
+  private migrationsPromise: Promise<void> | null = null;
+
+  private searchTextIndexStates = {
+    conversation: SqliteConversationTextSearchIndex.getSearchTextIndexState(),
+    document: SqliteDocumentTextSearchIndex.getSearchTextIndexState(),
+  };
+
+  constructor(
+    private options: {
+      fileName: string;
+      defaultGlobalSettings: GlobalSettings;
+    },
+  ) {}
+
+  async runInSerializableTransaction<ReturnValue>(
+    fn: (
+      repos: DataRepositories,
+    ) => Promise<{ action: "commit" | "rollback"; returnValue: ReturnValue }>,
+  ): Promise<ReturnValue> {
+    await this.migrationsPromise;
+    const transactionSucceededCallbacks: (() => void)[] = [];
+    const db = await this.openDb();
+    await db.exec("BEGIN");
+    const repos = new SqliteDataRepositories(
+      db as never,
+      this.options.defaultGlobalSettings,
+      this.searchTextIndexStates,
+      (callback) => {
+        transactionSucceededCallbacks.push(callback);
+      },
+    );
+    try {
+      const { action, returnValue } = await fn(repos);
+      await db.exec(action === "commit" ? "COMMIT" : "ROLLBACK");
+      if (action === "commit") {
+        TursoDataRepositoriesManager.runTransactionSucceededCallbacks(
+          transactionSucceededCallbacks,
+        );
+      }
+      return returnValue;
+    } catch (error) {
+      if (db.inTransaction) {
+        await db.exec("ROLLBACK");
+      }
+      throw error;
+    } finally {
+      await db.close();
+    }
+  }
+
+  runMigrations(): void {
+    this.migrationsPromise = this.runMigrationsAsync();
+  }
+
+  private async runMigrationsAsync(): Promise<void> {
+    const db = await this.openDb();
+    try {
+      await migrate(db);
+    } finally {
+      await db.close();
+    }
+  }
+
+  private async openDb(): Promise<AsyncSqliteDatabase> {
+    const db = new AsyncSqliteDatabase(await connect(this.options.fileName));
+    await db.exec("PRAGMA journal_mode = WAL");
+    await db.exec("PRAGMA synchronous = FULL");
+    await db.exec("PRAGMA busy_timeout = 0");
+    return db;
+  }
+
+  private static runTransactionSucceededCallbacks(callbacks: (() => void)[]) {
+    callbacks.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.error(
+          "Uncaught error running transaction succeeded callback",
+          error,
+        );
+      }
+    });
+  }
+}

--- a/packages/data/turso-data-repositories/src/index.ts
+++ b/packages/data/turso-data-repositories/src/index.ts
@@ -1,0 +1,1 @@
+export { default as TursoDataRepositoriesManager } from "./TursoDataRepositoriesManager.js";

--- a/packages/data/turso-data-repositories/src/migrations/0000.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0000.sql
@@ -1,0 +1,141 @@
+-- Collection categories
+
+CREATE TABLE "collection_categories" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "icon" TEXT,
+  "parent_id" TEXT,
+  "created_at" TEXT NOT NULL,
+  FOREIGN KEY ("parent_id") REFERENCES "collection_categories" ("id")
+);
+
+CREATE INDEX "idx__collection_categories__on__parent_id" ON "collection_categories" (
+  "parent_id"
+);
+
+-- Collections
+
+CREATE TABLE "collections" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "settings" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  CHECK (json_valid("settings"))
+);
+
+CREATE INDEX "idx__collections__on__settings_collection_category_id" ON "collections" (
+  "settings" ->> '$.collectionCategoryId'
+);
+
+-- Collection versions
+
+CREATE TABLE "collection_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "collection_id" TEXT NOT NULL,
+  "schema" TEXT NOT NULL,
+  "settings" TEXT NOT NULL,
+  "migration" TEXT,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "collection_versions" ("id"),
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  CHECK (json_valid("schema")),
+  CHECK (json_valid("settings")),
+  CHECK (json_valid("migration"))
+);
+
+CREATE INDEX "idx__collection_versions__on__collection_id" ON "collection_versions" (
+  "collection_id"
+);
+
+CREATE INDEX "idx__collection_versions__on__is_latest" ON "collection_versions" (
+  "is_latest"
+);
+
+CREATE UNIQUE INDEX "idx__collection_versions__on__collection_id__unique_is_latest_true" ON "collection_versions" (
+  "collection_id"
+)
+WHERE "is_latest" = 1;
+
+-- Documents
+
+CREATE TABLE "documents" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id")
+);
+
+CREATE INDEX "idx__documents__on__collection_id" ON "documents" (
+  "collection_id"
+);
+
+-- Document versions
+
+CREATE TABLE "document_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "collection_id" TEXT NOT NULL,
+  "document_id" TEXT NOT NULL,
+  "collection_version_id" TEXT NOT NULL,
+  "content_delta" TEXT,
+  "content_snapshot" TEXT,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "document_versions" ("id"),
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  FOREIGN KEY ("document_id") REFERENCES "documents" ("id"),
+  FOREIGN KEY ("collection_version_id") REFERENCES "collection_versions" ("id"),
+  CHECK (json_valid("content_delta")),
+  CHECK (json_valid("content_snapshot"))
+);
+
+CREATE INDEX "idx__document_versions__on__collection_id" ON "document_versions" (
+  "collection_id"
+);
+
+CREATE INDEX "idx__document_versions__on__document_id" ON "document_versions" (
+  "document_id"
+);
+
+CREATE INDEX "idx__document_versions__on__is_latest" ON "document_versions" (
+  "is_latest"
+);
+
+CREATE INDEX "idx__document_versions__on__collection_id__is_latest_true" ON "document_versions" (
+  "collection_id"
+)
+WHERE "is_latest" = 1;
+
+CREATE UNIQUE INDEX "idx__document_versions__on__document_id__unique_is_latest_true" ON "document_versions" (
+  "document_id"
+)
+WHERE "is_latest" = 1;
+
+-- Files
+
+CREATE TABLE "files" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "document_id" TEXT NOT NULL,
+  "created_with_document_version_id" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "content" BLOB NOT NULL,
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  FOREIGN KEY ("document_id") REFERENCES "documents" ("id"),
+  FOREIGN KEY (
+    "created_with_document_version_id"
+  ) REFERENCES "document_versions" ("id")
+);
+
+CREATE INDEX "idx__files__on__collection_id" ON "files" ("collection_id");
+
+CREATE INDEX "idx__files__on__document_id" ON "files" ("document_id");
+
+-- Global settings
+
+CREATE TABLE "singleton__global_settings" (
+  "id" TEXT PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+  "value" TEXT NOT NULL,
+  CHECK ("id" = 'singleton')
+);

--- a/packages/data/turso-data-repositories/src/migrations/0001.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0001.sql
@@ -1,0 +1,47 @@
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "conversation_id" TEXT;
+
+ALTER TABLE "document_versions"
+ADD COLUMN "created_by" TEXT NOT NULL DEFAULT 'User';
+
+-- Conversations
+
+CREATE TABLE "conversations" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "assistant" TEXT NOT NULL,
+  "format" TEXT NOT NULL,
+  "title" TEXT,
+  "context_fingerprint" TEXT NOT NULL,
+  "messages" BLOB NOT NULL,
+  "status" TEXT NOT NULL,
+  "error" TEXT,
+  "created_at" TEXT NOT NULL,
+  CHECK (json_valid("error"))
+);
+
+-- Background jobs
+
+CREATE TABLE "background_jobs" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "input" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "enqueued_at" TEXT NOT NULL,
+  "started_processing_at" TEXT,
+  "finished_processing_at" TEXT,
+  "error" TEXT,
+  CHECK (json_valid("input")),
+  CHECK (json_valid("error"))
+);
+
+CREATE UNIQUE INDEX "idx__background_jobs__on__status__unique_status_processing" ON "background_jobs" (
+  "status"
+)
+WHERE "status" = 'Processing';
+
+CREATE INDEX "idx__background_jobs__on__enqueued_at__status_enqueued" ON "background_jobs" (
+  "enqueued_at"
+)
+WHERE "status" = 'Enqueued';

--- a/packages/data/turso-data-repositories/src/migrations/0002.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0002.sql
@@ -1,0 +1,29 @@
+-- Collections
+
+ALTER TABLE "collections"
+ADD COLUMN "remote" BLOB;
+
+-- Collection versions
+
+ALTER TABLE "collection_versions"
+ADD COLUMN "remote_converters" BLOB;
+
+-- Documents
+
+ALTER TABLE "documents"
+ADD COLUMN "remote_id" TEXT;
+ALTER TABLE "documents"
+ADD COLUMN "remote_url" TEXT;
+ALTER TABLE "documents"
+ADD COLUMN "latest_remote_document" BLOB;
+
+CREATE UNIQUE INDEX "idx__documents__on__collection_id_remote_id__unique" ON "documents" (
+  "collection_id",
+  "remote_id"
+)
+WHERE "remote_id" IS NOT NULL;
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "remote_id" TEXT;

--- a/packages/data/turso-data-repositories/src/migrations/0003.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0003.sql
@@ -1,0 +1,36 @@
+-- Apps
+
+CREATE TABLE "apps" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "type" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL
+);
+
+-- App versions
+
+CREATE TABLE "app_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "app_id" TEXT NOT NULL,
+  "target_collections" BLOB NOT NULL,
+  "files" BLOB NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "app_versions" ("id"),
+  FOREIGN KEY ("app_id") REFERENCES "apps" ("id")
+);
+
+CREATE INDEX "idx__app_versions__on__app_id" ON "app_versions" ("app_id");
+
+CREATE INDEX "idx__app_versions__on__is_latest" ON "app_versions" ("is_latest");
+
+CREATE UNIQUE INDEX "idx__app_versions__on__app_id__unique_is_latest_true" ON "app_versions" (
+  "app_id"
+)
+WHERE "is_latest" = 1;
+
+-- Collections
+
+UPDATE "collections"
+SET "settings" = json_set("settings", '$.defaultCollectionViewAppId', NULL);

--- a/packages/data/turso-data-repositories/src/migrations/0004.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0004.sql
@@ -1,0 +1,31 @@
+-- Files
+
+CREATE TABLE "files_new" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "referenced_by" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "content" BLOB NOT NULL,
+  CHECK (json_valid("referenced_by"))
+);
+
+INSERT INTO "files_new"
+  ("id", "referenced_by", "created_at", "content")
+SELECT
+  "id",
+  json_array(
+    json_object(
+      'collectionId',
+      "collection_id",
+      'documentId',
+      "document_id",
+      'documentVersionId',
+      "created_with_document_version_id"
+    )
+  ) AS "referenced_by",
+  "created_at",
+  "content"
+FROM "files";
+
+DROP TABLE "files";
+
+ALTER TABLE "files_new" RENAME TO "files";

--- a/packages/data/turso-data-repositories/src/migrations/0005.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0005.sql
@@ -1,0 +1,9 @@
+-- Flexsearch indexes
+
+CREATE TABLE "flexsearch_indexes" (
+  "key" TEXT NOT NULL,
+  "target" TEXT NOT NULL,
+  "data" TEXT NOT NULL,
+  PRIMARY KEY ("key", "target"),
+  CHECK ("target" IN ('document', 'conversation'))
+);

--- a/packages/data/turso-data-repositories/src/migrations/0006.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0006.sql
@@ -1,0 +1,35 @@
+-- Collection versions
+
+ALTER TABLE "collection_versions"
+ADD COLUMN "content_blocking_keys_getter" TEXT;
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "referenced_documents" TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE "document_versions"
+ADD COLUMN "content_blocking_keys" TEXT;
+
+-- Document version blocking keys. This is a lookup table used purely as an
+-- index for fast blocking key searches.
+
+CREATE TABLE "document_version_content_blocking_keys" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "document_version_id" TEXT NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "blocking_key" TEXT NOT NULL,
+  FOREIGN KEY ("document_version_id") REFERENCES "document_versions" ("id")
+    ON DELETE CASCADE
+);
+
+-- Index for duplicate detection: find any document with matching key in
+-- collection.
+CREATE INDEX "idx__document_version_content_blocking_keys__collection_id__blocking_key" ON "document_version_content_blocking_keys" (
+  "collection_id",
+  "blocking_key"
+);
+
+-- Index for cleanup when deleting document versions.
+CREATE INDEX "idx__document_version_content_blocking_keys__document_version_id" ON "document_version_content_blocking_keys" (
+  "document_version_id"
+);

--- a/packages/data/turso-data-repositories/src/migrations/0007.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0007.sql
@@ -1,0 +1,4 @@
+-- Conversations
+
+ALTER TABLE "conversations"
+DROP COLUMN "format";

--- a/packages/data/turso-data-repositories/src/migrations/0008.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0008.sql
@@ -1,0 +1,52 @@
+-- Document text search texts
+
+CREATE TABLE "document_text_search_texts" (
+  "document_id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "text" TEXT NOT NULL
+);
+
+CREATE INDEX "idx__document_text_search_texts__collection_id" ON "document_text_search_texts" (
+  "collection_id"
+);
+
+-- Conversation text search texts
+
+CREATE TABLE "conversation_text_search_texts" (
+  "conversation_id" TEXT PRIMARY KEY NOT NULL,
+  "text" TEXT NOT NULL
+);
+
+-- Flexsearch indexes
+
+DROP TABLE "flexsearch_indexes";
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "content_summary" TEXT NOT NULL DEFAULT '{}';
+
+CREATE INDEX "idx__document_versions__on__collection_version_id" ON "document_versions" (
+  "collection_version_id"
+);
+
+-- Collection versions
+
+-- Migrate content_blocking_keys_getter from a separate column into the settings
+-- JSON column.
+
+-- Step 1: Update the settings column to include contentBlockingKeysGetter.
+UPDATE "collection_versions"
+SET "settings" = json_set(
+  "settings",
+  '$.contentBlockingKeysGetter',
+  CASE
+    WHEN "content_blocking_keys_getter" IS NOT NULL THEN json(
+      "content_blocking_keys_getter"
+    )
+    ELSE json('null')
+  END
+);
+
+-- Step 2: Drop the old column.
+ALTER TABLE "collection_versions" DROP COLUMN "content_blocking_keys_getter";

--- a/packages/data/turso-data-repositories/src/migrations/0009.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0009.sql
@@ -1,0 +1,4 @@
+-- Conversations
+
+ALTER TABLE "conversations"
+ADD COLUMN "processing_started_at" TEXT;

--- a/packages/data/turso-data-repositories/src/migrations/0010.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0010.sql
@@ -1,0 +1,16 @@
+-- Collections
+
+-- Add redirectToCollectionAfterDocumentCreation to collection settings,
+-- defaulting to false for existing collections.
+
+UPDATE "collections"
+SET "settings" = json_set(
+  "settings",
+  '$.redirectToCollectionAfterDocumentCreation',
+  json('false')
+)
+WHERE
+  json_extract(
+    "settings",
+    '$.redirectToCollectionAfterDocumentCreation'
+  ) IS NULL;

--- a/packages/data/turso-data-repositories/src/migrations/migrate.ts
+++ b/packages/data/turso-data-repositories/src/migrations/migrate.ts
@@ -1,0 +1,107 @@
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import m0000 from "./0000.sql?raw";
+import m0001 from "./0001.sql?raw";
+import m0002 from "./0002.sql?raw";
+import m0003 from "./0003.sql?raw";
+import m0004 from "./0004.sql?raw";
+import m0005 from "./0005.sql?raw";
+import m0006 from "./0006.sql?raw";
+import m0007 from "./0007.sql?raw";
+import m0008 from "./0008.sql?raw";
+import m0009 from "./0009.sql?raw";
+import m0010 from "./0010.sql?raw";
+
+const migrationFiles = {
+  "0000.sql": m0000,
+  "0001.sql": m0001,
+  "0002.sql": m0002,
+  "0003.sql": m0003,
+  "0004.sql": m0004,
+  "0005.sql": m0005,
+  "0006.sql": m0006,
+  "0007.sql": m0007,
+  "0008.sql": m0008,
+  "0009.sql": m0009,
+  "0010.sql": m0010,
+};
+const table = "migrations";
+
+interface SqliteMigration {
+  file_name: string;
+  /** ISO 8601 */
+  applied_at: string;
+}
+
+export default async function migrate(db: AsyncSqliteDatabase) {
+  await db.exec("BEGIN IMMEDIATE");
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS "${table}" (
+      "file_name" TEXT PRIMARY KEY,
+      "applied_at" TEXT NOT NULL
+    )
+  `);
+
+  const migrationFileNames = (
+    Object.keys(migrationFiles) as (keyof typeof migrationFiles)[]
+  ).sort();
+
+  const appliedMigrations = (await db
+    .prepare(`SELECT * FROM "${table}"`)
+    .all()) as any as SqliteMigration[];
+
+  ensureIntegrity(appliedMigrations, migrationFileNames);
+
+  for (const fileName of migrationFileNames) {
+    if (appliedMigrations.some(({ file_name }) => file_name === fileName)) {
+      continue;
+    }
+    await db.exec(migrationFiles[fileName]);
+    const insertMigration = db.prepare(
+      `INSERT INTO "${table}" ("file_name", "applied_at") VALUES (?, ?)`,
+    );
+    await insertMigration.run(fileName, new Date().toISOString());
+  }
+  await db.exec("COMMIT");
+}
+
+/**
+ * Ensures that:
+ *
+ * 1. Every applied migration has a corresponding migration file.
+ * 2. No migrations were missed. That is, all migrations up to the latest
+ *    applied migration have been applied.
+ *
+ * Note: migrations are applied (and MUST be applied) in alphabetical order by
+ * their file name.
+ */
+function ensureIntegrity(
+  appliedMigrations: SqliteMigration[],
+  migrationFileNames: string[],
+) {
+  // If no migrations have been applied, there are no checks to run.
+  if (appliedMigrations.length === 0) {
+    return;
+  }
+
+  // Check #1.
+  for (const { file_name } of appliedMigrations) {
+    if (!migrationFileNames.includes(file_name)) {
+      throw new Error(
+        `Applied migration "${file_name}" has no corresponding file in the migrations directory.`,
+      );
+    }
+  }
+
+  // Check #2.
+  const sortedAppliedMigrationFileNames = [...appliedMigrations]
+    .map(({ file_name }) => file_name)
+    .sort();
+  const sortedMigrationFileNames = [...migrationFileNames].sort();
+  for (let i = 0; i < sortedAppliedMigrationFileNames.length; i++) {
+    if (sortedAppliedMigrationFileNames[i] !== sortedMigrationFileNames[i]) {
+      throw new Error(
+        `Migration "${sortedMigrationFileNames[i]}" was not applied.`,
+      );
+    }
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteAppRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteAppRepository.ts
@@ -1,0 +1,61 @@
+import type { AppId } from "@superego/backend";
+import type { AppEntity, AppRepository } from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteApp from "../types/SqliteApp.js";
+import { toEntity } from "../types/SqliteApp.js";
+
+const table = "apps";
+
+export default class SqliteAppRepository implements AppRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(app: AppEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "type", "name", "created_at")
+        VALUES
+          (?, ?, ?, ?)
+      `)
+      .run(app.id, app.type, app.name, app.createdAt.toISOString());
+  }
+
+  async replace(app: AppEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "type" = ?,
+          "name" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(app.type, app.name, app.createdAt.toISOString(), app.id);
+  }
+
+  async delete(id: AppId): Promise<AppId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: AppId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: AppId): Promise<AppEntity | null> {
+    const app = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteApp | undefined;
+    return app ? toEntity(app) : null;
+  }
+
+  async findAll(): Promise<AppEntity[]> {
+    const apps = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "name" ASC`)
+      .all()) as SqliteApp[];
+    return apps.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteAppVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteAppVersionRepository.ts
@@ -1,0 +1,72 @@
+import { encode } from "@msgpack/msgpack";
+import type { AppId, AppVersionId } from "@superego/backend";
+import type {
+  AppVersionEntity,
+  AppVersionRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteAppVersion from "../types/SqliteAppVersion.js";
+import { toEntity } from "../types/SqliteAppVersion.js";
+
+const table = "app_versions";
+
+export default class SqliteAppVersionRepository implements AppVersionRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(appVersion: AppVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET "is_latest" = 0
+        WHERE "app_id" = ? AND "is_latest" = 1
+      `)
+      .run(appVersion.appId);
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "previous_version_id",
+            "app_id",
+            "target_collections",
+            "files",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        appVersion.id,
+        appVersion.previousVersionId,
+        appVersion.appId,
+        encode(appVersion.targetCollections),
+        encode(appVersion.files),
+        appVersion.createdAt.toISOString(),
+        1,
+      );
+  }
+
+  async deleteAllWhereAppIdEq(appId: AppId): Promise<AppVersionId[]> {
+    const result = (await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "app_id" = ? RETURNING "id" AS id`)
+      .all(appId)) as { id: AppVersionId }[];
+    return result.map(({ id }) => id);
+  }
+
+  async findLatestWhereAppIdEq(appId: AppId): Promise<AppVersionEntity | null> {
+    const appVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "app_id" = ? AND "is_latest" = 1`,
+      )
+      .get(appId)) as SqliteAppVersion | undefined;
+    return appVersion ? toEntity(appVersion) : null;
+  }
+
+  async findAllLatests(): Promise<AppVersionEntity[]> {
+    const appVersions = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "is_latest" = 1`)
+      .all()) as SqliteAppVersion[];
+    return appVersions.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteBackgroundJobRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteBackgroundJobRepository.ts
@@ -1,0 +1,113 @@
+import { type BackgroundJobId, BackgroundJobStatus } from "@superego/backend";
+import type {
+  BackgroundJobEntity,
+  BackgroundJobRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteBackgroundJob from "../types/SqliteBackgroundJob.js";
+import { toEntity } from "../types/SqliteBackgroundJob.js";
+
+const table = "background_jobs";
+
+export default class SqliteBackgroundJobRepository implements BackgroundJobRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(backgroundJob: BackgroundJobEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "name",
+            "input",
+            "status",
+            "enqueued_at",
+            "started_processing_at" ,
+            "finished_processing_at",
+            "error"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        backgroundJob.id,
+        backgroundJob.name,
+        JSON.stringify(backgroundJob.input),
+        backgroundJob.status,
+        backgroundJob.enqueuedAt.toISOString(),
+        backgroundJob.startedProcessingAt?.toISOString() ?? null,
+        backgroundJob.finishedProcessingAt?.toISOString() ?? null,
+        backgroundJob.error ? JSON.stringify(backgroundJob.error) : null,
+      );
+  }
+
+  async replace(backgroundJob: BackgroundJobEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "name" = ?,
+          "input" = ?,
+          "status" = ?,
+          "enqueued_at" = ?,
+          "started_processing_at"  = ?,
+          "finished_processing_at" = ?,
+          "error" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        backgroundJob.name,
+        JSON.stringify(backgroundJob.input),
+        backgroundJob.status,
+        backgroundJob.enqueuedAt.toISOString(),
+        backgroundJob.startedProcessingAt?.toISOString() ?? null,
+        backgroundJob.finishedProcessingAt?.toISOString() ?? null,
+        backgroundJob.error ? JSON.stringify(backgroundJob.error) : null,
+        backgroundJob.id,
+      );
+  }
+
+  async find(id: BackgroundJobId): Promise<BackgroundJobEntity | null> {
+    const backgroundJob = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteBackgroundJob | undefined;
+    return backgroundJob ? toEntity(backgroundJob) : null;
+  }
+
+  async findWhereStatusEqProcessing(): Promise<
+    (BackgroundJobEntity & { status: BackgroundJobStatus.Processing }) | null
+  > {
+    const backgroundJob = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "status" = '${BackgroundJobStatus.Processing}'`,
+      )
+      .get()) as SqliteBackgroundJob | undefined;
+    return backgroundJob
+      ? (toEntity(backgroundJob) as BackgroundJobEntity & {
+          status: BackgroundJobStatus.Processing;
+        })
+      : null;
+  }
+
+  async findOldestWhereStatusEqEnqueued(): Promise<
+    (BackgroundJobEntity & { status: BackgroundJobStatus.Enqueued }) | null
+  > {
+    const backgroundJob = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "status" = '${BackgroundJobStatus.Enqueued}' ORDER BY "enqueued_at" ASC`,
+      )
+      .get()) as SqliteBackgroundJob | undefined;
+    return backgroundJob
+      ? (toEntity(backgroundJob) as BackgroundJobEntity & {
+          status: BackgroundJobStatus.Enqueued;
+        })
+      : null;
+  }
+
+  async findAll(): Promise<BackgroundJobEntity[]> {
+    const backgroundJobs = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "enqueued_at" DESC`)
+      .all()) as SqliteBackgroundJob[];
+    return backgroundJobs.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteCollectionCategoryRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteCollectionCategoryRepository.ts
@@ -1,0 +1,88 @@
+import type { CollectionCategoryId } from "@superego/backend";
+import type {
+  CollectionCategoryEntity,
+  CollectionCategoryRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteCollectionCategory from "../types/SqliteCollectionCategory.js";
+import { toEntity } from "../types/SqliteCollectionCategory.js";
+
+const table = "collection_categories";
+
+export default class SqliteCollectionCategoryRepository implements CollectionCategoryRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(collectionCategory: CollectionCategoryEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "name", "icon", "parent_id", "created_at")
+        VALUES
+          (?, ?, ?, ?, ?)
+      `)
+      .run(
+        collectionCategory.id,
+        collectionCategory.name,
+        collectionCategory.icon,
+        collectionCategory.parentId,
+        collectionCategory.createdAt.toISOString(),
+      );
+  }
+
+  async replace(collectionCategory: CollectionCategoryEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "name" = ?,
+          "icon" = ?,
+          "parent_id" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        collectionCategory.name,
+        collectionCategory.icon,
+        collectionCategory.parentId,
+        collectionCategory.createdAt.toISOString(),
+        collectionCategory.id,
+      );
+  }
+
+  async delete(id: CollectionCategoryId): Promise<CollectionCategoryId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: CollectionCategoryId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async existsWhereParentIdEq(
+    parentId: CollectionCategoryId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "parent_id" = ?`)
+      .get(parentId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(
+    id: CollectionCategoryId,
+  ): Promise<CollectionCategoryEntity | null> {
+    const collectionCategory = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteCollectionCategory | undefined;
+    return collectionCategory ? toEntity(collectionCategory) : null;
+  }
+
+  async findAll(): Promise<CollectionCategoryEntity[]> {
+    const collectionCategories = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "name" ASC`)
+      .all()) as SqliteCollectionCategory[];
+    return collectionCategories.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteCollectionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteCollectionRepository.ts
@@ -1,0 +1,86 @@
+import { encode } from "@msgpack/msgpack";
+import type { CollectionCategoryId, CollectionId } from "@superego/backend";
+import type {
+  CollectionEntity,
+  CollectionRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteCollection from "../types/SqliteCollection.js";
+import { toEntity } from "../types/SqliteCollection.js";
+
+const table = "collections";
+
+export default class SqliteCollectionRepository implements CollectionRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(collection: CollectionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "settings", "remote", "created_at")
+        VALUES
+          (?, ?, ?, ?)
+      `)
+      .run(
+        collection.id,
+        JSON.stringify(collection.settings),
+        collection.remote ? encode(collection.remote) : null,
+        collection.createdAt.toISOString(),
+      );
+  }
+
+  async replace(collection: CollectionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "settings" = ?,
+          "remote" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        JSON.stringify(collection.settings),
+        collection.remote ? encode(collection.remote) : null,
+        collection.createdAt.toISOString(),
+        collection.id,
+      );
+  }
+
+  async delete(id: CollectionId): Promise<CollectionId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: CollectionId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async existsWhereSettingsCollectionCategoryIdEq(
+    settingsCollectionCategoryId: CollectionCategoryId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(
+        `SELECT 1 FROM "${table}" WHERE "settings" ->> '$.collectionCategoryId' = ?`,
+      )
+      .get(settingsCollectionCategoryId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: CollectionId): Promise<CollectionEntity | null> {
+    const collection = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteCollection | undefined;
+    return collection ? toEntity(collection) : null;
+  }
+
+  async findAll(): Promise<CollectionEntity[]> {
+    const collections = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "settings" ->> '$.name' ASC`)
+      .all()) as SqliteCollection[];
+    return collections.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteCollectionVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteCollectionVersionRepository.ts
@@ -1,0 +1,123 @@
+import { encode } from "@msgpack/msgpack";
+import type { CollectionId, CollectionVersionId } from "@superego/backend";
+import type {
+  CollectionVersionEntity,
+  CollectionVersionRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteCollectionVersion from "../types/SqliteCollectionVersion.js";
+import { toEntity } from "../types/SqliteCollectionVersion.js";
+
+const table = "collection_versions";
+
+export default class SqliteCollectionVersionRepository implements CollectionVersionRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(collectionVersion: CollectionVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET "is_latest" = 0
+        WHERE "collection_id" = ? AND "is_latest" = 1
+      `)
+      .run(collectionVersion.collectionId);
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "previous_version_id",
+            "collection_id",
+            "schema",
+            "settings",
+            "migration",
+            "remote_converters",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        collectionVersion.id,
+        collectionVersion.previousVersionId,
+        collectionVersion.collectionId,
+        JSON.stringify(collectionVersion.schema),
+        JSON.stringify(collectionVersion.settings),
+        collectionVersion.migration
+          ? JSON.stringify(collectionVersion.migration)
+          : null,
+        collectionVersion.remoteConverters
+          ? encode(collectionVersion.remoteConverters)
+          : null,
+        collectionVersion.createdAt.toISOString(),
+        1,
+      );
+  }
+
+  async replace(collectionVersion: CollectionVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "previous_version_id" = ?,
+          "collection_id" = ?,
+          "schema" = ?,
+          "settings" = ?,
+          "migration" = ?,
+          "remote_converters" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        collectionVersion.previousVersionId,
+        collectionVersion.collectionId,
+        JSON.stringify(collectionVersion.schema),
+        JSON.stringify(collectionVersion.settings),
+        collectionVersion.migration
+          ? JSON.stringify(collectionVersion.migration)
+          : null,
+        collectionVersion.remoteConverters
+          ? encode(collectionVersion.remoteConverters)
+          : null,
+        collectionVersion.createdAt.toISOString(),
+        collectionVersion.id,
+      );
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<CollectionVersionId[]> {
+    const result = (await this.db
+      .prepare(
+        `DELETE FROM "${table}" WHERE "collection_id" = ? RETURNING "id" AS id`,
+      )
+      .all(collectionId)) as { id: CollectionVersionId }[];
+    return result.map(({ id }) => id);
+  }
+
+  async find(id: CollectionVersionId): Promise<CollectionVersionEntity | null> {
+    const collectionVersion = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteCollectionVersion | undefined;
+    return collectionVersion ? toEntity(collectionVersion) : null;
+  }
+
+  async findLatestWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<CollectionVersionEntity | null> {
+    const collectionVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "collection_id" = ? AND "is_latest" = 1`,
+      )
+      .get(collectionId)) as SqliteCollectionVersion | undefined;
+    return collectionVersion ? toEntity(collectionVersion) : null;
+  }
+
+  async findAllLatests(): Promise<CollectionVersionEntity[]> {
+    const collectionVersions = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "is_latest" = 1`)
+      .all()) as SqliteCollectionVersion[];
+    return collectionVersions.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteConversationRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteConversationRepository.ts
@@ -1,0 +1,81 @@
+import { encode } from "@msgpack/msgpack";
+import type { ConversationId } from "@superego/backend";
+import type {
+  ConversationEntity,
+  ConversationRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteConversation from "../types/SqliteConversation.js";
+import { toEntity } from "../types/SqliteConversation.js";
+
+const table = "conversations";
+
+export default class SqliteConversationRepository implements ConversationRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async upsert(conversation: ConversationEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "assistant",
+            "title",
+            "context_fingerprint",
+            "messages",
+            "status",
+            "processing_started_at",
+            "error",
+            "created_at"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT("id") DO UPDATE SET
+          "assistant" = excluded."assistant",
+          "title" = excluded."title",
+          "context_fingerprint" = excluded."context_fingerprint",
+          "messages" = excluded."messages",
+          "status" = excluded."status",
+          "processing_started_at" = excluded."processing_started_at",
+          "error" = excluded."error",
+          "created_at" = excluded."created_at"
+      `)
+      .run(
+        conversation.id,
+        conversation.assistant,
+        conversation.title,
+        conversation.contextFingerprint,
+        encode(conversation.messages),
+        conversation.status,
+        conversation.processingStartedAt?.toISOString() ?? null,
+        conversation.error ? JSON.stringify(conversation.error) : null,
+        conversation.createdAt.toISOString(),
+      );
+  }
+
+  async delete(id: ConversationId): Promise<ConversationId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: ConversationId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: ConversationId): Promise<ConversationEntity | null> {
+    const conversation = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteConversation | undefined;
+    return conversation ? toEntity(conversation) : null;
+  }
+
+  async findAll(): Promise<ConversationEntity[]> {
+    const conversations = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "created_at" DESC`)
+      .all()) as SqliteConversation[];
+    return conversations.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteConversationTextSearchIndex.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteConversationTextSearchIndex.ts
@@ -1,0 +1,123 @@
+import type { ConversationId } from "@superego/backend";
+import type { ConversationTextSearchIndex } from "@superego/executing-backend";
+import { Document as FlexsearchDocument } from "flexsearch";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteConversationTextSearchText from "../types/SqliteConversationTextSearchText.js";
+
+const table = "conversation_text_search_texts";
+
+type FlexsearchDocumentData = {
+  id: ConversationId;
+  text: string;
+};
+
+export interface SearchTextIndexState {
+  index: FlexsearchDocument<FlexsearchDocumentData>;
+  isLoaded: boolean;
+}
+
+export default class SqliteConversationTextSearchIndex implements ConversationTextSearchIndex {
+  constructor(
+    private db: AsyncSqliteDatabase,
+    private searchTextIndexState: SearchTextIndexState,
+    private onTransactionSucceeded: (callback: () => void) => void,
+  ) {}
+
+  async upsert(
+    conversationId: ConversationId,
+    textChunks: { title: string[]; messages: string[] },
+  ): Promise<void> {
+    const text = [...textChunks.title, ...textChunks.messages].join(" | ");
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("conversation_id", "text")
+        VALUES
+          (?, ?)
+      `)
+      .run(conversationId, text);
+
+    this.onTransactionSucceeded(() => {
+      this.searchTextIndexState.index.remove(conversationId);
+      this.searchTextIndexState.index.add({ id: conversationId, text });
+    });
+  }
+
+  async remove(conversationId: ConversationId): Promise<void> {
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "conversation_id" = ?`)
+      .run(conversationId);
+
+    this.onTransactionSucceeded(() =>
+      this.searchTextIndexState.index.remove(conversationId),
+    );
+  }
+
+  async search(
+    query: string,
+    options: { limit: number },
+  ): Promise<
+    {
+      conversationId: ConversationId;
+      matchedText: string;
+    }[]
+  > {
+    if (query === "") {
+      const rows = (await this.db
+        .prepare(`SELECT * FROM "${table}" LIMIT ?`)
+        .all(options.limit)) as SqliteConversationTextSearchText[];
+      return rows.map((row) => ({
+        conversationId: row.conversation_id,
+        matchedText: "",
+      }));
+    }
+
+    await this.loadIndex();
+
+    const results = this.searchTextIndexState.index.search(query, {
+      limit: options.limit,
+      merge: true,
+      enrich: true,
+      highlight: {
+        template: "«$1»",
+        boundary: 128,
+      },
+    });
+
+    return results.map(({ id, highlight }) => ({
+      conversationId: id as ConversationId,
+      matchedText: highlight!.text,
+    }));
+  }
+
+  private async loadIndex(): Promise<void> {
+    if (this.searchTextIndexState.isLoaded) {
+      return;
+    }
+
+    const conversationTextSearchTexts = (await this.db
+      .prepare(`SELECT * FROM "${table}"`)
+      .all()) as SqliteConversationTextSearchText[];
+
+    for (const { conversation_id, text } of conversationTextSearchTexts) {
+      this.searchTextIndexState.index.add({ id: conversation_id, text: text });
+    }
+
+    this.searchTextIndexState.isLoaded = true;
+  }
+
+  static getSearchTextIndexState(): SearchTextIndexState {
+    return {
+      index: new FlexsearchDocument<FlexsearchDocumentData>({
+        document: {
+          id: "id",
+          index: ["text"],
+          store: ["text"],
+        },
+        tokenize: "forward",
+        context: true,
+      }),
+      isLoaded: false,
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteDocumentRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteDocumentRepository.ts
@@ -1,0 +1,126 @@
+import { encode } from "@msgpack/msgpack";
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type {
+  DocumentEntity,
+  DocumentRepository,
+} from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteDocument from "../types/SqliteDocument.js";
+import { toEntity } from "../types/SqliteDocument.js";
+
+const table = "documents";
+
+export default class SqliteDocumentRepository implements DocumentRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(document: DocumentEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "remote_id",
+            "remote_url",
+            "latest_remote_document",
+            "collection_id",
+            "created_at"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        document.id,
+        document.remoteId,
+        document.remoteUrl,
+        document.latestRemoteDocument
+          ? encode(document.latestRemoteDocument)
+          : null,
+        document.collectionId,
+        document.createdAt.toISOString(),
+      );
+  }
+
+  async replace(document: DocumentEntity): Promise<void> {
+    await this.db
+      .prepare(`
+          UPDATE "${table}"
+          SET
+            "remote_id" = ?,
+            "remote_url" = ?,
+            "latest_remote_document" = ?,
+            "collection_id" = ?,
+            "created_at" = ?
+          WHERE "id" = ?
+        `)
+      .run(
+        document.remoteId,
+        document.remoteUrl,
+        document.latestRemoteDocument
+          ? encode(document.latestRemoteDocument)
+          : null,
+        document.collectionId,
+        document.createdAt.toISOString(),
+        document.id,
+      );
+  }
+
+  async delete(id: DocumentId): Promise<DocumentId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentId[]> {
+    const result = (await this.db
+      .prepare(
+        `DELETE FROM "${table}" WHERE "collection_id" = ? RETURNING "id" AS id`,
+      )
+      .all(collectionId)) as { id: DocumentId }[];
+    return result.map(({ id }) => id);
+  }
+
+  async exists(id: DocumentId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async oneExistsWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "collection_id" = ?`)
+      .get(collectionId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: DocumentId): Promise<DocumentEntity | null> {
+    const document = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as SqliteDocument | undefined;
+    return document ? toEntity(document) : null;
+  }
+
+  async findWhereCollectionIdAndRemoteIdEq(
+    collectionId: CollectionId,
+    remoteId: string,
+  ): Promise<DocumentEntity | null> {
+    const document = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "collection_id" = ? AND "remote_id" = ?`,
+      )
+      .get(collectionId, remoteId)) as SqliteDocument | undefined;
+    return document ? toEntity(document) : null;
+  }
+
+  async findAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentEntity[]> {
+    const documents = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "collection_id" = ?`)
+      .all(collectionId)) as SqliteDocument[];
+    return documents.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteDocumentTextSearchIndex.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteDocumentTextSearchIndex.ts
@@ -1,0 +1,153 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type { DocumentTextSearchIndex } from "@superego/executing-backend";
+import type { TextChunks } from "@superego/schema";
+import { Document as FlexsearchDocument } from "flexsearch";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteDocumentTextSearchText from "../types/SqliteDocumentTextSearchText.js";
+
+const table = "document_text_search_texts";
+
+type FlexsearchDocumentData = {
+  id: DocumentId;
+  collectionId: CollectionId;
+  text: string;
+};
+
+export interface SearchTextIndexState {
+  index: FlexsearchDocument<FlexsearchDocumentData>;
+  isLoaded: boolean;
+}
+
+export default class SqliteDocumentTextSearchIndex implements DocumentTextSearchIndex {
+  constructor(
+    private db: AsyncSqliteDatabase,
+    private searchTextIndexState: SearchTextIndexState,
+    private onTransactionSucceeded: (callback: () => void) => void,
+  ) {}
+
+  async upsert(
+    collectionId: CollectionId,
+    documentId: DocumentId,
+    textChunks: TextChunks,
+  ): Promise<void> {
+    const text = Object.values(textChunks).flat().join(" | ");
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("document_id", "collection_id", "text")
+        VALUES
+          (?, ?, ?)
+      `)
+      .run(documentId, collectionId, text);
+
+    this.onTransactionSucceeded(() => {
+      this.searchTextIndexState.index.remove(documentId);
+      this.searchTextIndexState.index.add({
+        id: documentId,
+        collectionId,
+        text,
+      });
+    });
+  }
+
+  async remove(
+    _collectionId: CollectionId,
+    documentId: DocumentId,
+  ): Promise<void> {
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "document_id" = ?`)
+      .run(documentId);
+
+    this.onTransactionSucceeded(() =>
+      this.searchTextIndexState.index.remove(documentId),
+    );
+  }
+
+  async search(
+    collectionId: CollectionId | null,
+    query: string,
+    options: { limit: number },
+  ): Promise<
+    {
+      collectionId: CollectionId;
+      documentId: DocumentId;
+      matchedText: string;
+    }[]
+  > {
+    if (query === "") {
+      const rows = (await this.db
+        .prepare(
+          collectionId
+            ? `SELECT * FROM "${table}" WHERE "collection_id" = ? LIMIT ?`
+            : `SELECT * FROM "${table}" LIMIT ?`,
+        )
+        .all(
+          ...(collectionId ? [collectionId, options.limit] : [options.limit]),
+        )) as SqliteDocumentTextSearchText[];
+      return rows.map((row) => ({
+        collectionId: row.collection_id,
+        documentId: row.document_id,
+        matchedText: "",
+      }));
+    }
+
+    await this.loadIndex();
+
+    const results = this.searchTextIndexState.index.search(query, {
+      tag: collectionId ? { collectionId } : undefined,
+      limit: options.limit,
+      merge: true,
+      enrich: true,
+      highlight: {
+        template: "«$1»",
+        boundary: 128,
+      },
+    });
+
+    return results.map(({ id, doc, highlight }) => ({
+      collectionId: doc!.collectionId,
+      documentId: id as DocumentId,
+      matchedText: highlight!.text,
+    }));
+  }
+
+  private async loadIndex(): Promise<void> {
+    if (this.searchTextIndexState.isLoaded) {
+      return;
+    }
+
+    const documentTextSearchTexts = (await this.db
+      .prepare(`SELECT * FROM "${table}"`)
+      .all()) as SqliteDocumentTextSearchText[];
+
+    for (const {
+      document_id,
+      collection_id,
+      text,
+    } of documentTextSearchTexts) {
+      this.searchTextIndexState.index.add({
+        id: document_id,
+        collectionId: collection_id,
+        text: text,
+      });
+    }
+
+    this.searchTextIndexState.isLoaded = true;
+  }
+
+  static getSearchTextIndexState(): SearchTextIndexState {
+    return {
+      index: new FlexsearchDocument<FlexsearchDocumentData>({
+        document: {
+          id: "id",
+          index: ["text"],
+          tag: ["collectionId"],
+          store: ["collectionId", "text"],
+        },
+        tokenize: "forward",
+        context: true,
+      }),
+      isLoaded: false,
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteDocumentVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteDocumentVersionRepository.ts
@@ -1,0 +1,323 @@
+import type {
+  CollectionId,
+  CollectionVersionId,
+  DocumentId,
+  DocumentVersionId,
+} from "@superego/backend";
+import type {
+  DocumentVersionEntity,
+  DocumentVersionRepository,
+  MinimalDocumentVersionEntity,
+} from "@superego/executing-backend";
+import { create } from "jsondiffpatch";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteDocumentVersion from "../types/SqliteDocumentVersion.js";
+import { toEntity, toMinimalEntity } from "../types/SqliteDocumentVersion.js";
+
+const documentVersionsTable = "document_versions";
+const documentVersionContentBlockingKeysTable =
+  "document_version_content_blocking_keys";
+
+const jdp = create({ omitRemovedValues: true });
+
+export default class SqliteDocumentVersionRepository implements DocumentVersionRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insert(documentVersion: DocumentVersionEntity): Promise<void> {
+    const previousDocumentVersion = await this.findLatestWhereDocumentIdEq(
+      documentVersion.documentId,
+    );
+    if (previousDocumentVersion) {
+      await this.db
+        .prepare(`
+          UPDATE "${documentVersionsTable}"
+          SET "is_latest" = 0, "content_snapshot" = null
+          WHERE "document_id" = ? AND "is_latest" = 1
+        `)
+        .run(documentVersion.documentId);
+    }
+    await this.db
+      .prepare(`
+        INSERT INTO "${documentVersionsTable}"
+          (
+            "id",
+            "remote_id",
+            "previous_version_id",
+            "collection_id",
+            "document_id",
+            "collection_version_id",
+            "conversation_id",
+            "content_delta",
+            "content_snapshot",
+            "content_blocking_keys",
+            "content_summary",
+            "referenced_documents",
+            "created_by",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        documentVersion.id,
+        documentVersion.remoteId,
+        documentVersion.previousVersionId,
+        documentVersion.collectionId,
+        documentVersion.documentId,
+        documentVersion.collectionVersionId,
+        documentVersion.conversationId,
+        JSON.stringify(
+          jdp.diff(previousDocumentVersion?.content, documentVersion.content),
+        ) ?? null,
+        JSON.stringify(documentVersion.content),
+        documentVersion.contentBlockingKeys
+          ? JSON.stringify(documentVersion.contentBlockingKeys)
+          : null,
+        JSON.stringify(documentVersion.contentSummary),
+        JSON.stringify(documentVersion.referencedDocuments),
+        documentVersion.createdBy,
+        documentVersion.createdAt.toISOString(),
+        1,
+      );
+    // Insert blocking keys into the "index" table.
+    await this.insertContentBlockingKeys(
+      documentVersion.collectionId,
+      documentVersion.id,
+      documentVersion.contentBlockingKeys,
+    );
+    // Delete content blocking keys of previous versions from the index table.
+    // We only need to keep blocking keys for the latest version of each
+    // document.
+    if (previousDocumentVersion) {
+      await this.deleteContentBlockingKeys(previousDocumentVersion.id);
+    }
+  }
+
+  async updateContentBlockingKeys(
+    id: DocumentVersionId,
+    contentBlockingKeys: DocumentVersionEntity["contentBlockingKeys"],
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE "${documentVersionsTable}" SET "content_blocking_keys" = ? WHERE "id" = ?`,
+      )
+      .run(
+        contentBlockingKeys ? JSON.stringify(contentBlockingKeys) : null,
+        id,
+      );
+
+    // Only update the index table for the latest version.
+    const documentVersion = (await this.db
+      .prepare(
+        `SELECT "collection_id" FROM "${documentVersionsTable}" WHERE "id" = ? AND "is_latest" = 1`,
+      )
+      .get(id)) as { collection_id: CollectionId } | undefined;
+    if (!documentVersion) {
+      return;
+    }
+    await this.deleteContentBlockingKeys(id);
+    await this.insertContentBlockingKeys(
+      documentVersion.collection_id,
+      id,
+      contentBlockingKeys,
+    );
+  }
+
+  async updateContentSummary(
+    id: DocumentVersionId,
+    contentSummary: DocumentVersionEntity["contentSummary"],
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE "${documentVersionsTable}" SET "content_summary" = ? WHERE "id" = ?`,
+      )
+      .run(JSON.stringify(contentSummary), id);
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentVersionId[]> {
+    const result = (await this.db
+      .prepare(
+        `DELETE FROM "${documentVersionsTable}" WHERE "collection_id" = ? RETURNING "id" AS id`,
+      )
+      .all(collectionId)) as { id: DocumentVersionId }[];
+    // documentVersionContentBlockingKeysTable rows are deleted ON CASCADE.
+    return result.map(({ id }) => id);
+  }
+
+  async deleteAllWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<DocumentVersionId[]> {
+    const result = (await this.db
+      .prepare(
+        `DELETE FROM "${documentVersionsTable}" WHERE "document_id" = ? RETURNING "id" AS id`,
+      )
+      .all(documentId)) as { id: DocumentVersionId }[];
+    // documentVersionContentBlockingKeysTable rows are deleted ON CASCADE.
+    return result.map(({ id }) => id);
+  }
+
+  async find(id: DocumentVersionId): Promise<DocumentVersionEntity | null> {
+    const documentVersion = (await this.db
+      .prepare(`SELECT * FROM "${documentVersionsTable}" WHERE "id" = ?`)
+      .get(id)) as SqliteDocumentVersion | undefined;
+    if (!documentVersion) {
+      return null;
+    }
+    if (documentVersion.is_latest === 1) {
+      return toEntity(documentVersion);
+    }
+    const allDocumentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ?`,
+      )
+      .all(documentVersion.document_id)) as SqliteDocumentVersion[];
+    return toEntity(documentVersion, allDocumentVersions, jdp);
+  }
+
+  async findLatestWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<DocumentVersionEntity | null> {
+    const documentVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ? AND "is_latest" = 1`,
+      )
+      .get(documentId)) as
+      | (SqliteDocumentVersion & { is_latest: 1 })
+      | undefined;
+    return documentVersion ? toEntity(documentVersion) : null;
+  }
+
+  async findAllWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<MinimalDocumentVersionEntity[]> {
+    const allDocumentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ? ORDER BY "created_at" DESC`,
+      )
+      .all(documentId)) as SqliteDocumentVersion[];
+    return allDocumentVersions.map(toMinimalEntity);
+  }
+
+  async findAllWhereCollectionVersionIdEq(
+    collectionVersionId: CollectionVersionId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "collection_version_id" = ?`,
+      )
+      .all(collectionVersionId)) as SqliteDocumentVersion[];
+
+    const findAllByDocumentIdStatement = this.db.prepare(
+      `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ?`,
+    );
+    const allVersionsByDocumentId = new Map<string, SqliteDocumentVersion[]>();
+    const entities: DocumentVersionEntity[] = [];
+    for (const documentVersion of documentVersions) {
+      if (documentVersion.is_latest === 1) {
+        entities.push(toEntity(documentVersion));
+        continue;
+      }
+      let allVersionsForDocument = allVersionsByDocumentId.get(
+        documentVersion.document_id,
+      );
+      if (!allVersionsForDocument) {
+        allVersionsForDocument = (await findAllByDocumentIdStatement.all(
+          documentVersion.document_id,
+        )) as SqliteDocumentVersion[];
+        allVersionsByDocumentId.set(
+          documentVersion.document_id,
+          allVersionsForDocument,
+        );
+      }
+      entities.push(toEntity(documentVersion, allVersionsForDocument, jdp));
+    }
+    return entities;
+  }
+
+  async findAllLatestsWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "collection_id" = ? AND "is_latest" = 1`,
+      )
+      .all(collectionId)) as (SqliteDocumentVersion & { is_latest: 1 })[];
+    return documentVersions.map(toEntity);
+  }
+
+  async findAllLatestWhereReferencedDocumentsContains(
+    collectionId: CollectionId,
+    documentId: DocumentId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(`
+        SELECT * FROM "${documentVersionsTable}"
+        WHERE "is_latest" = 1
+        AND EXISTS (
+          SELECT 1 FROM json_each("referenced_documents")
+          WHERE json_extract(value, '$.collectionId') = ?
+          AND json_extract(value, '$.documentId') = ?
+        )
+      `)
+      .all(collectionId, documentId)) as (SqliteDocumentVersion & {
+      is_latest: 1;
+    })[];
+    return documentVersions.map(toEntity);
+  }
+
+  async findAnyLatestWhereCollectionIdEqAndContentBlockingKeysOverlap(
+    collectionId: CollectionId,
+    contentBlockingKeys: string[],
+  ): Promise<DocumentVersionEntity | null> {
+    if (contentBlockingKeys.length === 0) {
+      return null;
+    }
+    const placeholders = contentBlockingKeys.map(() => "?").join(", ");
+    const documentVersion = (await this.db
+      .prepare(`
+        SELECT dv.* FROM "${documentVersionsTable}" dv
+        JOIN "${documentVersionContentBlockingKeysTable}" dvcbk
+          ON dv."id" = dvcbk."document_version_id"
+        WHERE dvcbk."collection_id" = ?
+        AND dvcbk."blocking_key" IN (${placeholders})
+        AND dv."is_latest" = 1
+        LIMIT 1
+      `)
+      .get(collectionId, ...contentBlockingKeys)) as
+      | (SqliteDocumentVersion & { is_latest: 1 })
+      | undefined;
+    return documentVersion ? toEntity(documentVersion) : null;
+  }
+
+  private async insertContentBlockingKeys(
+    collectionId: CollectionId,
+    documentVersionId: DocumentVersionId,
+    contentBlockingKeys: string[] | null,
+  ): Promise<void> {
+    if (contentBlockingKeys === null) {
+      return;
+    }
+    const insertBlockingKey = this.db.prepare(`
+      INSERT INTO "${documentVersionContentBlockingKeysTable}"
+        ("collection_id", "document_version_id", "blocking_key")
+      VALUES
+        (?, ?, ?)
+    `);
+    for (const blockingKey of contentBlockingKeys) {
+      await insertBlockingKey.run(collectionId, documentVersionId, blockingKey);
+    }
+  }
+
+  private async deleteContentBlockingKeys(
+    documentVersionId: DocumentVersionId,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `DELETE FROM "${documentVersionContentBlockingKeysTable}" WHERE "document_version_id" = ?`,
+      )
+      .run(documentVersionId);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteFileRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteFileRepository.ts
@@ -1,0 +1,199 @@
+import type { FileId } from "@superego/backend";
+import type { FileEntity, FileRepository } from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteFile from "../types/SqliteFile.js";
+import { toEntity } from "../types/SqliteFile.js";
+
+const table = "files";
+
+export default class SqliteFileRepository implements FileRepository {
+  constructor(private db: AsyncSqliteDatabase) {}
+
+  async insertAll(
+    filesWithContent: (FileEntity & { content: Uint8Array<ArrayBuffer> })[],
+  ): Promise<void> {
+    const insert = this.db.prepare(`
+      INSERT INTO "${table}"
+        (
+          "id",
+          "referenced_by",
+          "created_at",
+          "content"
+        )
+      VALUES
+        (?, ?, ?, ?)
+    `);
+    for (const file of filesWithContent) {
+      await insert.run(
+        file.id,
+        JSON.stringify(file.referencedBy),
+        file.createdAt.toISOString(),
+        Buffer.from(file.content),
+      );
+    }
+  }
+
+  async addReferenceToAll(
+    ids: FileId[],
+    reference: FileEntity.Reference,
+  ): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
+    const placeholders = ids.map(() => "?").join(", ");
+    const files = (await this.db
+      .prepare(
+        `SELECT "id", "referenced_by" FROM "${table}" WHERE "id" IN (${placeholders})`,
+      )
+      .all(...ids)) as Pick<SqliteFile, "id" | "referenced_by">[];
+    const update = this.db.prepare(
+      `UPDATE "${table}" SET "referenced_by" = ? WHERE "id" = ?`,
+    );
+    for (const file of files) {
+      const references = SqliteFileRepository.parseReferences(
+        file.referenced_by,
+      );
+      if (!SqliteFileRepository.referencesIncludes(references, reference)) {
+        references.push(reference);
+        await update.run(JSON.stringify(references), file.id);
+      }
+    }
+  }
+
+  async deleteReferenceFromAll(
+    reference:
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">
+      | FileEntity.ConversationReference,
+  ): Promise<void> {
+    const files = (await this.db
+      .prepare(`SELECT "id", "referenced_by" FROM "${table}"`)
+      .all()) as Pick<SqliteFile, "id" | "referenced_by">[];
+    const update = this.db.prepare(
+      `UPDATE "${table}" SET "referenced_by" = ? WHERE "id" = ?`,
+    );
+    const del = this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`);
+    for (const file of files) {
+      const references = SqliteFileRepository.parseReferences(
+        file.referenced_by,
+      );
+      const updatedReferences = references.filter(
+        (ref) =>
+          !SqliteFileRepository.matchesReferenceForDeletion(ref, reference),
+      );
+      if (updatedReferences.length === 0) {
+        await del.run(file.id);
+      } else if (updatedReferences.length !== references.length) {
+        await update.run(JSON.stringify(updatedReferences), file.id);
+      }
+    }
+  }
+
+  async find(id: FileId): Promise<FileEntity | null> {
+    const file = (await this.db
+      .prepare(`
+        SELECT
+          "id",
+          "referenced_by",
+          "created_at"
+        FROM "${table}"
+        WHERE "id" = ?;
+      `)
+      .get(id)) as Omit<SqliteFile, "content"> | undefined;
+    return file ? toEntity(file) : null;
+  }
+
+  async findAllWhereIdIn(ids: FileId[]): Promise<FileEntity[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    const placeholders = ids.map(() => "?").join(", ");
+    const files = (await this.db
+      .prepare(`
+        SELECT
+          "id",
+          "referenced_by",
+          "created_at"
+        FROM "${table}"
+        WHERE "id" IN (${placeholders})
+      `)
+      .all(...ids)) as Omit<SqliteFile, "content">[];
+    return files.map(toEntity);
+  }
+
+  async getContent(id: FileId): Promise<Uint8Array<ArrayBuffer> | null> {
+    const result = (await this.db
+      .prepare(`SELECT "content" FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as { content: Buffer } | undefined;
+    return result ? new Uint8Array(result.content) : null;
+  }
+
+  private static parseReferences(json: string): FileEntity.Reference[] {
+    return JSON.parse(json) as FileEntity.Reference[];
+  }
+
+  private static referencesIncludes(
+    references: FileEntity.Reference[],
+    reference: FileEntity.Reference,
+  ): boolean {
+    return references.some((ref) =>
+      SqliteFileRepository.referencesAreEqual(ref, reference),
+    );
+  }
+
+  private static referencesAreEqual(
+    a: FileEntity.Reference,
+    b: FileEntity.Reference,
+  ): boolean {
+    if (
+      SqliteFileRepository.isConversationReference(a) &&
+      SqliteFileRepository.isConversationReference(b)
+    ) {
+      return a.conversationId === b.conversationId;
+    }
+    if (
+      SqliteFileRepository.isDocumentVersionReference(a) &&
+      SqliteFileRepository.isDocumentVersionReference(b)
+    ) {
+      return (
+        a.collectionId === b.collectionId &&
+        a.documentId === b.documentId &&
+        a.documentVersionId === b.documentVersionId
+      );
+    }
+    return false;
+  }
+
+  private static matchesReferenceForDeletion(
+    reference: FileEntity.Reference,
+    target:
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">
+      | FileEntity.ConversationReference,
+  ): boolean {
+    if (SqliteFileRepository.isConversationReference(target)) {
+      return (
+        SqliteFileRepository.isConversationReference(reference) &&
+        reference.conversationId === target.conversationId
+      );
+    }
+    return (
+      SqliteFileRepository.isDocumentVersionReference(reference) &&
+      reference.collectionId === target.collectionId &&
+      reference.documentId === target.documentId
+    );
+  }
+
+  private static isConversationReference(
+    reference:
+      | FileEntity.Reference
+      | FileEntity.ConversationReference
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">,
+  ): reference is FileEntity.ConversationReference {
+    return Object.hasOwn(reference, "conversationId");
+  }
+
+  private static isDocumentVersionReference(
+    reference: FileEntity.Reference,
+  ): reference is FileEntity.DocumentVersionReference {
+    return Object.hasOwn(reference, "collectionId");
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/SqliteGlobalSettingsRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/SqliteGlobalSettingsRepository.ts
@@ -1,0 +1,96 @@
+import {
+  AssistantName,
+  type GlobalSettings,
+  type InferenceOptions,
+  type InferenceProvider,
+} from "@superego/backend";
+import type { GlobalSettingsRepository } from "@superego/executing-backend";
+import type AsyncSqliteDatabase from "../AsyncSqliteDatabase.js";
+import type SqliteGlobalSettings from "../types/SqliteGlobalSettings.js";
+import { toEntity } from "../types/SqliteGlobalSettings.js";
+import type DeepPartial from "../utils/DeepPartial.js";
+
+const table = "singleton__global_settings";
+
+export default class SqliteGlobalSettingsRepository implements GlobalSettingsRepository {
+  constructor(
+    private db: AsyncSqliteDatabase,
+    private defaultGlobalSettings: GlobalSettings,
+  ) {}
+
+  async replace(globalSettings: GlobalSettings): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("id", "value")
+        VALUES
+          (?, ?)
+      `)
+      .run("singleton", JSON.stringify(globalSettings));
+  }
+
+  async get(): Promise<GlobalSettings> {
+    const settings = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get("singleton")) as SqliteGlobalSettings | undefined;
+    return this.mergeDefaults(settings ? toEntity(settings) : {});
+  }
+
+  // The settings retrieved from SQLite could be either missing, or they could
+  // have been saved by a previous version of Superego and been missing some
+  // properties. This function merges them with the default settings, ensuring
+  // that the returned object respects the GlobalSettings interface.
+  private mergeDefaults(settings: DeepPartial<GlobalSettings>): GlobalSettings {
+    return {
+      appearance: {
+        theme:
+          settings?.appearance?.theme ??
+          this.defaultGlobalSettings.appearance.theme,
+      },
+      inference: {
+        providers:
+          (settings.inference?.providers as InferenceProvider[]) ??
+          this.defaultGlobalSettings.inference.providers,
+        defaultInferenceOptions: {
+          completion:
+            (settings.inference?.defaultInferenceOptions
+              ?.completion as InferenceOptions["completion"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .completion,
+          transcription:
+            (settings.inference?.defaultInferenceOptions
+              ?.transcription as InferenceOptions["transcription"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .transcription,
+          fileInspection:
+            (settings.inference?.defaultInferenceOptions
+              ?.fileInspection as InferenceOptions["fileInspection"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .fileInspection,
+        },
+      },
+      assistants: {
+        userInfo:
+          settings.assistants?.userInfo ??
+          this.defaultGlobalSettings.assistants.userInfo,
+        userPreferences:
+          settings.assistants?.userPreferences ??
+          this.defaultGlobalSettings.assistants.userPreferences,
+        developerPrompts: {
+          [AssistantName.CollectionCreator]:
+            settings.assistants?.developerPrompts?.[
+              AssistantName.CollectionCreator
+            ] ??
+            this.defaultGlobalSettings.assistants.developerPrompts[
+              AssistantName.CollectionCreator
+            ],
+          [AssistantName.Factotum]:
+            settings.assistants?.developerPrompts?.[AssistantName.Factotum] ??
+            this.defaultGlobalSettings.assistants.developerPrompts[
+              AssistantName.Factotum
+            ],
+        },
+      },
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/test/setupTursoWasm.ts
+++ b/packages/data/turso-data-repositories/src/test/setupTursoWasm.ts
@@ -1,0 +1,163 @@
+import { Worker as NodeWorker, type WorkerOptions } from "node:worker_threads";
+
+type BrowserWorkerEvent = { data: unknown };
+
+type BrowserWorkerListener =
+  | ((event: BrowserWorkerEvent) => void)
+  | { handleEvent: (event: BrowserWorkerEvent) => void };
+
+const tursoWorkerPreamble = `
+import { parentPort } from "node:worker_threads";
+import {
+  closeSync,
+  fstatSync,
+  ftruncateSync,
+  fsyncSync,
+  openSync,
+  readSync,
+  writeSync,
+} from "node:fs";
+
+class NodeSyncAccessHandle {
+  constructor(path, create) {
+    try {
+      this.fileDescriptor = openSync(path, "r+");
+    } catch (error) {
+      if (!create) {
+        throw error;
+      }
+      this.fileDescriptor = openSync(path, "w+");
+    }
+  }
+
+  read(buffer, options = {}) {
+    return readSync(
+      this.fileDescriptor,
+      buffer,
+      0,
+      buffer.byteLength,
+      Number(options.at ?? 0),
+    );
+  }
+
+  write(buffer, options = {}) {
+    return writeSync(
+      this.fileDescriptor,
+      buffer,
+      0,
+      buffer.byteLength,
+      Number(options.at ?? 0),
+    );
+  }
+
+  flush() {
+    fsyncSync(this.fileDescriptor);
+  }
+
+  truncate(size) {
+    ftruncateSync(this.fileDescriptor, Number(size));
+  }
+
+  getSize() {
+    return fstatSync(this.fileDescriptor).size;
+  }
+
+  close() {
+    closeSync(this.fileDescriptor);
+  }
+}
+
+Object.defineProperty(globalThis, "self", {
+  configurable: true,
+  value: globalThis,
+});
+Object.defineProperty(globalThis, "postMessage", {
+  configurable: true,
+  value: (message) => parentPort.postMessage(message),
+});
+Object.defineProperty(globalThis, "navigator", {
+  configurable: true,
+  value: {
+    storage: {
+      async getDirectory() {
+        return {
+          async getFileHandle(path, options = {}) {
+            return {
+              async createSyncAccessHandle() {
+                return new NodeSyncAccessHandle(path, options.create ?? false);
+              },
+            };
+          },
+        };
+      },
+    },
+  },
+});
+
+parentPort.on("message", (data) => {
+  if (data.__turso__ === "unregister") {
+    parentPort.postMessage({ __turso__: true, id: data.id });
+    return;
+  }
+  globalThis.onmessage?.({ data });
+});
+`;
+
+class BrowserLikeWorker extends NodeWorker {
+  private browserListenerWrappers = new Map<
+    BrowserWorkerListener,
+    (data: unknown) => void
+  >();
+
+  constructor(specifier: string | URL, options?: WorkerOptions) {
+    let normalizedSpecifier = specifier;
+    if (
+      typeof normalizedSpecifier === "string" &&
+      normalizedSpecifier.startsWith("data:text/javascript")
+    ) {
+      const commaIndex = normalizedSpecifier.indexOf(",");
+      const workerSource = decodeURIComponent(
+        normalizedSpecifier.slice(commaIndex + 1),
+      );
+      normalizedSpecifier = new URL(
+        `data:text/javascript;charset=utf-8,${encodeURIComponent(
+          tursoWorkerPreamble + workerSource,
+        )}`,
+      );
+    }
+    super(normalizedSpecifier, options);
+    this.setMaxListeners(0);
+  }
+
+  addEventListener(type: string, listener: BrowserWorkerListener): void {
+    if (type !== "message") {
+      return;
+    }
+
+    const wrappedListener = (data: unknown) => {
+      const event = { data };
+      if (typeof listener === "function") {
+        listener(event);
+      } else {
+        listener.handleEvent(event);
+      }
+    };
+    this.browserListenerWrappers.set(listener, wrappedListener);
+    this.on("message", wrappedListener);
+  }
+
+  removeEventListener(type: string, listener: BrowserWorkerListener): void {
+    if (type !== "message") {
+      return;
+    }
+
+    const wrappedListener = this.browserListenerWrappers.get(listener);
+    if (wrappedListener == null) {
+      return;
+    }
+    this.off("message", wrappedListener);
+    this.browserListenerWrappers.delete(listener);
+  }
+}
+
+(globalThis as Record<string, unknown>)["Worker"] = BrowserLikeWorker;

--- a/packages/data/turso-data-repositories/src/tursodatabase-database-wasm-bundle.d.ts
+++ b/packages/data/turso-data-repositories/src/tursodatabase-database-wasm-bundle.d.ts
@@ -1,0 +1,3 @@
+declare module "@tursodatabase/database-wasm/bundle" {
+  export * from "@tursodatabase/database-wasm";
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteApp.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteApp.ts
@@ -1,0 +1,20 @@
+import type { AppId, AppType } from "@superego/backend";
+import type { AppEntity } from "@superego/executing-backend";
+
+type SqliteApp = {
+  id: AppId;
+  type: AppType;
+  name: string;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default SqliteApp;
+
+export function toEntity(app: SqliteApp): AppEntity {
+  return {
+    id: app.id,
+    type: app.type,
+    name: app.name,
+    createdAt: new Date(app.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteAppVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteAppVersion.ts
@@ -1,0 +1,30 @@
+import { decode } from "@msgpack/msgpack";
+import type { AppId, AppVersionId } from "@superego/backend";
+import type { AppVersionEntity } from "@superego/executing-backend";
+
+type SqliteAppVersion = {
+  id: AppVersionId;
+  previous_version_id: AppVersionId | null;
+  app_id: AppId;
+  /** MessagePack */
+  target_collections: Buffer;
+  /** MessagePack */
+  files: Buffer;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+};
+export default SqliteAppVersion;
+
+export function toEntity(appVersion: SqliteAppVersion): AppVersionEntity {
+  return {
+    id: appVersion.id,
+    previousVersionId: appVersion.previous_version_id,
+    appId: appVersion.app_id,
+    targetCollections: decode(
+      appVersion.target_collections,
+    ) as AppVersionEntity["targetCollections"],
+    files: decode(appVersion.files) as AppVersionEntity["files"],
+    createdAt: new Date(appVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteBackgroundJob.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteBackgroundJob.ts
@@ -1,0 +1,42 @@
+import type {
+  BackgroundJobId,
+  BackgroundJobName,
+  BackgroundJobStatus,
+} from "@superego/backend";
+import type { BackgroundJobEntity } from "@superego/executing-backend";
+
+type SqliteBackgroundJob = {
+  id: BackgroundJobId;
+  name: BackgroundJobName;
+  /** JSON */
+  input: string;
+  status: BackgroundJobStatus;
+  /** ISO 8601 */
+  enqueued_at: string;
+  /** ISO 8601 */
+  started_processing_at: string | null;
+  /** ISO 8601 */
+  finished_processing_at: string | null;
+  /** JSON */
+  error: string | null;
+};
+export default SqliteBackgroundJob;
+
+export function toEntity(
+  backgroundJob: SqliteBackgroundJob,
+): BackgroundJobEntity {
+  return {
+    id: backgroundJob.id,
+    name: backgroundJob.name,
+    input: JSON.parse(backgroundJob.input),
+    status: backgroundJob.status,
+    enqueuedAt: new Date(backgroundJob.enqueued_at),
+    startedProcessingAt: backgroundJob.started_processing_at
+      ? new Date(backgroundJob.started_processing_at)
+      : null,
+    finishedProcessingAt: backgroundJob.finished_processing_at
+      ? new Date(backgroundJob.finished_processing_at)
+      : null,
+    error: backgroundJob.error ? JSON.parse(backgroundJob.error) : null,
+  } as BackgroundJobEntity;
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteCollection.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteCollection.ts
@@ -1,0 +1,28 @@
+import { decode } from "@msgpack/msgpack";
+import type { CollectionId } from "@superego/backend";
+import type {
+  CollectionEntity,
+  RemoteEntity,
+} from "@superego/executing-backend";
+
+type SqliteCollection = {
+  id: CollectionId;
+  /** JSON */
+  settings: string;
+  /** MessagePack */
+  remote: Buffer | null;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default SqliteCollection;
+
+export function toEntity(collection: SqliteCollection): CollectionEntity {
+  return {
+    id: collection.id,
+    settings: JSON.parse(collection.settings),
+    remote: collection.remote
+      ? (decode(collection.remote) as RemoteEntity)
+      : null,
+    createdAt: new Date(collection.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteCollectionCategory.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteCollectionCategory.ts
@@ -1,0 +1,24 @@
+import type { CollectionCategoryId } from "@superego/backend";
+import type { CollectionCategoryEntity } from "@superego/executing-backend";
+
+type SqliteCollectionCategory = {
+  id: CollectionCategoryId;
+  name: string;
+  icon: string | null;
+  parent_id: CollectionCategoryId | null;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default SqliteCollectionCategory;
+
+export function toEntity(
+  collectionCategory: SqliteCollectionCategory,
+): CollectionCategoryEntity {
+  return {
+    id: collectionCategory.id,
+    name: collectionCategory.name,
+    icon: collectionCategory.icon,
+    parentId: collectionCategory.parent_id,
+    createdAt: new Date(collectionCategory.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteCollectionVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteCollectionVersion.ts
@@ -1,0 +1,44 @@
+import { decode } from "@msgpack/msgpack";
+import type {
+  CollectionId,
+  CollectionVersionId,
+  RemoteConverters,
+} from "@superego/backend";
+import type { CollectionVersionEntity } from "@superego/executing-backend";
+
+type SqliteCollectionVersion = {
+  id: CollectionVersionId;
+  previous_version_id: CollectionVersionId | null;
+  collection_id: CollectionId;
+  /** JSON */
+  schema: string;
+  /** JSON */
+  settings: string;
+  /** JSON */
+  migration: string | null;
+  /** MessagePack */
+  remote_converters: Buffer | null;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+};
+export default SqliteCollectionVersion;
+
+export function toEntity(
+  collectionVersion: SqliteCollectionVersion,
+): CollectionVersionEntity {
+  return {
+    id: collectionVersion.id,
+    previousVersionId: collectionVersion.previous_version_id,
+    collectionId: collectionVersion.collection_id,
+    schema: JSON.parse(collectionVersion.schema),
+    settings: JSON.parse(collectionVersion.settings),
+    migration: collectionVersion.migration
+      ? JSON.parse(collectionVersion.migration)
+      : null,
+    remoteConverters: collectionVersion.remote_converters
+      ? (decode(collectionVersion.remote_converters) as RemoteConverters)
+      : null,
+    createdAt: new Date(collectionVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteConversation.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteConversation.ts
@@ -1,0 +1,41 @@
+import { decode } from "@msgpack/msgpack";
+import type {
+  AssistantName,
+  ConversationId,
+  ConversationStatus,
+  Message,
+} from "@superego/backend";
+import type { ConversationEntity } from "@superego/executing-backend";
+
+type SqliteConversation = {
+  id: ConversationId;
+  assistant: AssistantName;
+  title: string | null;
+  context_fingerprint: string;
+  /** MessagePack */
+  messages: Buffer;
+  status: ConversationStatus;
+  /** ISO 8601 */
+  processing_started_at: string | null;
+  /** JSON */
+  error: string | null;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default SqliteConversation;
+
+export function toEntity(conversation: SqliteConversation): ConversationEntity {
+  return {
+    id: conversation.id,
+    assistant: conversation.assistant,
+    title: conversation.title,
+    contextFingerprint: conversation.context_fingerprint,
+    messages: decode(new Uint8Array(conversation.messages)) as Message[],
+    status: conversation.status,
+    processingStartedAt: conversation.processing_started_at
+      ? new Date(conversation.processing_started_at)
+      : null,
+    error: conversation.error ? JSON.parse(conversation.error) : null,
+    createdAt: new Date(conversation.created_at),
+  } as ConversationEntity;
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteConversationTextSearchText.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteConversationTextSearchText.ts
@@ -1,0 +1,7 @@
+import type { ConversationId } from "@superego/backend";
+
+type SqliteConversationTextSearchText = {
+  conversation_id: ConversationId;
+  text: string;
+};
+export default SqliteConversationTextSearchText;

--- a/packages/data/turso-data-repositories/src/types/SqliteDocument.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteDocument.ts
@@ -1,0 +1,28 @@
+import { decode } from "@msgpack/msgpack";
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type { DocumentEntity } from "@superego/executing-backend";
+
+type SqliteDocument = {
+  id: DocumentId;
+  remote_id: string | null;
+  remote_url: string | null;
+  /** MessagePack */
+  latest_remote_document: Buffer | null;
+  collection_id: CollectionId;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default SqliteDocument;
+
+export function toEntity(document: SqliteDocument): DocumentEntity {
+  return {
+    id: document.id,
+    remoteId: document.remote_id,
+    remoteUrl: document.remote_url,
+    latestRemoteDocument: document.latest_remote_document
+      ? (decode(document.latest_remote_document) as any)
+      : null,
+    collectionId: document.collection_id,
+    createdAt: new Date(document.created_at),
+  } as DocumentEntity;
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteDocumentTextSearchText.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteDocumentTextSearchText.ts
@@ -1,0 +1,8 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+
+type SqliteDocumentTextSearchText = {
+  document_id: DocumentId;
+  collection_id: CollectionId;
+  text: string;
+};
+export default SqliteDocumentTextSearchText;

--- a/packages/data/turso-data-repositories/src/types/SqliteDocumentVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteDocumentVersion.ts
@@ -1,0 +1,133 @@
+import type {
+  CollectionId,
+  CollectionVersionId,
+  ConversationId,
+  DocumentId,
+  DocumentVersion,
+  DocumentVersionCreator,
+  DocumentVersionId,
+} from "@superego/backend";
+import type {
+  DocumentVersionEntity,
+  MinimalDocumentVersionEntity,
+} from "@superego/executing-backend";
+import type { DiffPatcher } from "jsondiffpatch";
+
+type SqliteDocumentVersion = {
+  id: DocumentVersionId;
+  remote_id: string | null;
+  previous_version_id: DocumentVersionId | null;
+  collection_id: CollectionId;
+  document_id: DocumentId;
+  collection_version_id: CollectionVersionId;
+  conversation_id: ConversationId | null;
+  /**
+   * JSON. It's a jsondiffpatch delta or `null` when there is no delta from the
+   * previous version.
+   */
+  content_delta: string | null;
+  /** JSON. Array of contentBlockingKeys. */
+  content_blocking_keys: string | null;
+  /** JSON. Content summary result. */
+  content_summary: string;
+  /** JSON. Array of DocumentRef objects. */
+  referenced_documents: string;
+  created_by: DocumentVersionCreator;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+} & (
+  | {
+      is_latest: 0;
+      content_snapshot: null;
+    }
+  | {
+      is_latest: 1;
+      /** JSON */
+      content_snapshot: string;
+    }
+);
+export default SqliteDocumentVersion;
+
+export function toEntity(
+  documentVersion: SqliteDocumentVersion & { is_latest: 1 },
+): DocumentVersionEntity;
+export function toEntity(
+  documentVersion: SqliteDocumentVersion & { is_latest: 0 },
+  allDocumentVersions: SqliteDocumentVersion[],
+  jdp: DiffPatcher,
+): DocumentVersionEntity;
+export function toEntity(
+  documentVersion: SqliteDocumentVersion,
+  allDocumentVersions?: SqliteDocumentVersion[],
+  jdp?: DiffPatcher,
+): DocumentVersionEntity {
+  return {
+    id: documentVersion.id,
+    remoteId: documentVersion.remote_id,
+    previousVersionId: documentVersion.previous_version_id,
+    collectionId: documentVersion.collection_id,
+    documentId: documentVersion.document_id,
+    collectionVersionId: documentVersion.collection_version_id,
+    conversationId: documentVersion.conversation_id,
+    content:
+      documentVersion.is_latest === 1
+        ? JSON.parse(documentVersion.content_snapshot)
+        : makeContent(documentVersion.id, allDocumentVersions!, jdp!),
+    contentBlockingKeys: documentVersion.content_blocking_keys
+      ? JSON.parse(documentVersion.content_blocking_keys)
+      : null,
+    contentSummary: JSON.parse(
+      documentVersion.content_summary,
+    ) as DocumentVersion["contentSummary"],
+    referencedDocuments: JSON.parse(documentVersion.referenced_documents),
+    createdBy: documentVersion.created_by,
+    createdAt: new Date(documentVersion.created_at),
+  } as DocumentVersionEntity;
+}
+
+/** Makes the specified DocumentVersion content by applying all deltas. */
+function makeContent(
+  id: DocumentVersionId,
+  allDocumentVersions: SqliteDocumentVersion[],
+  jdp: DiffPatcher,
+): any {
+  const documentVersionsById: Record<DocumentVersionId, SqliteDocumentVersion> =
+    {};
+  for (const documentVersion of allDocumentVersions) {
+    documentVersionsById[documentVersion.id] = documentVersion;
+  }
+
+  const deltas: any[] = [];
+  let currentDocumentVersion = documentVersionsById[id]!;
+  for (;;) {
+    if (currentDocumentVersion.content_delta !== null) {
+      deltas.push(JSON.parse(currentDocumentVersion.content_delta));
+    }
+    if (currentDocumentVersion.previous_version_id) {
+      currentDocumentVersion =
+        documentVersionsById[currentDocumentVersion.previous_version_id]!;
+    } else {
+      break;
+    }
+  }
+
+  return deltas.reduceRight((content, delta) => jdp.patch(content, delta), {});
+}
+
+export function toMinimalEntity(
+  documentVersion: SqliteDocumentVersion,
+): MinimalDocumentVersionEntity {
+  return {
+    id: documentVersion.id,
+    remoteId: documentVersion.remote_id,
+    previousVersionId: documentVersion.previous_version_id,
+    collectionId: documentVersion.collection_id,
+    documentId: documentVersion.document_id,
+    collectionVersionId: documentVersion.collection_version_id,
+    conversationId: documentVersion.conversation_id,
+    referencedDocuments: JSON.parse(documentVersion.referenced_documents),
+    createdBy: documentVersion.created_by,
+    createdAt: new Date(documentVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteDocumentVersionBlockingKey.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteDocumentVersionBlockingKey.ts
@@ -1,0 +1,9 @@
+import type { CollectionId, DocumentVersionId } from "@superego/backend";
+
+type SqliteDocumentVersionBlockingKey = {
+  id: number;
+  collection_id: CollectionId;
+  document_version_id: DocumentVersionId;
+  blocking_key: string;
+};
+export default SqliteDocumentVersionBlockingKey;

--- a/packages/data/turso-data-repositories/src/types/SqliteFile.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteFile.ts
@@ -1,0 +1,20 @@
+import type { FileId } from "@superego/backend";
+import type { FileEntity } from "@superego/executing-backend";
+
+type SqliteFile = {
+  id: FileId;
+  /** JSON */
+  referenced_by: string;
+  /** ISO 8601 */
+  created_at: string;
+  content: Buffer;
+};
+export default SqliteFile;
+
+export function toEntity(file: Omit<SqliteFile, "content">): FileEntity {
+  return {
+    id: file.id,
+    referencedBy: JSON.parse(file.referenced_by),
+    createdAt: new Date(file.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/SqliteGlobalSettings.ts
+++ b/packages/data/turso-data-repositories/src/types/SqliteGlobalSettings.ts
@@ -1,0 +1,15 @@
+import type { GlobalSettings } from "@superego/backend";
+import type DeepPartial from "../utils/DeepPartial.js";
+
+type SqliteGlobalSettings = {
+  id: "singleton";
+  /** JSON */
+  value: string;
+};
+export default SqliteGlobalSettings;
+
+export function toEntity(
+  settings: SqliteGlobalSettings,
+): DeepPartial<GlobalSettings> {
+  return JSON.parse(settings.value);
+}

--- a/packages/data/turso-data-repositories/src/utils/DeepPartial.ts
+++ b/packages/data/turso-data-repositories/src/utils/DeepPartial.ts
@@ -1,0 +1,4 @@
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+export default DeepPartial;

--- a/packages/data/turso-data-repositories/tsconfig.json
+++ b/packages/data/turso-data-repositories/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["../../../tsconfig.common.json"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/data/turso-data-repositories/vitest.config.ts
+++ b/packages/data/turso-data-repositories/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: ["./src/test/setupTursoWasm.ts"],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1414,13 +1414,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
+"@emnapi/core@npm:1.10.0, @emnapi/core@npm:^1.10.0, @emnapi/core@npm:^1.5.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
   dependencies:
     "@emnapi/wasi-threads": "npm:1.2.1"
     tslib: "npm:^2.4.0"
   checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  languageName: node
+  linkType: hard
+
+"@emnapi/core@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/core@npm:1.8.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
   languageName: node
   linkType: hard
 
@@ -1434,12 +1444,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0":
+"@emnapi/runtime@npm:1.10.0, @emnapi/runtime@npm:^1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.8.1, @emnapi/runtime@npm:^1.7.0":
+  version: 1.8.1
+  resolution: "@emnapi/runtime@npm:1.8.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
   languageName: node
   linkType: hard
 
@@ -1452,21 +1471,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.0":
-  version: 1.8.1
-  resolution: "@emnapi/runtime@npm:1.8.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f4929d75e37aafb24da77d2f58816761fe3f826aad2e37fa6d4421dac9060cbd5098eea1ac3c9ecc4526b89deb58153852fa432f87021dc57863f2ff726d713f
-  languageName: node
-  linkType: hard
-
 "@emnapi/runtime@npm:^1.7.1":
   version: 1.9.1
   resolution: "@emnapi/runtime@npm:1.9.1"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
   languageName: node
   linkType: hard
 
@@ -3679,6 +3698,17 @@ __metadata:
   version: 3.1.3
   resolution: "@msgpack/msgpack@npm:3.1.3"
   checksum: 10c0/1fa9a760a58e64e121561d17977b680198ff24d83e951df3896f8639d06824f2cba20af92a19940461e0d5d6dc696bd01222bd901164759432eadd0f482d0816
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@napi-rs/wasm-runtime@npm:1.0.7"
+  dependencies:
+    "@emnapi/core": "npm:^1.5.0"
+    "@emnapi/runtime": "npm:^1.5.0"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/2d8635498136abb49d6dbf7395b78c63422292240963bf055f307b77aeafbde57ae2c0ceaaef215601531b36d6eb92a2cdd6f5ba90ed2aa8127c27aff9c4ae55
   languageName: node
   linkType: hard
 
@@ -7023,6 +7053,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@superego/turso-data-repositories@workspace:packages/data/turso-data-repositories":
+  version: 0.0.0-use.local
+  resolution: "@superego/turso-data-repositories@workspace:packages/data/turso-data-repositories"
+  dependencies:
+    "@emnapi/core": "npm:^1.10.0"
+    "@emnapi/runtime": "npm:^1.10.0"
+    "@msgpack/msgpack": "npm:^3.1.3"
+    "@superego/backend": "workspace:*"
+    "@superego/executing-backend": "workspace:*"
+    "@superego/schema": "workspace:*"
+    "@tursodatabase/database-wasm": "npm:0.6.0"
+    "@types/node": "npm:^25.8.0"
+    es-toolkit: "npm:^1.46.1"
+    flexsearch: "npm:^0.8.212"
+    jsondiffpatch: "npm:^0.7.6"
+    typescript: "npm:^6.0.3"
+    vitest: "npm:^4.1.6"
+  languageName: unknown
+  linkType: soft
+
 "@superego/vitest-registered@workspace:*, @superego/vitest-registered@workspace:packages/misc/vitest-registered":
   version: 0.0.0-use.local
   resolution: "@superego/vitest-registered@workspace:packages/misc/vitest-registered"
@@ -8126,6 +8176,34 @@ __metadata:
     rbush: "npm:^3.0.1"
     tslib: "npm:^2.8.1"
   checksum: 10c0/b3c974fc9dfee75314a0b6f94d6f04506739639376c3d546358174a2c25d52c09544caa524173fdeb73d6e91214c542b98eccde9bef049fc326d743253f37136
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-common@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@tursodatabase/database-common@npm:0.6.0"
+  checksum: 10c0/2fd04c8e6c2df3d4f72a40b3356330f736addc5f45342d4beca2b4fe1fd201c37871dd1b9c250b4c219ae7e006713131c2b150146446f62f145e2d952712333c
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-wasm-common@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@tursodatabase/database-wasm-common@npm:0.6.0"
+  dependencies:
+    "@emnapi/core": "npm:1.8.1"
+    "@emnapi/runtime": "npm:1.8.1"
+    "@napi-rs/wasm-runtime": "npm:1.0.7"
+  checksum: 10c0/86ceeb5c24187360168813c5b86cfc76577bb918f7be0d15c5e4fdfd192118e68c721d6e41f7f2e88f895960dde34d71e0e29e73af2d18dca950e89dc60026f9
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-wasm@npm:0.6.0":
+  version: 0.6.0
+  resolution: "@tursodatabase/database-wasm@npm:0.6.0"
+  dependencies:
+    "@tursodatabase/database-common": "npm:^0.6.0"
+    "@tursodatabase/database-wasm-common": "npm:^0.6.0"
+  checksum: 10c0/a5c88a08c66822545f9dc0486f38cb81bc173cb6ba6823f06fe8438b60d8bfd022770c10cb85b322fbf0fd84cfd68040368332f06d823a6d96fd50eae6ffe5f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add the `@superego/turso-data-repositories` workspace backed by `@tursodatabase/database-wasm@0.6.0`.
- Adapt the SQLite repository implementation to Turso's async WASM API via a small database/statement adapter.
- Use the Turso browser bundle entrypoint and add a Vitest-only Worker/OPFS shim so the shared repository conformance tests can run in Node.

## Why

The Turso WASM package is browser-oriented and loads through a bundled Worker/OPFS runtime. The data repository implementation needs to use that package directly while still preserving the existing data repository contract and test coverage.

## Validation

- `yarn workspace @superego/turso-data-repositories run check-types`
- `yarn workspace @superego/turso-data-repositories run test` — 158 tests passed
- `yarn fix-formatting`