### PR TITLE
[codex] Add JSON args file support to CLI

### DIFF
--- a/packages/apps/cli/package.json
+++ b/packages/apps/cli/package.json
@@ -23,7 +23,11 @@
     "@superego/tsc-typescript-compiler": "workspace:*",
     "@valibot/to-json-schema": "^1.7.0",
     "commander": "^14.0.3",
+    "mime-types": "^3.0.2",
     "typescript": "^6.0.3",
     "valibot": "^1.4.0"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^3.0.1"
   }
 }

--- a/packages/apps/cli/src/additional-notes.md
+++ b/packages/apps/cli/src/additional-notes.md
@@ -134,7 +134,8 @@ a JSON object keyed by camelCase argument names.
   directory.
 - For document file fields, use `{ "$file": "/path/to/file" }`; the CLI reads
   the file and sends it as a Superego file value.
-- Do not read or write the Superego SQLite database directly. Use the CLI only.
+- **NEVER** read or write the Superego SQLite database directly. Use the CLI
+  only.
 - Do not run Superego CLI commands in parallel. The app and CLI share one SQLite
   database.
 - Use `collections get-typescript-schema` before writing document content or

--- a/packages/apps/cli/src/additional-notes.md
+++ b/packages/apps/cli/src/additional-notes.md
@@ -115,18 +115,27 @@ Well-known formats:
 
 ### CLI
 
-Run `superego <domain> <command> --help` for command-specific options and JSON
-schemas.
+Run `superego <domain> <command> --help` for command-specific options and args
+file schemas.
 
 #### JSON Inputs
 
-Most data commands take named options.
+Commands with inputs take a single `--args <file>` option. The file must contain
+a JSON object keyed by camelCase argument names.
 
-- String options take plain shell strings: `--id Collection_abc`.
-- To pass `null` for nullable string options, use JSON null:
-  `--collection-id null`.
-- Objects, arrays, booleans, numbers, and null must be valid JSON in one shell
-  argument: `--definition '{"collectionId":"Collection_abc","content":{}}'`.
-- Mixed-type options use JSON.
+- Example:
+  ```json
+  {
+    "collectionId": "Collection_abc",
+    "id": "Document_abc"
+  }
+  ```
+- Relative file paths inside args files are resolved from the args file
+  directory.
+- For document file fields, use `{ "$file": "/path/to/file" }`; the CLI reads
+  the file and sends it as a Superego file value.
+- Do not read or write the Superego SQLite database directly. Use the CLI only.
+- Do not run Superego CLI commands in parallel. The app and CLI share one SQLite
+  database.
 - Use `collections get-typescript-schema` before writing document content or
   TypeScript functions for a collection.

--- a/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
+++ b/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
@@ -8,6 +8,8 @@ Use `superego` to inspect and mutate the local Superego database.
 
 Rules:
 
+- **NEVER** read or write the Superego SQLite database directly. Use the
+  `superego` CLI only.
 - Commands output JSON unless invoked with `--help`.
 - `agents install-skill` is user-facing and outputs normal text; other commands
   are for agent/tool use.
@@ -15,8 +17,6 @@ Rules:
 - Local workflow commands output `{ "success": true, "data": ... }` or
   `{ "success": false, "error": ... }`.
 - Run `superego <domain> <command> --help` before using an unfamiliar command.
-- Never read or write the Superego SQLite database directly. Use the `superego`
-  CLI only.
 - Do not run Superego CLI commands in parallel. The app and CLI share one SQLite
   database.
 - Commands with inputs take `--args <file>`, where `<file>` contains a JSON

--- a/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
+++ b/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
@@ -9,11 +9,18 @@ Use `superego` to inspect and mutate the local Superego database.
 Rules:
 
 - Commands output JSON unless invoked with `--help`.
+- `agents install-skill` is user-facing and outputs normal text; other commands
+  are for agent/tool use.
 - Backend object commands output backend `Result` JSON.
 - Local workflow commands output `{ "success": true, "data": ... }` or
   `{ "success": false, "error": ... }`.
 - Run `superego <domain> <command> --help` before using an unfamiliar command.
-- Prefer CLI commands over direct database edits.
+- Never read or write the Superego SQLite database directly. Use the `superego`
+  CLI only.
+- Do not run Superego CLI commands in parallel. The app and CLI share one SQLite
+  database.
+- Commands with inputs take `--args <file>`, where `<file>` contains a JSON
+  object keyed by camelCase argument names.
 
 Command map:
 
@@ -31,8 +38,7 @@ Command map:
 Common workflows:
 
 - Inspect command docs: `superego <domain> <command> --help`
-- Create/list/update backend objects with named JSON options.
-- Create an app project:
-  `superego apps init ./my-app --collection Collection_...`
+- Create/list/update backend objects with `--args ./args.json`.
+- Create an app project: `superego apps init --args ./args.json`
 - Validate an app project: `superego apps check`
 - Commit an app project: `superego apps commit`

--- a/packages/apps/cli/src/commands/agents/install-skill/install-skill.ts
+++ b/packages/apps/cli/src/commands/agents/install-skill/install-skill.ts
@@ -3,7 +3,6 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { Command } from "commander";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
-import { runCommand, successfulResult } from "../../../utils/results.js";
 import skillContent from "./SKILL.md?raw";
 
 const agentDirectories = {
@@ -25,7 +24,7 @@ export default useMarkdownHelp(
     .option("--agent <agent>", "Known agent name.")
     .option("--directory <directory>", "Explicit skills directory.")
     .action(async (options: { agent?: string; directory?: string }) => {
-      await runCommand(async () => {
+      try {
         const skillsDirectory = getSkillsDirectory(options);
         const skillDirectory = join(skillsDirectory, "superego-cli");
         await mkdir(skillDirectory, { recursive: true });
@@ -34,11 +33,17 @@ export default useMarkdownHelp(
           skillContent,
           "utf-8",
         );
-        return successfulResult({
-          directory: skillDirectory,
-          file: join(skillDirectory, "SKILL.md"),
-        });
-      });
+        process.stdout.write(
+          `Installed Superego CLI skill at ${join(skillDirectory, "SKILL.md")}\n`,
+        );
+      } catch (error) {
+        process.stderr.write(
+          `Failed to install Superego CLI skill: ${
+            error instanceof Error ? error.message : String(error)
+          }\n`,
+        );
+        process.exitCode = 1;
+      }
     }),
 );
 

--- a/packages/apps/cli/src/commands/agents/install-skill/install-skill.ts
+++ b/packages/apps/cli/src/commands/agents/install-skill/install-skill.ts
@@ -33,14 +33,14 @@ export default useMarkdownHelp(
           skillContent,
           "utf-8",
         );
-        process.stdout.write(
-          `Installed Superego CLI skill at ${join(skillDirectory, "SKILL.md")}\n`,
+        console.log(
+          `Installed Superego CLI skill at ${join(skillDirectory, "SKILL.md")}`,
         );
       } catch (error) {
-        process.stderr.write(
+        console.error(
           `Failed to install Superego CLI skill: ${
             error instanceof Error ? error.message : String(error)
-          }\n`,
+          }`,
         );
         process.exitCode = 1;
       }

--- a/packages/apps/cli/src/commands/apps/add-collection/add-collection.ts
+++ b/packages/apps/cli/src/commands/apps/add-collection/add-collection.ts
@@ -3,6 +3,11 @@ import { Command } from "commander";
 import createBackend from "../../../utils/createBackend.js";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
 import {
+  getRequiredStringArg,
+  readAppsArgs,
+  requireArgsFile,
+} from "../common/args.js";
+import {
   resolveLatestTargetCollections,
   runAppCommand,
 } from "../common/commandUtils.js";
@@ -10,33 +15,34 @@ import { regenerateGeneratedFiles } from "../common/generatedFiles.js";
 import { readManifest, writeManifest } from "../common/manifest.js";
 
 export default useMarkdownHelp(
-  new Command("add-collection")
-    .description("Add a target collection to the local app project.")
-    .requiredOption("--collection-id <collectionId>", "Collection id.")
-    .action(async (options: { collectionId: CollectionId }) => {
-      await runAppCommand(async () => {
-        const path = process.cwd();
-        const manifest = readManifest(path);
-        if (manifest.targetCollectionIds.includes(options.collectionId)) {
-          throw new Error(
-            `Collection ${options.collectionId} is already present.`,
-          );
-        }
-        const nextManifest = {
-          ...manifest,
-          targetCollectionIds: [
-            ...manifest.targetCollectionIds,
-            options.collectionId,
-          ],
-        };
-        const backend = await createBackend();
-        const targetCollections = await resolveLatestTargetCollections(
-          backend,
-          nextManifest.targetCollectionIds,
-        );
-        await writeManifest(path, nextManifest);
-        await regenerateGeneratedFiles(path, targetCollections);
-        return { targetCollectionIds: nextManifest.targetCollectionIds };
-      });
-    }),
+  requireArgsFile(
+    new Command("add-collection").description(
+      "Add a target collection to the local app project.",
+    ),
+  ).action(async (options: { args: string }) => {
+    await runAppCommand(async () => {
+      const args = readAppsArgs(options.args, ["collectionId"]);
+      const collectionId = getRequiredStringArg(
+        args,
+        "collectionId",
+      ) as CollectionId;
+      const path = process.cwd();
+      const manifest = readManifest(path);
+      if (manifest.targetCollectionIds.includes(collectionId)) {
+        throw new Error(`Collection ${collectionId} is already present.`);
+      }
+      const nextManifest = {
+        ...manifest,
+        targetCollectionIds: [...manifest.targetCollectionIds, collectionId],
+      };
+      const backend = await createBackend();
+      const targetCollections = await resolveLatestTargetCollections(
+        backend,
+        nextManifest.targetCollectionIds,
+      );
+      await writeManifest(path, nextManifest);
+      await regenerateGeneratedFiles(path, targetCollections);
+      return { targetCollectionIds: nextManifest.targetCollectionIds };
+    });
+  }),
 );

--- a/packages/apps/cli/src/commands/apps/checkout/checkout.ts
+++ b/packages/apps/cli/src/commands/apps/checkout/checkout.ts
@@ -2,6 +2,11 @@ import { resolve } from "node:path";
 import { Command } from "commander";
 import createBackend from "../../../utils/createBackend.js";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
+import {
+  getRequiredStringArg,
+  readAppsArgs,
+  requireArgsFile,
+} from "../common/args.js";
 import assertEmptyTarget from "../common/assertEmptyTarget.js";
 import {
   resolveLockedTargetCollections,
@@ -11,43 +16,44 @@ import { buildLock } from "../common/lock.js";
 import writeAppProject from "../common/writeAppProject.js";
 
 export default useMarkdownHelp(
-  new Command("checkout")
-    .description("Check out an existing backend app into a local folder.")
-    .requiredOption("--path <path>", "New project path.")
-    .requiredOption("--app-id <appId>", "Backend app id.")
-    .action(async (options: { path: string; appId: string }) => {
-      await runAppCommand(async () => {
-        const projectPath = resolve(options.path);
-        assertEmptyTarget(projectPath);
-        const backend = await createBackend();
-        const appsResult = await backend.apps.list();
-        if (!appsResult.success) {
-          throw new Error(JSON.stringify(appsResult.error));
-        }
-        const app = appsResult.data.find(
-          (candidate) => candidate.id === options.appId,
-        );
-        if (!app) {
-          throw new Error(`App ${options.appId} not found.`);
-        }
-        const targetCollections = await resolveLockedTargetCollections(
-          backend,
-          app.latestVersion.targetCollections,
-        );
-        await writeAppProject(
-          projectPath,
-          {
-            name: app.name,
-            type: app.type,
-            targetCollectionIds: app.latestVersion.targetCollections.map(
-              (targetCollection) => targetCollection.id,
-            ),
-          },
-          app.latestVersion.files["/main.tsx"].source,
-          targetCollections,
-          buildLock(app),
-        );
-        return { path: projectPath, appId: app.id };
-      });
-    }),
+  requireArgsFile(
+    new Command("checkout").description(
+      "Check out an existing backend app into a local folder.",
+    ),
+  ).action(async (options: { args: string }) => {
+    await runAppCommand(async () => {
+      const args = readAppsArgs(options.args, ["path", "appId"]);
+      const path = getRequiredStringArg(args, "path");
+      const appId = getRequiredStringArg(args, "appId");
+      const projectPath = resolve(path);
+      assertEmptyTarget(projectPath);
+      const backend = await createBackend();
+      const appsResult = await backend.apps.list();
+      if (!appsResult.success) {
+        throw new Error(JSON.stringify(appsResult.error));
+      }
+      const app = appsResult.data.find((candidate) => candidate.id === appId);
+      if (!app) {
+        throw new Error(`App ${appId} not found.`);
+      }
+      const targetCollections = await resolveLockedTargetCollections(
+        backend,
+        app.latestVersion.targetCollections,
+      );
+      await writeAppProject(
+        projectPath,
+        {
+          name: app.name,
+          type: app.type,
+          targetCollectionIds: app.latestVersion.targetCollections.map(
+            (targetCollection) => targetCollection.id,
+          ),
+        },
+        app.latestVersion.files["/main.tsx"].source,
+        targetCollections,
+        buildLock(app),
+      );
+      return { path: projectPath, appId: app.id };
+    });
+  }),
 );

--- a/packages/apps/cli/src/commands/apps/common/args.ts
+++ b/packages/apps/cli/src/commands/apps/common/args.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import {
+  assertNoUnknownArgs,
+  getOptionalStringArg,
+  getOptionalStringArrayArg,
+  getRequiredStringArg,
+  readArgsFileOrThrow,
+} from "../../../utils/argsFile.js";
+
+export function requireArgsFile(command: Command): Command {
+  return command.requiredOption("--args <file>", "Path to JSON args file.");
+}
+
+export function readAppsArgs(
+  path: string,
+  allowedKeys: string[],
+): Record<string, unknown> {
+  const args = readArgsFileOrThrow(path);
+  assertNoUnknownArgs(args, allowedKeys);
+  return args;
+}
+
+export {
+  getOptionalStringArg,
+  getOptionalStringArrayArg,
+  getRequiredStringArg,
+};

--- a/packages/apps/cli/src/commands/apps/common/commandUtils.ts
+++ b/packages/apps/cli/src/commands/apps/common/commandUtils.ts
@@ -3,6 +3,7 @@ import type {
   CollectionId,
   CollectionVersionId,
 } from "@superego/backend";
+import { isArgsFileError } from "../../../utils/argsFile.js";
 import createBackend from "../../../utils/createBackend.js";
 import {
   runCommand,
@@ -13,13 +14,6 @@ import type { TargetCollection } from "./types.js";
 
 export type CliBackend = Awaited<ReturnType<typeof createBackend>>;
 
-export function collect(
-  value: string,
-  previous: CollectionId[],
-): CollectionId[] {
-  return [...previous, value as CollectionId];
-}
-
 export async function runAppCommand<Data>(
   run: () => Promise<Data>,
 ): Promise<void> {
@@ -27,6 +21,9 @@ export async function runAppCommand<Data>(
     try {
       return successfulResult(await run());
     } catch (error) {
+      if (isArgsFileError(error)) {
+        return unsuccessfulResult("ArgumentsNotValid", error.details);
+      }
       return unsuccessfulResult("CommandFailed", {
         message: error instanceof Error ? error.message : String(error),
       });

--- a/packages/apps/cli/src/commands/apps/delete/delete.ts
+++ b/packages/apps/cli/src/commands/apps/delete/delete.ts
@@ -1,16 +1,30 @@
 import type { AppId } from "@superego/backend";
 import { Command } from "commander";
+import { ArgsFileError } from "../../../utils/argsFile.js";
 import createBackend from "../../../utils/createBackend.js";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
-import { runCommand } from "../../../utils/results.js";
+import { runCommand, unsuccessfulResult } from "../../../utils/results.js";
+import {
+  getRequiredStringArg,
+  readAppsArgs,
+  requireArgsFile,
+} from "../common/args.js";
 
 export default useMarkdownHelp(
-  new Command("delete")
-    .description("Delete a backend app.")
-    .requiredOption("--id <value>", "Backend app id.")
-    .action(async (options: { id: AppId }) => {
-      await runCommand(async () =>
-        (await createBackend()).apps.delete(options.id, "delete"),
-      );
-    }),
+  requireArgsFile(
+    new Command("delete").description("Delete a backend app."),
+  ).action(async (options: { args: string }) => {
+    await runCommand(async () => {
+      try {
+        const args = readAppsArgs(options.args, ["id"]);
+        const id = getRequiredStringArg(args, "id") as AppId;
+        return (await createBackend()).apps.delete(id, "delete");
+      } catch (error) {
+        if (error instanceof ArgsFileError) {
+          return unsuccessfulResult("ArgumentsNotValid", error.details);
+        }
+        throw error;
+      }
+    });
+  }),
 );

--- a/packages/apps/cli/src/commands/apps/init/init.ts
+++ b/packages/apps/cli/src/commands/apps/init/init.ts
@@ -3,9 +3,15 @@ import { AppType, type CollectionId } from "@superego/backend";
 import { Command } from "commander";
 import createBackend from "../../../utils/createBackend.js";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
+import {
+  getOptionalStringArg,
+  getOptionalStringArrayArg,
+  getRequiredStringArg,
+  readAppsArgs,
+  requireArgsFile,
+} from "../common/args.js";
 import assertEmptyTarget from "../common/assertEmptyTarget.js";
 import {
-  collect,
   resolveLatestTargetCollections,
   runAppCommand,
 } from "../common/commandUtils.js";
@@ -13,47 +19,37 @@ import { getInitialMainSource } from "../common/mainSource.js";
 import writeAppProject from "../common/writeAppProject.js";
 
 export default useMarkdownHelp(
-  new Command("init")
-    .description("Create a new local app project.")
-    .requiredOption("--path <path>", "New project path.")
-    .option("--name <name>", "App name.", "Untitled App")
-    .option(
-      "--collection <collectionId>",
-      "Target collection. Can be passed multiple times.",
-      collect,
-      [],
-    )
-    .action(
-      async (options: {
-        path: string;
-        name: string;
-        collection: CollectionId[];
-      }) => {
-        await runAppCommand(async () => {
-          const projectPath = resolve(options.path);
-          assertEmptyTarget(projectPath);
-          const backend = await createBackend();
-          const targetCollections = await resolveLatestTargetCollections(
-            backend,
-            options.collection,
-          );
-          const manifest = {
-            name: options.name,
-            type: AppType.CollectionView,
-            targetCollectionIds: options.collection,
-          };
-          await writeAppProject(
-            projectPath,
-            manifest,
-            getInitialMainSource(targetCollections),
-            targetCollections,
-            null,
-          );
-          return {
-            path: projectPath,
-            targetCollectionIds: options.collection,
-          };
-        });
-      },
-    ),
+  requireArgsFile(
+    new Command("init").description("Create a new local app project."),
+  ).action(async (options: { args: string }) => {
+    await runAppCommand(async () => {
+      const args = readAppsArgs(options.args, ["path", "name", "collection"]);
+      const path = getRequiredStringArg(args, "path");
+      const name = getOptionalStringArg(args, "name", "Untitled App");
+      const collection = getOptionalStringArrayArg(args, "collection", []);
+      const projectPath = resolve(path);
+      assertEmptyTarget(projectPath);
+      const backend = await createBackend();
+      const targetCollections = await resolveLatestTargetCollections(
+        backend,
+        collection as CollectionId[],
+      );
+      const manifest = {
+        name,
+        type: AppType.CollectionView,
+        targetCollectionIds: collection as CollectionId[],
+      };
+      await writeAppProject(
+        projectPath,
+        manifest,
+        getInitialMainSource(targetCollections),
+        targetCollections,
+        null,
+      );
+      return {
+        path: projectPath,
+        targetCollectionIds: collection,
+      };
+    });
+  }),
 );

--- a/packages/apps/cli/src/commands/apps/remove-collection/remove-collection.ts
+++ b/packages/apps/cli/src/commands/apps/remove-collection/remove-collection.ts
@@ -3,6 +3,11 @@ import { Command } from "commander";
 import createBackend from "../../../utils/createBackend.js";
 import { useMarkdownHelp } from "../../../utils/markdownHelp.js";
 import {
+  getRequiredStringArg,
+  readAppsArgs,
+  requireArgsFile,
+} from "../common/args.js";
+import {
   resolveLatestTargetCollections,
   runAppCommand,
 } from "../common/commandUtils.js";
@@ -10,30 +15,36 @@ import { regenerateGeneratedFiles } from "../common/generatedFiles.js";
 import { readManifest, writeManifest } from "../common/manifest.js";
 
 export default useMarkdownHelp(
-  new Command("remove-collection")
-    .description("Remove a target collection from the local app project.")
-    .requiredOption("--collection-id <collectionId>", "Collection id.")
-    .action(async (options: { collectionId: CollectionId }) => {
-      await runAppCommand(async () => {
-        const path = process.cwd();
-        const manifest = readManifest(path);
-        if (!manifest.targetCollectionIds.includes(options.collectionId)) {
-          throw new Error(`Collection ${options.collectionId} is not present.`);
-        }
-        const nextManifest = {
-          ...manifest,
-          targetCollectionIds: manifest.targetCollectionIds.filter(
-            (targetCollectionId) => targetCollectionId !== options.collectionId,
-          ),
-        };
-        const backend = await createBackend();
-        const targetCollections = await resolveLatestTargetCollections(
-          backend,
-          nextManifest.targetCollectionIds,
-        );
-        await writeManifest(path, nextManifest);
-        await regenerateGeneratedFiles(path, targetCollections);
-        return { targetCollectionIds: nextManifest.targetCollectionIds };
-      });
-    }),
+  requireArgsFile(
+    new Command("remove-collection").description(
+      "Remove a target collection from the local app project.",
+    ),
+  ).action(async (options: { args: string }) => {
+    await runAppCommand(async () => {
+      const args = readAppsArgs(options.args, ["collectionId"]);
+      const collectionId = getRequiredStringArg(
+        args,
+        "collectionId",
+      ) as CollectionId;
+      const path = process.cwd();
+      const manifest = readManifest(path);
+      if (!manifest.targetCollectionIds.includes(collectionId)) {
+        throw new Error(`Collection ${collectionId} is not present.`);
+      }
+      const nextManifest = {
+        ...manifest,
+        targetCollectionIds: manifest.targetCollectionIds.filter(
+          (targetCollectionId) => targetCollectionId !== collectionId,
+        ),
+      };
+      const backend = await createBackend();
+      const targetCollections = await resolveLatestTargetCollections(
+        backend,
+        nextManifest.targetCollectionIds,
+      );
+      await writeManifest(path, nextManifest);
+      await regenerateGeneratedFiles(path, targetCollections);
+      return { targetCollectionIds: nextManifest.targetCollectionIds };
+    });
+  }),
 );

--- a/packages/apps/cli/src/commands/collections/create-many/additional-notes.md
+++ b/packages/apps/cli/src/commands/collections/create-many/additional-notes.md
@@ -2,3 +2,6 @@
 
 Same input rules as `superego collections create --help`; apply them to each
 item in `definitions`.
+
+`collections create-many` is atomic: if any item fails, no collections are
+created.

--- a/packages/apps/cli/src/commands/documents/create-many/additional-notes.md
+++ b/packages/apps/cli/src/commands/documents/create-many/additional-notes.md
@@ -2,3 +2,5 @@
 
 Same content rules as `superego documents create --help`; apply them to each
 item in `definitions`.
+
+`documents create-many` is atomic: if any item fails, no documents are created.

--- a/packages/apps/cli/src/utils/argsFile.ts
+++ b/packages/apps/cli/src/utils/argsFile.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+import { lookup as lookupMimeType } from "mime-types";
+import { type LocalResult, unsuccessfulResult } from "./results.js";
+
+interface Issue {
+  message: string;
+  path?: { key: string | number }[];
+}
+
+export class ArgsFileError extends Error {
+  constructor(public details: { issues: Issue[] }) {
+    super(
+      details.issues.map(({ message }) => message).join("\n") ||
+        "Args file is invalid.",
+    );
+  }
+}
+
+export function isArgsFileError(error: unknown): error is ArgsFileError {
+  return error instanceof ArgsFileError;
+}
+
+export function readArgsFile(
+  path: string,
+): LocalResult<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (error) {
+    return issuesResult([
+      {
+        message: `Unable to read or parse args file: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      },
+    ]);
+  }
+
+  if (!isRecord(parsed)) {
+    return issuesResult([{ message: "Args file must contain a JSON object." }]);
+  }
+
+  const expanded = expandFilePlaceholders(parsed, dirname(resolve(path)), []);
+  if (!expanded.success) {
+    return unsuccessfulResult(expanded.error!.name, expanded.error!.details);
+  }
+  if (!isRecord(expanded.data)) {
+    return issuesResult([{ message: "Args file must contain a JSON object." }]);
+  }
+  return { success: true, data: expanded.data, error: null };
+}
+
+export function readArgsFileOrThrow(path: string): Record<string, unknown> {
+  const result = readArgsFile(path);
+  if (!result.success) {
+    throw new ArgsFileError(result.error!.details as { issues: Issue[] });
+  }
+  return result.data!;
+}
+
+export function assertNoUnknownArgs(
+  args: Record<string, unknown>,
+  allowedKeys: string[],
+): void {
+  const allowedKeysSet = new Set(allowedKeys);
+  const unknownKeys = Object.keys(args).filter(
+    (key) => !allowedKeysSet.has(key),
+  );
+  if (unknownKeys.length > 0) {
+    throw new ArgsFileError({
+      issues: unknownKeys.map((key) => ({
+        message: `Unknown args key "${key}".`,
+        path: [{ key }],
+      })),
+    });
+  }
+}
+
+export function getRequiredStringArg(
+  args: Record<string, unknown>,
+  key: string,
+): string {
+  const value = args[key];
+  if (typeof value !== "string") {
+    throw new ArgsFileError({
+      issues: [{ message: `"${key}" must be a string.`, path: [{ key }] }],
+    });
+  }
+  return value;
+}
+
+export function getOptionalStringArg(
+  args: Record<string, unknown>,
+  key: string,
+  defaultValue: string,
+): string {
+  const value = args[key];
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (typeof value !== "string") {
+    throw new ArgsFileError({
+      issues: [{ message: `"${key}" must be a string.`, path: [{ key }] }],
+    });
+  }
+  return value;
+}
+
+export function getOptionalStringArrayArg(
+  args: Record<string, unknown>,
+  key: string,
+  defaultValue: string[],
+): string[] {
+  const value = args[key];
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new ArgsFileError({
+      issues: [
+        { message: `"${key}" must be an array of strings.`, path: [{ key }] },
+      ],
+    });
+  }
+  return value;
+}
+
+function expandFilePlaceholders(
+  value: unknown,
+  baseDirectory: string,
+  path: (string | number)[],
+): LocalResult<unknown> {
+  if (Array.isArray(value)) {
+    const expandedItems: unknown[] = [];
+    for (const [index, item] of value.entries()) {
+      const expandedItem = expandFilePlaceholders(item, baseDirectory, [
+        ...path,
+        index,
+      ]);
+      if (!expandedItem.success) {
+        return expandedItem;
+      }
+      expandedItems.push(expandedItem.data);
+    }
+    return { success: true, data: expandedItems, error: null };
+  }
+
+  if (!isRecord(value)) {
+    return { success: true, data: value, error: null };
+  }
+
+  if (Object.hasOwn(value, "$file")) {
+    if (Object.keys(value).length !== 1 || typeof value["$file"] !== "string") {
+      return issuesResult([
+        {
+          message: '`$file` placeholders must be exactly { "$file": "path" }.',
+          path: toIssuePath(path),
+        },
+      ]);
+    }
+    const filePath = isAbsolute(value["$file"])
+      ? value["$file"]
+      : resolve(baseDirectory, value["$file"]);
+    try {
+      return {
+        success: true,
+        data: {
+          name: basename(filePath),
+          mimeType: lookupMimeType(filePath) || "application/octet-stream",
+          content: Uint8Array.from(readFileSync(filePath)),
+        },
+        error: null,
+      };
+    } catch (error) {
+      return issuesResult([
+        {
+          message: `Unable to read file placeholder "${filePath}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          path: toIssuePath(path),
+        },
+      ]);
+    }
+  }
+
+  const expandedEntries: [string, unknown][] = [];
+  for (const [key, childValue] of Object.entries(value)) {
+    const expandedChild = expandFilePlaceholders(childValue, baseDirectory, [
+      ...path,
+      key,
+    ]);
+    if (!expandedChild.success) {
+      return expandedChild;
+    }
+    expandedEntries.push([key, expandedChild.data]);
+  }
+  return {
+    success: true,
+    data: Object.fromEntries(expandedEntries),
+    error: null,
+  };
+}
+
+function issuesResult(issues: Issue[]): LocalResult<never> {
+  return unsuccessfulResult("ArgumentsNotValid", { issues });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Uint8Array)
+  );
+}
+
+function toIssuePath(path: (string | number)[]): { key: string | number }[] {
+  return path.map((key) => ({ key }));
+}

--- a/packages/apps/cli/src/utils/createBackendCommand.ts
+++ b/packages/apps/cli/src/utils/createBackendCommand.ts
@@ -2,9 +2,10 @@ import { SchemaJsonSchema } from "@superego/schema";
 import { toJsonSchema, type JsonSchema } from "@valibot/to-json-schema";
 import { Command } from "commander";
 import * as v from "valibot";
+import { readArgsFile } from "./argsFile.js";
 import createBackend from "./createBackend.js";
 import {
-  setJsonOptionsHelp,
+  setJsonArgsFileHelp,
   setAdditionalNotes,
   useMarkdownHelp,
 } from "./markdownHelp.js";
@@ -44,33 +45,26 @@ export default function createBackendCommand({
   additionalNotes,
 }: BackendCommandOptions): Command {
   let command = new Command(name).description(description);
-  const argumentSchemas = getArgumentSchemas(UsecaseClass);
 
-  for (const [index, argument] of commandArguments.entries()) {
-    if ("fixedValue" in argument) {
-      continue;
-    }
-    const acceptsPlainString = isStringLikeArgumentSchema(
-      argumentSchemas[index],
+  if (hasInputArguments(commandArguments)) {
+    command = command.requiredOption(
+      "--args <file>",
+      "Path to JSON args file.",
     );
-    const flags = `--${argument.name} <${
-      acceptsPlainString ? "value" : "json"
-    }>`;
-    const optionDescription = `${argument.description}${
-      acceptsPlainString ? "." : " JSON."
-    }`;
-    command =
-      argument.required === false
-        ? command.option(flags, optionDescription)
-        : command.requiredOption(flags, optionDescription);
   }
 
-  command.action(async (options: Record<string, string | undefined>) => {
+  command.action(async (options: { args?: string }) => {
     await runCommand(async () => {
+      const argsFileResult = options.args
+        ? readArgsFile(options.args)
+        : ({ success: true, data: {}, error: null } as const);
+      if (!argsFileResult.success) {
+        return argsFileResult;
+      }
+
       const parsedArguments = readArguments(
         commandArguments,
-        argumentSchemas,
-        options,
+        argsFileResult.data!,
       );
       if (!parsedArguments.success) {
         return parsedArguments;
@@ -90,10 +84,11 @@ export default function createBackendCommand({
     });
   });
 
-  setJsonOptionsHelp(
-    command,
-    getJsonOptionsHelp(UsecaseClass, commandArguments),
-  );
+  if (hasInputArguments(commandArguments)) {
+    setJsonArgsFileHelp(command, {
+      schema: getJsonArgsFileHelp(UsecaseClass, commandArguments),
+    });
+  }
   if (additionalNotes) {
     setAdditionalNotes(command, additionalNotes);
   }
@@ -102,136 +97,53 @@ export default function createBackendCommand({
 
 function readArguments(
   commandArguments: BackendCommandArgument[],
-  argumentSchemas: (v.GenericSchema<unknown, unknown> | undefined)[],
-  options: Record<string, string | undefined>,
+  args: Record<string, unknown>,
 ) {
+  const expectedKeys = commandArguments
+    .filter((argument) => !("fixedValue" in argument))
+    .map((argument) => toOptionPropertyName(argument.name));
+  const unknownKeys = Object.keys(args).filter(
+    (key) => !expectedKeys.includes(key),
+  );
+  if (unknownKeys.length > 0) {
+    return unsuccessfulResult("ArgumentsNotValid", {
+      issues: unknownKeys.map((key) => ({
+        message: `Unknown args key "${key}".`,
+        path: [{ key }],
+      })),
+    });
+  }
+
   const parsed: unknown[] = [];
-  for (const [index, argument] of commandArguments.entries()) {
+  for (const argument of commandArguments) {
     if ("fixedValue" in argument) {
       parsed.push(argument.fixedValue);
       continue;
     }
-    const raw = options[toOptionPropertyName(argument.name)];
+    const key = toOptionPropertyName(argument.name);
+    const raw = args[key];
     if (raw === undefined) {
       if (argument.required !== false) {
         return unsuccessfulResult("ArgumentsNotValid", {
-          issues: [{ message: `Missing required option --${argument.name}.` }],
+          issues: [{ message: `Missing required args key "${key}".` }],
         });
       }
       parsed.push(undefined);
       continue;
     }
-    const parsedArgument = parseArgument(
-      raw,
-      argumentSchemas[index],
-      argument.name,
-    );
-    if (!parsedArgument.success) {
-      return parsedArgument;
-    }
-    parsed.push(parsedArgument.data);
+    parsed.push(raw);
   }
   return { success: true as const, data: parsed, error: null };
 }
 
-function parseArgument(
-  raw: string,
-  schema: v.GenericSchema<unknown, unknown> | undefined,
-  name: string,
-) {
-  if (schema && isStringLikeArgumentSchema(schema)) {
-    if (raw === "null" && isNullableArgumentSchema(schema)) {
-      return { success: true as const, data: null, error: null };
-    }
-    if (raw.startsWith('"')) {
-      try {
-        return {
-          success: true as const,
-          data: JSON.parse(raw) as unknown,
-          error: null,
-        };
-      } catch (error) {
-        return unsuccessfulResult("ArgumentsNotValid", {
-          issues: [
-            {
-              message: `--${name} must be a plain string or valid JSON string: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            },
-          ],
-        });
-      }
-    }
-    return { success: true as const, data: raw, error: null };
-  }
-
-  try {
-    return {
-      success: true as const,
-      data: JSON.parse(raw) as unknown,
-      error: null,
-    };
-  } catch (error) {
-    return unsuccessfulResult("ArgumentsNotValid", {
-      issues: [
-        {
-          message: `--${name} must be valid JSON: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        },
-      ],
-    });
-  }
-}
-
-function isStringLikeArgumentSchema(
-  schema: v.GenericSchema<unknown, unknown> | undefined,
-): boolean {
-  if (!schema) {
-    return false;
-  }
-  const schemaInternals = schema as any;
-  switch (schemaInternals.type) {
-    case "string":
-    case "custom":
-      return true;
-    case "optional":
-    case "nullable":
-      return isStringLikeArgumentSchema(schemaInternals.wrapped);
-    case "union":
-      return schemaInternals.options.every(isStringLikeArgumentSchema);
-    default:
-      return false;
-  }
-}
-
-function isNullableArgumentSchema(
-  schema: v.GenericSchema<unknown, unknown>,
-): boolean {
-  const schemaInternals = schema as any;
-  switch (schemaInternals.type) {
-    case "nullable":
-      return true;
-    case "optional":
-      return isNullableArgumentSchema(schemaInternals.wrapped);
-    case "union":
-      return schemaInternals.options.some(
-        (option: v.GenericSchema<unknown, unknown>) =>
-          isNullArgumentSchema(option) || isNullableArgumentSchema(option),
-      );
-    default:
-      return false;
-  }
-}
-
-function isNullArgumentSchema(
-  schema: v.GenericSchema<unknown, unknown>,
-): boolean {
-  return (schema as any).type === "null";
-}
-
 function getArgumentSchemas(UsecaseClass: BackendUsecaseClass) {
   return (getArgumentsSchema(UsecaseClass) as TupleSchemaWithItems).items ?? [];
+}
+
+function hasInputArguments(
+  commandArguments: BackendCommandArgument[],
+): boolean {
+  return commandArguments.some((argument) => !("fixedValue" in argument));
 }
 
 function toOptionPropertyName(name: string): string {
@@ -253,22 +165,27 @@ function getArgumentsSchema(UsecaseClass: BackendUsecaseClass) {
   return usecase.argumentsSchema;
 }
 
-function getJsonOptionsHelp(
+function getJsonArgsFileHelp(
   UsecaseClass: BackendUsecaseClass,
   commandArguments: BackendCommandArgument[],
 ) {
   const argumentSchemas = getArgumentSchemas(UsecaseClass);
-  return commandArguments.flatMap((argument, index) => {
-    if ("fixedValue" in argument) {
-      return [];
-    }
-    return [
-      {
-        name: argument.name,
-        schema: toArgumentJsonSchema(argumentSchemas[index]),
-      },
-    ];
-  });
+  const inputArguments = commandArguments
+    .map((argument, index) => ({ argument, index }))
+    .filter(({ argument }) => !("fixedValue" in argument));
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: Object.fromEntries(
+      inputArguments.map(({ argument, index }) => [
+        toOptionPropertyName(argument.name),
+        toArgumentJsonSchema(argumentSchemas[index]),
+      ]),
+    ),
+    required: inputArguments
+      .filter(({ argument }) => argument.required !== false)
+      .map(({ argument }) => toOptionPropertyName(argument.name)),
+  };
 }
 
 function toArgumentJsonSchema(

--- a/packages/apps/cli/src/utils/markdownHelp.ts
+++ b/packages/apps/cli/src/utils/markdownHelp.ts
@@ -1,18 +1,17 @@
 import { Command } from "commander";
 
-interface JsonOptionHelp {
-  name: string;
+interface JsonArgsFileHelp {
   schema: unknown;
 }
 
-const jsonOptionsHelpByCommand = new WeakMap<Command, JsonOptionHelp[]>();
+const jsonArgsFileHelpByCommand = new WeakMap<Command, JsonArgsFileHelp>();
 const additionalNotesByCommand = new WeakMap<Command, string>();
 
-export function setJsonOptionsHelp(
+export function setJsonArgsFileHelp(
   command: Command,
-  jsonOptionsHelp: JsonOptionHelp[],
+  jsonArgsFileHelp: JsonArgsFileHelp,
 ): void {
-  jsonOptionsHelpByCommand.set(command, jsonOptionsHelp);
+  jsonArgsFileHelpByCommand.set(command, jsonArgsFileHelp);
 }
 
 export function setAdditionalNotes(
@@ -64,19 +63,16 @@ function formatMarkdownHelp(command: Command): string {
     lines.push("## Options", "", ...optionsHelp, "");
   }
 
-  const jsonOptionsHelp = jsonOptionsHelpByCommand.get(command);
-  if (jsonOptionsHelp && jsonOptionsHelp.length > 0) {
-    lines.push("## JSON Options", "");
-    for (const optionHelp of jsonOptionsHelp) {
-      lines.push(
-        `### --${optionHelp.name}`,
-        "",
-        "```json",
-        JSON.stringify(optionHelp.schema, null, 2),
-        "```",
-        "",
-      );
-    }
+  const jsonArgsFileHelp = jsonArgsFileHelpByCommand.get(command);
+  if (jsonArgsFileHelp) {
+    lines.push(
+      "## Args File Schema",
+      "",
+      "```json",
+      JSON.stringify(jsonArgsFileHelp.schema, null, 2),
+      "```",
+      "",
+    );
   }
 
   const subcommands = command.commands.map(

--- a/packages/apps/website/src/content/docs/getting-started/cli.md
+++ b/packages/apps/website/src/content/docs/getting-started/cli.md
@@ -22,36 +22,3 @@ superego agents install-skill --agent claude
 
 You can then ask your agent to do almost everything Superego allows you to do
 (you can run `superego --help` to see all available commands).
-
-## Agent rules
-
-- Agents must never read or write the Superego SQLite database directly. They
-  must use the `superego` CLI.
-- Agents must not run Superego CLI commands in parallel. The app and CLI share
-  one SQLite database.
-- Commands with inputs take `--args <file>`, where `<file>` contains a JSON
-  object keyed by camelCase argument names.
-- `documents create-many` and `collections create-many` are atomic: if any item
-  fails, no item is created.
-
-Example args file:
-
-```json
-{
-  "collectionId": "Collection_...",
-  "id": "Document_..."
-}
-```
-
-Document file fields can use a file placeholder:
-
-```json
-{
-  "definition": {
-    "collectionId": "Collection_...",
-    "content": {
-      "photo": { "$file": "/Users/me/Downloads/plant.jpg" }
-    }
-  }
-}
-```

--- a/packages/apps/website/src/content/docs/getting-started/cli.md
+++ b/packages/apps/website/src/content/docs/getting-started/cli.md
@@ -22,3 +22,36 @@ superego agents install-skill --agent claude
 
 You can then ask your agent to do almost everything Superego allows you to do
 (you can run `superego --help` to see all available commands).
+
+## Agent rules
+
+- Agents must never read or write the Superego SQLite database directly. They
+  must use the `superego` CLI.
+- Agents must not run Superego CLI commands in parallel. The app and CLI share
+  one SQLite database.
+- Commands with inputs take `--args <file>`, where `<file>` contains a JSON
+  object keyed by camelCase argument names.
+- `documents create-many` and `collections create-many` are atomic: if any item
+  fails, no item is created.
+
+Example args file:
+
+```json
+{
+  "collectionId": "Collection_...",
+  "id": "Document_..."
+}
+```
+
+Document file fields can use a file placeholder:
+
+```json
+{
+  "definition": {
+    "collectionId": "Collection_...",
+    "content": {
+      "photo": { "$file": "/Users/me/Downloads/plant.jpg" }
+    }
+  }
+}
+```

--- a/packages/core/backend/src/Backend.ts
+++ b/packages/core/backend/src/Backend.ts
@@ -161,6 +161,7 @@ export default interface Backend {
       | UnexpectedError
     >;
 
+    /** Atomic: if any collection fails, no collections are created. */
     createMany(
       definitions: CollectionDefinition[],
     ): ResultPromise<
@@ -345,6 +346,7 @@ export default interface Backend {
       | UnexpectedError
     >;
 
+    /** Atomic: if any document fails, no documents are created. */
     createMany(
       definitions: DocumentDefinition[],
     ): ResultPromise<

--- a/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.test.ts
+++ b/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.test.ts
@@ -1,15 +1,36 @@
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { AssistantName, Theme } from "@superego/backend";
 import { registerDataRepositoriesTests } from "@superego/executing-backend/tests";
-import { afterAll, beforeAll } from "vitest";
+import { Id } from "@superego/shared-utils";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import SqliteDataRepositoriesManager from "./SqliteDataRepositoriesManager.js";
 
 const databasesTmpDir = join(
   tmpdir(),
   "superego-sqlite-data-repositories-tests",
 );
+const defaultGlobalSettings = {
+  appearance: { theme: Theme.Auto },
+  inference: {
+    providers: [],
+    defaultInferenceOptions: {
+      completion: null,
+      transcription: null,
+      fileInspection: null,
+    },
+  },
+  assistants: {
+    userInfo: null,
+    userPreferences: null,
+    developerPrompts: {
+      [AssistantName.Factotum]: null,
+      [AssistantName.CollectionCreator]: null,
+    },
+  },
+};
 
 beforeAll(() => {
   mkdirSync(databasesTmpDir, { recursive: true });
@@ -21,27 +42,46 @@ afterAll(() => {
 registerDataRepositoriesTests(() => {
   const dataRepositoriesManager = new SqliteDataRepositoriesManager({
     fileName: join(databasesTmpDir, `${crypto.randomUUID()}.sqlite`),
-    defaultGlobalSettings: {
-      appearance: { theme: Theme.Auto },
-      inference: {
-        providers: [],
-        defaultInferenceOptions: {
-          completion: null,
-          transcription: null,
-          fileInspection: null,
-        },
-      },
-      assistants: {
-        userInfo: null,
-        userPreferences: null,
-        developerPrompts: {
-          [AssistantName.Factotum]: null,
-          [AssistantName.CollectionCreator]: null,
-        },
-      },
-    },
+    defaultGlobalSettings,
     enableForeignKeyConstraints: false,
   });
   dataRepositoriesManager.runMigrations();
   return { dataRepositoriesManager };
+});
+
+it("returns a clear error when SQLite is locked", async () => {
+  // Setup SUT
+  const fileName = join(databasesTmpDir, `${crypto.randomUUID()}.sqlite`);
+  const dataRepositoriesManager = new SqliteDataRepositoriesManager({
+    fileName,
+    defaultGlobalSettings,
+    enableForeignKeyConstraints: false,
+  });
+  dataRepositoriesManager.runMigrations();
+  const lockDb = new DatabaseSync(fileName);
+  lockDb.exec("PRAGMA journal_mode = WAL");
+  lockDb.exec("BEGIN IMMEDIATE");
+  const collectionCategory = {
+    id: Id.generate.collectionCategory(),
+    name: "name",
+    icon: null,
+    parentId: null,
+    createdAt: new Date(),
+  };
+
+  try {
+    // Exercise
+    const promise = dataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => {
+        await repos.collectionCategory.insert(collectionCategory);
+        return { action: "commit", returnValue: null };
+      },
+    );
+
+    // Verify
+    await expect(promise).rejects.toThrow("SQLite database is locked.");
+  } finally {
+    lockDb.exec("ROLLBACK");
+    lockDb.close();
+  }
 });

--- a/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.ts
+++ b/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.ts
@@ -30,15 +30,16 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
     ) => Promise<{ action: "commit" | "rollback"; returnValue: ReturnValue }>,
   ): Promise<ReturnValue> {
     const transactionSucceededCallbacks: (() => void)[] = [];
-    const db = this.openDb();
-    db.exec("BEGIN");
-    const repos = new SqliteDataRepositories(
-      db,
-      this.options.defaultGlobalSettings,
-      this.searchTextIndexStates,
-      (callback) => transactionSucceededCallbacks.push(callback),
-    );
+    let db: DatabaseSync | null = null;
     try {
+      db = this.openDb();
+      db.exec("BEGIN");
+      const repos = new SqliteDataRepositories(
+        db,
+        this.options.defaultGlobalSettings,
+        this.searchTextIndexStates,
+        (callback) => transactionSucceededCallbacks.push(callback),
+      );
       const { action, returnValue } = await fn(repos);
       db.exec(action === "commit" ? "COMMIT" : "ROLLBACK");
       if (action === "commit") {
@@ -48,27 +49,37 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
       }
       return returnValue;
     } catch (error) {
-      if (db.isTransaction) {
+      if (db?.isTransaction) {
         db.exec("ROLLBACK");
       }
-      throw error;
+      throw toSqliteLockedError(error);
     } finally {
-      db.close();
+      db?.close();
     }
   }
 
   runMigrations(): void {
     const db = this.openDb();
-    migrate(db);
-    db.close();
+    try {
+      migrate(db);
+    } catch (error) {
+      throw toSqliteLockedError(error);
+    } finally {
+      db.close();
+    }
   }
 
   private openDb() {
     const { fileName, enableForeignKeyConstraints = true } = this.options;
     const db = new DatabaseSync(fileName, { enableForeignKeyConstraints });
-    db.exec("PRAGMA journal_mode = WAL");
-    db.exec("PRAGMA synchronous = FULL");
-    return db;
+    try {
+      db.exec("PRAGMA journal_mode = WAL");
+      db.exec("PRAGMA synchronous = FULL");
+      return db;
+    } catch (error) {
+      db.close();
+      throw toSqliteLockedError(error);
+    }
   }
 
   private static runTransactionSucceededCallbacks(callbacks: (() => void)[]) {
@@ -83,4 +94,28 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
       }
     });
   }
+}
+
+function toSqliteLockedError(error: unknown): unknown {
+  if (!isSqliteLockedError(error)) {
+    return error;
+  }
+  return new Error(
+    "SQLite database is locked. Superego app and CLI share one SQLite database; avoid parallel Superego CLI commands and retry after the current Superego operation finishes.",
+    { cause: error },
+  );
+}
+
+function isSqliteLockedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const message = "message" in error ? String(error.message) : "";
+  const code = "code" in error ? String(error.code) : "";
+  return (
+    code === "SQLITE_BUSY" ||
+    code === "SQLITE_LOCKED" ||
+    message.includes("database is locked") ||
+    message.includes("database table is locked")
+  );
 }

--- a/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.ts
+++ b/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.ts
@@ -8,6 +8,7 @@ import migrate from "./migrations/migrate.js";
 import SqliteConversationTextSearchIndex from "./repositories/SqliteConversationTextSearchIndex.js";
 import SqliteDocumentTextSearchIndex from "./repositories/SqliteDocumentTextSearchIndex.js";
 import SqliteDataRepositories from "./SqliteDataRepositories.js";
+import toSqliteLockedError from "./toSqliteLockedError.js";
 
 export default class SqliteDataRepositoriesManager implements DataRepositoriesManager {
   private searchTextIndexStates = {
@@ -30,16 +31,15 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
     ) => Promise<{ action: "commit" | "rollback"; returnValue: ReturnValue }>,
   ): Promise<ReturnValue> {
     const transactionSucceededCallbacks: (() => void)[] = [];
-    let db: DatabaseSync | null = null;
+    const db = this.openDb();
+    db.exec("BEGIN");
+    const repos = new SqliteDataRepositories(
+      db,
+      this.options.defaultGlobalSettings,
+      this.searchTextIndexStates,
+      (callback) => transactionSucceededCallbacks.push(callback),
+    );
     try {
-      db = this.openDb();
-      db.exec("BEGIN");
-      const repos = new SqliteDataRepositories(
-        db,
-        this.options.defaultGlobalSettings,
-        this.searchTextIndexStates,
-        (callback) => transactionSucceededCallbacks.push(callback),
-      );
       const { action, returnValue } = await fn(repos);
       db.exec(action === "commit" ? "COMMIT" : "ROLLBACK");
       if (action === "commit") {
@@ -49,12 +49,12 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
       }
       return returnValue;
     } catch (error) {
-      if (db?.isTransaction) {
+      if (db.isTransaction) {
         db.exec("ROLLBACK");
       }
       throw toSqliteLockedError(error);
     } finally {
-      db?.close();
+      db.close();
     }
   }
 
@@ -94,28 +94,4 @@ export default class SqliteDataRepositoriesManager implements DataRepositoriesMa
       }
     });
   }
-}
-
-function toSqliteLockedError(error: unknown): unknown {
-  if (!isSqliteLockedError(error)) {
-    return error;
-  }
-  return new Error(
-    "SQLite database is locked. Superego app and CLI share one SQLite database; avoid parallel Superego CLI commands and retry after the current Superego operation finishes.",
-    { cause: error },
-  );
-}
-
-function isSqliteLockedError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-  const message = "message" in error ? String(error.message) : "";
-  const code = "code" in error ? String(error.code) : "";
-  return (
-    code === "SQLITE_BUSY" ||
-    code === "SQLITE_LOCKED" ||
-    message.includes("database is locked") ||
-    message.includes("database table is locked")
-  );
 }

--- a/packages/data/sqlite-data-repositories/src/toSqliteLockedError.ts
+++ b/packages/data/sqlite-data-repositories/src/toSqliteLockedError.ts
@@ -2,10 +2,7 @@ export default function toSqliteLockedError(error: unknown): unknown {
   if (!isSqliteLockedError(error)) {
     return error;
   }
-  return new Error(
-    "SQLite database is locked. Avoid parallel Superego CLI commands.",
-    { cause: error },
-  );
+  return new Error("SQLite database is locked.", { cause: error });
 }
 
 function isSqliteLockedError(error: unknown): boolean {

--- a/packages/data/sqlite-data-repositories/src/toSqliteLockedError.ts
+++ b/packages/data/sqlite-data-repositories/src/toSqliteLockedError.ts
@@ -1,0 +1,23 @@
+export default function toSqliteLockedError(error: unknown): unknown {
+  if (!isSqliteLockedError(error)) {
+    return error;
+  }
+  return new Error(
+    "SQLite database is locked. Avoid parallel Superego CLI commands.",
+    { cause: error },
+  );
+}
+
+function isSqliteLockedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const message = "message" in error ? String(error.message) : "";
+  const code = "code" in error ? String(error.code) : "";
+  return (
+    code === "SQLITE_BUSY" ||
+    code === "SQLITE_LOCKED" ||
+    message.includes("database is locked") ||
+    message.includes("database table is locked")
+  );
+}

--- a/packages/tests/backend-e2e-tests/src/suites/collections.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/collections.ts
@@ -110,6 +110,70 @@ export default rd<GetDependencies>("Collections", (deps) => {
       });
     });
 
+    it("atomicity: no collections created if one fails validation", async () => {
+      // Setup SUT
+      const { backend } = deps();
+
+      // Exercise
+      const result = await backend.collections.createMany([
+        {
+          settings: {
+            name: "valid collection",
+            icon: null,
+            collectionCategoryId: null,
+            defaultCollectionViewAppId: null,
+            description: null,
+            assistantInstructions: null,
+            redirectToCollectionAfterDocumentCreation: false,
+          },
+          schema: {
+            types: { Root: { dataType: DataType.Struct, properties: {} } },
+            rootType: "Root",
+          },
+          versionSettings: {
+            contentBlockingKeysGetter: null,
+            contentSummaryGetter: {
+              source: "",
+              compiled:
+                "export default function getContentSummary() { return {}; }",
+            },
+            defaultDocumentViewUiOptions: null,
+          },
+        },
+        {
+          settings: {
+            name: "",
+            icon: null,
+            collectionCategoryId: null,
+            defaultCollectionViewAppId: null,
+            description: null,
+            assistantInstructions: null,
+            redirectToCollectionAfterDocumentCreation: false,
+          },
+          schema: {
+            types: { Root: { dataType: DataType.Struct, properties: {} } },
+            rootType: "Root",
+          },
+          versionSettings: {
+            contentBlockingKeysGetter: null,
+            contentSummaryGetter: {
+              source: "",
+              compiled:
+                "export default function getContentSummary() { return {}; }",
+            },
+            defaultDocumentViewUiOptions: null,
+          },
+        },
+      ]);
+
+      // Verify
+      expect(result.success).toBe(false);
+      expect(result.error?.name).toBe("CollectionSettingsNotValid");
+      const listResult = await backend.collections.list();
+      assert.isTrue(listResult.success);
+      expect(listResult.data).toHaveLength(0);
+    });
+
     it("error: CollectionCategoryNotFound", async () => {
       // Setup SUT
       const { backend } = deps();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6781,8 +6781,10 @@ __metadata:
     "@superego/shared-utils": "workspace:*"
     "@superego/sqlite-data-repositories": "workspace:*"
     "@superego/tsc-typescript-compiler": "workspace:*"
+    "@types/mime-types": "npm:^3.0.1"
     "@valibot/to-json-schema": "npm:^1.7.0"
     commander: "npm:^14.0.3"
+    mime-types: "npm:^3.0.2"
     typescript: "npm:^6.0.3"
     valibot: "npm:^1.4.0"
   languageName: unknown
@@ -8645,6 +8647,13 @@ __metadata:
   version: 2.0.13
   resolution: "@types/mdx@npm:2.0.13"
   checksum: 10c0/5edf1099505ac568da55f9ae8a93e7e314e8cbc13d3445d0be61b75941226b005e1390d9b95caecf5dcb00c9d1bab2f1f60f6ff9876dc091a48b547495007720
+  languageName: node
+  linkType: hard
+
+"@types/mime-types@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@types/mime-types@npm:3.0.1"
+  checksum: 10c0/61c2056529dc5bc73c25b2a053e21f063fd547c21e12a2be94ca78b89b0f83c9a75afed9a8bda3c78592ee880acc82778302651527f7882cf5ba8e58ab320e29
   languageName: node
   linkType: hard
 
@@ -15316,12 +15325,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.25, mime-types@npm:^2.1.27":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Move non-user-facing CLI commands with inputs to `--args <file>` JSON input.
- Add args-file `$file` placeholder expansion for document writes.
- Make `agents install-skill` user-facing plain text output.
- Clarify SQLite lock failures and document safe agent/CLI rules.
- Document and test create-many atomicity.

## Validation

- `yarn workspace @superego/cli run check-types`
- `yarn workspace @superego/sqlite-data-repositories run check-types`
- `yarn workspace @superego/backend-e2e-tests run check-types`
- `yarn workspace @superego/sqlite-data-repositories run test -- SqliteDataRepositoriesManager.test.ts`
- `yarn workspace @superego/backend-e2e-tests run test -- collections`
- `yarn fix-formatting`
- `yarn check-formatting`
- `yarn check-types`
- `yarn check-linting`
- `git diff --check`
