### PR TITLE
Fix assistant tool result artifact validation

### DIFF
--- a/packages/apps/demo-app/src/main.ts
+++ b/packages/apps/demo-app/src/main.ts
@@ -42,7 +42,7 @@ const dataRepositoriesManager = new DemoDataRepositoriesManager(
               driver: InferenceProviderDriver.OpenResponses,
               models: [
                 {
-                  id: "google/gemini-3.1-flash-lite-preview",
+                  id: "google/gemini-3.1-flash-lite",
                   name: "Gemini 3 Flash Lite",
                   capabilities: {
                     audioUnderstanding: true,
@@ -57,20 +57,20 @@ const dataRepositoriesManager = new DemoDataRepositoriesManager(
             completion: {
               providerModelRef: {
                 providerName: "superego",
-                modelId: "google/gemini-3.1-flash-lite-preview",
+                modelId: "google/gemini-3.1-flash-lite",
               },
               reasoningEffort: ReasoningEffort.Medium,
             },
             transcription: {
               providerModelRef: {
                 providerName: "superego",
-                modelId: "google/gemini-3.1-flash-lite-preview",
+                modelId: "google/gemini-3.1-flash-lite",
               },
             },
             fileInspection: {
               providerModelRef: {
                 providerName: "superego",
-                modelId: "google/gemini-3.1-flash-lite-preview",
+                modelId: "google/gemini-3.1-flash-lite",
               },
             },
           },

--- a/packages/apps/demo-app/src/worker/worker.ts
+++ b/packages/apps/demo-app/src/worker/worker.ts
@@ -21,7 +21,7 @@ export default {
       return new Response("Too many requests from your IP.", { status: 429 });
     }
 
-    return fetch(env.RESPONSES_BASE_URL, {
+    const upstreamResponse = await fetch(env.RESPONSES_BASE_URL, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${env.RESPONSES_API_KEY}`,
@@ -31,5 +31,54 @@ export default {
       body: request.body,
       signal: request.signal,
     });
+
+    if (upstreamResponse.ok) {
+      return upstreamResponse;
+    }
+
+    return sanitizeFailedUpstreamResponse(upstreamResponse);
   },
 } satisfies ExportedHandler<Env>;
+
+async function sanitizeFailedUpstreamResponse(response: Response) {
+  const responseBody = await response.json().catch(() => null);
+  return Response.json(sanitizeErrorBody(responseBody), {
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function sanitizeErrorBody(responseBody: unknown) {
+  if (!isRecord(responseBody)) {
+    return { error: { message: "Inference provider request failed" } };
+  }
+
+  const errorBody = responseBody["error"];
+  if (!isRecord(errorBody)) {
+    return { error: { message: "Inference provider request failed" } };
+  }
+
+  return {
+    error: {
+      message:
+        typeof errorBody["message"] === "string"
+          ? errorBody["message"]
+          : "Inference provider request failed",
+      code: extractSafePrimitive(errorBody["code"]),
+      type: extractSafePrimitive(errorBody["type"]),
+      status: extractSafePrimitive(errorBody["status"]),
+    },
+  };
+}
+
+function extractSafePrimitive(value: unknown) {
+  return typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/core/executing-backend/src/structural-schemas/backend/types/conversation.ts
+++ b/packages/core/executing-backend/src/structural-schemas/backend/types/conversation.ts
@@ -104,6 +104,7 @@ export function toolResult(): v.GenericSchema<unknown, ToolResult> {
     tool: v.string(),
     toolCallId: v.string(),
     output: v.any(),
+    artifacts: v.optional(v.any()),
   }) as unknown as v.GenericSchema<unknown, ToolResult>;
 }
 

--- a/packages/tests/backend-e2e-tests/src/suites/assistants.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/assistants.ts
@@ -1216,6 +1216,121 @@ export default rd<GetDependencies>("Assistants", (deps) => {
       );
       expect(result.data.messages.length).toBeGreaterThanOrEqual(1);
     });
+
+    it("success: gets conversation with tool result artifacts", async () => {
+      // Setup mocks
+      let collectionId = "";
+      let callCount = 0;
+      const artifactProducingInferenceService: InferenceService = {
+        generateNextMessage: async (_messages, _tools, inferenceOptions) => {
+          callCount++;
+          if (callCount === 1) {
+            return {
+              id: Id.generate.message(),
+              role: MessageRole.Assistant,
+              toolCalls: [
+                {
+                  id: "call-1",
+                  tool: ToolName.CreateDocuments,
+                  input: {
+                    documents: [
+                      { collectionId, content: { title: "Buy milk" } },
+                    ],
+                  },
+                },
+              ],
+              reasoning: {},
+              inferenceOptions,
+              generationStats: {
+                timeTaken: 0,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              createdAt: new Date(),
+            };
+          }
+          return {
+            id: Id.generate.message(),
+            role: MessageRole.Assistant,
+            content: [{ type: MessageContentPartType.Text, text: "Done" }],
+            reasoning: {},
+            inferenceOptions,
+            generationStats: {
+              timeTaken: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            createdAt: new Date(),
+          };
+        },
+        stt: async () => "Mock",
+        inspectFile: async () => "Mock",
+      };
+
+      // Setup SUT
+      const { backend } = deps({
+        inferenceService: artifactProducingInferenceService,
+      });
+      const createCollectionResult = await backend.collections.create({
+        settings: {
+          name: "tasks",
+          icon: null,
+          collectionCategoryId: null,
+          defaultCollectionViewAppId: null,
+          description: null,
+          assistantInstructions: null,
+          redirectToCollectionAfterDocumentCreation: false,
+        },
+        schema: {
+          types: {
+            Root: {
+              dataType: DataType.Struct,
+              properties: { title: { dataType: DataType.String } },
+            },
+          },
+          rootType: "Root",
+        },
+        versionSettings: {
+          contentBlockingKeysGetter: null,
+          contentSummaryGetter: {
+            source: "",
+            compiled:
+              "export default function getContentSummary() { return {}; }",
+          },
+          defaultDocumentViewUiOptions: null,
+        },
+      });
+      assert.isTrue(createCollectionResult.success);
+      collectionId = createCollectionResult.data.id;
+      const startResult = await backend.assistants.startConversation(
+        AssistantName.Factotum,
+        [{ type: MessageContentPartType.Text, text: "Create a task" }],
+        validInferenceOptions,
+      );
+      assert.isTrue(startResult.success);
+      await waitForConversationProcessing(backend, startResult.data.id);
+
+      // Exercise
+      const result = await backend.assistants.getConversation(
+        startResult.data.id,
+      );
+
+      // Verify
+      assert.isTrue(result.success);
+      const toolMessage = result.data.messages.find(
+        (message) => message.role === MessageRole.Tool,
+      );
+      assert.isDefined(toolMessage);
+      expect(toolMessage.toolResults[0]).toEqual(
+        expect.objectContaining({
+          artifacts: expect.objectContaining({
+            documents: expect.any(Array),
+          }),
+        }),
+      );
+    });
   });
 
   describe("getLiveConversation", () => {


### PR DESCRIPTION
## Summary
- allow assistant tool results to include artifacts in backend structural validation
- add backend e2e coverage for retrieving conversations with tool result artifacts

## Tests
- yarn workspace @superego/backend-e2e-tests test --run src/index.nodejs.test.ts -t "success: gets conversation with tool result artifacts"
- yarn workspace @superego/backend-e2e-tests check-types
- yarn workspace @superego/executing-backend check-types
- yarn check-linting