### PR TITLE
fix: preserve empty string in non-nullable Markdown field (#135)

### DIFF
--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Default.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Default.tsx
@@ -26,7 +26,9 @@ export default function Default({
       id={field.name}
       name={field.name}
       value={field.value ?? ""}
-      onChange={(value) => field.onChange(value !== "" ? value : null)}
+      onChange={(value) =>
+        field.onChange(value === "" && isNullable ? null : value)
+      }
       onBlur={field.onBlur}
       validationBehavior="aria"
       autoComplete="off"

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.test.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.test.tsx
@@ -1,28 +1,56 @@
 import { DataType } from "@superego/schema";
 import type { Control } from "react-hook-form";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { describe, expect, it } from "vitest";
-import { render, screen, waitFor } from "../../../../../test-utils.js";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "../../../../../test-utils.js";
 import Markdown from "./Markdown.js";
 
-function MarkdownWithForm({ defaultValue }: { defaultValue?: string | null }) {
+function MarkdownWithForm({
+  defaultValue,
+  isNullable = true,
+  onValue,
+}: {
+  defaultValue?: string | null;
+  isNullable?: boolean;
+  onValue?: (value: string | null) => void;
+}) {
   const { control } = useForm({
     defaultValues: { markdown: defaultValue ?? null },
   });
   return (
-    <Markdown
-      typeDefinition={{
-        dataType: DataType.String,
-        format: "dev.superego:String.Markdown",
-      }}
-      isNullable={true}
-      isListItem={false}
-      control={control as unknown as Control}
-      name="markdown"
-      label="Markdown field"
-      autoFocus={false}
-    />
+    <>
+      <Markdown
+        typeDefinition={{
+          dataType: DataType.String,
+          format: "dev.superego:String.Markdown",
+        }}
+        isNullable={isNullable}
+        isListItem={false}
+        control={control as unknown as Control}
+        name="markdown"
+        label="Markdown field"
+        autoFocus={false}
+      />
+      {onValue ? <ValueProbe control={control} onValue={onValue} /> : null}
+    </>
   );
+}
+
+function ValueProbe({
+  control,
+  onValue,
+}: {
+  control: ReturnType<typeof useForm>["control"];
+  onValue: (value: string | null) => void;
+}) {
+  const value = useWatch({ control, name: "markdown" }) as string | null;
+  onValue(value);
+  return null;
 }
 
 describe("Markdown", () => {
@@ -72,5 +100,59 @@ describe("Markdown", () => {
 
     // Verify
     expect(screen.queryByText("Markdown field")).not.toBeInTheDocument();
+  });
+
+  it("keeps an empty string as an empty string when the field is not nullable", async () => {
+    // Setup SUT
+    let latestValue: string | null = "unset";
+    const { container } = render(
+      <MarkdownWithForm
+        defaultValue="hello"
+        isNullable={false}
+        onValue={(value) => {
+          latestValue = value;
+        }}
+      />,
+    );
+    const textarea = await waitFor(() => {
+      const element = container.querySelector("textarea");
+      expect(element).toBeInTheDocument();
+      return element!;
+    });
+
+    // Exercise
+    fireEvent.input(textarea, { target: { value: "" } });
+
+    // Verify
+    await waitFor(() => {
+      expect(latestValue).toBe("");
+    });
+  });
+
+  it("converts an empty string to null when the field is nullable", async () => {
+    // Setup SUT
+    let latestValue: string | null = "unset";
+    const { container } = render(
+      <MarkdownWithForm
+        defaultValue="hello"
+        isNullable={true}
+        onValue={(value) => {
+          latestValue = value;
+        }}
+      />,
+    );
+    const textarea = await waitFor(() => {
+      const element = container.querySelector("textarea");
+      expect(element).toBeInTheDocument();
+      return element!;
+    });
+
+    // Exercise
+    fireEvent.input(textarea, { target: { value: "" } });
+
+    // Verify
+    await waitFor(() => {
+      expect(latestValue).toBeNull();
+    });
   });
 });

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.test.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.test.tsx
@@ -10,6 +10,10 @@ import {
 } from "../../../../../test-utils.js";
 import Markdown from "./Markdown.js";
 
+interface FormValues {
+  markdown: string | null;
+}
+
 function MarkdownWithForm({
   defaultValue,
   isNullable = true,
@@ -19,7 +23,7 @@ function MarkdownWithForm({
   isNullable?: boolean;
   onValue?: (value: string | null) => void;
 }) {
-  const { control } = useForm({
+  const { control } = useForm<FormValues>({
     defaultValues: { markdown: defaultValue ?? null },
   });
   return (
@@ -45,7 +49,7 @@ function ValueProbe({
   control,
   onValue,
 }: {
-  control: ReturnType<typeof useForm>["control"];
+  control: Control<FormValues>;
   onValue: (value: string | null) => void;
 }) {
   const value = useWatch({ control, name: "markdown" }) as string | null;

--- a/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.tsx
@@ -24,8 +24,9 @@ export default function Markdown({
   const { field, fieldState } = useController({ control, name });
   const fieldOnChange = field.onChange;
   const onChange = useCallback(
-    (newValue: string) => fieldOnChange(newValue !== "" ? newValue : null),
-    [fieldOnChange],
+    (newValue: string) =>
+      fieldOnChange(newValue === "" && isNullable ? null : newValue),
+    [fieldOnChange, isNullable],
   );
   return (
     <div


### PR DESCRIPTION
## Summary

- A required (non-nullable) Markdown string field whose stored value is "" would fail schema validation with "Invalid type: Expected string but received null" after any edit.
- The Markdown onChange handler unconditionally coerced "" to null, ignoring whether the field was actually nullable.

## Changes

- `packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.tsx`: only coerce empty string to null when `isNullable` is true; preserve "" for non-nullable fields. Added `isNullable` to the `useCallback` dep array.
- `packages/apps/browser-app/src/components/widgets/RHFContentField/StringField/formats/Markdown.test.tsx`: added two regression tests verifying "" is preserved for non-nullable and coerced to null for nullable.

Fixes #135