### PR TITLE
[codex] Add frontmatter to generated skills

### DIFF
--- a/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
+++ b/packages/apps/cli/src/commands/agents/install-skill/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: superego-cli
+description:
+  Use when working with the local Superego database through the `superego` CLI.
+---
+
 # Superego CLI
 
 Superego is a local-first personal database. It stores collections, documents,

--- a/packages/apps/cli/src/commands/apps/common/agent-files/writing-superego-apps.md
+++ b/packages/apps/cli/src/commands/apps/common/agent-files/writing-superego-apps.md
@@ -1,3 +1,10 @@
+---
+name: writing-superego-apps
+description:
+  Use when writing Superego collection-view apps in generated app project
+  checkouts.
+---
+
 # Writing Superego Apps
 
 Superego apps are single-entrypoint collection-view apps.


### PR DESCRIPTION
## Summary

- add Codex-required YAML frontmatter to the installed Superego CLI skill
- add Codex-required YAML frontmatter to the generated app-project writing skill

Fixes #139.

## Root cause

Superego copied Markdown skill templates verbatim into agent skill directories, but the templates did not include the `name` and `description` frontmatter Codex uses when loading skills.

## Validation

- `yarn fix-formatting`
- YAML metadata parse check for both skill sources
- `yarn workspace @superego/cli run check-types`
- `yarn check-formatting`
- `yarn check-linting`
