### PR TITLE
[codex] Compact CLI write success output

### DIFF
--- a/packages/apps/cli/package.json
+++ b/packages/apps/cli/package.json
@@ -9,7 +9,8 @@
     }
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest --reporter=verbose"
   },
   "dependencies": {
     "@superego/app-sandbox": "workspace:*",
@@ -28,6 +29,7 @@
     "valibot": "^1.4.1"
   },
   "devDependencies": {
-    "@types/mime-types": "^3.0.1"
+    "@types/mime-types": "^3.0.1",
+    "vitest": "^4.1.7"
   }
 }

--- a/packages/apps/cli/src/additional-notes.md
+++ b/packages/apps/cli/src/additional-notes.md
@@ -140,3 +140,10 @@ a JSON object keyed by camelCase argument names.
   database.
 - Use `collections get-typescript-schema` before writing document content or
   TypeScript functions for a collection.
+
+#### JSON Outputs
+
+Commands print a JSON result envelope with `success`, `data`, and `error`.
+Successful object write commands return compact identity/version summaries. Use
+read commands such as `documents get` and `collections get` when you need the
+full object.

--- a/packages/apps/cli/src/commands/collection-categories/create/create.ts
+++ b/packages/apps/cli/src/commands/collection-categories/create/create.ts
@@ -1,5 +1,6 @@
 import { CollectionCategoriesCreate } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollectionCategory } from "../../../utils/successSummaries.js";
 
 export default createBackendCommand({
   name: "create",
@@ -9,4 +10,5 @@ export default createBackendCommand({
   arguments: [
     { name: "definition", description: "Collection category definition" },
   ],
+  summarizeSuccessData: summarizeCollectionCategory,
 });

--- a/packages/apps/cli/src/commands/collection-categories/update/update.ts
+++ b/packages/apps/cli/src/commands/collection-categories/update/update.ts
@@ -1,5 +1,6 @@
 import { CollectionCategoriesUpdate } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollectionCategory } from "../../../utils/successSummaries.js";
 
 export default createBackendCommand({
   name: "update",
@@ -10,4 +11,5 @@ export default createBackendCommand({
     { name: "id", description: "Collection category id" },
     { name: "patch", description: "Collection category patch" },
   ],
+  summarizeSuccessData: summarizeCollectionCategory,
 });

--- a/packages/apps/cli/src/commands/collections/create-many/create-many.ts
+++ b/packages/apps/cli/src/commands/collections/create-many/create-many.ts
@@ -1,5 +1,6 @@
 import { CollectionsCreateMany } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollections } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -11,4 +12,5 @@ export default createBackendCommand({
     { name: "definitions", description: "Collection definitions array" },
   ],
   additionalNotes,
+  summarizeSuccessData: summarizeCollections,
 });

--- a/packages/apps/cli/src/commands/collections/create-new-version/create-new-version.ts
+++ b/packages/apps/cli/src/commands/collections/create-new-version/create-new-version.ts
@@ -1,5 +1,6 @@
 import { CollectionsCreateNewVersion } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollection } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -16,4 +17,5 @@ export default createBackendCommand({
     { name: "migration", description: "Collection migration module" },
   ],
   additionalNotes,
+  summarizeSuccessData: summarizeCollection,
 });

--- a/packages/apps/cli/src/commands/collections/create/create.ts
+++ b/packages/apps/cli/src/commands/collections/create/create.ts
@@ -1,5 +1,6 @@
 import { CollectionsCreate } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollection } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -9,4 +10,5 @@ export default createBackendCommand({
   getCall: (backend) => backend.collections.create,
   arguments: [{ name: "definition", description: "Collection definition" }],
   additionalNotes,
+  summarizeSuccessData: summarizeCollection,
 });

--- a/packages/apps/cli/src/commands/collections/update-latest-version-settings/update-latest-version-settings.ts
+++ b/packages/apps/cli/src/commands/collections/update-latest-version-settings/update-latest-version-settings.ts
@@ -1,5 +1,6 @@
 import { CollectionsUpdateLatestVersionSettings } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollection } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -16,4 +17,5 @@ export default createBackendCommand({
     },
   ],
   additionalNotes,
+  summarizeSuccessData: summarizeCollection,
 });

--- a/packages/apps/cli/src/commands/collections/update-settings/update-settings.ts
+++ b/packages/apps/cli/src/commands/collections/update-settings/update-settings.ts
@@ -1,5 +1,6 @@
 import { CollectionsUpdateSettings } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeCollection } from "../../../utils/successSummaries.js";
 
 export default createBackendCommand({
   name: "update-settings",
@@ -10,4 +11,5 @@ export default createBackendCommand({
     { name: "id", description: "Collection id" },
     { name: "settings-patch", description: "Collection settings patch" },
   ],
+  summarizeSuccessData: summarizeCollection,
 });

--- a/packages/apps/cli/src/commands/documents/create-many/create-many.ts
+++ b/packages/apps/cli/src/commands/documents/create-many/create-many.ts
@@ -1,5 +1,6 @@
 import { DocumentsCreateMany } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeDocuments } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -11,4 +12,5 @@ export default createBackendCommand({
     { name: "definitions", description: "Document definitions array" },
   ],
   additionalNotes,
+  summarizeSuccessData: summarizeDocuments,
 });

--- a/packages/apps/cli/src/commands/documents/create-new-version/create-new-version.ts
+++ b/packages/apps/cli/src/commands/documents/create-new-version/create-new-version.ts
@@ -1,5 +1,6 @@
 import { DocumentsCreateNewVersion } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeDocument } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -14,4 +15,5 @@ export default createBackendCommand({
     { name: "content-change", description: "Document content change" },
   ],
   additionalNotes,
+  summarizeSuccessData: summarizeDocument,
 });

--- a/packages/apps/cli/src/commands/documents/create/create.ts
+++ b/packages/apps/cli/src/commands/documents/create/create.ts
@@ -1,5 +1,6 @@
 import { DocumentsCreate } from "@superego/executing-backend";
 import createBackendCommand from "../../../utils/createBackendCommand.js";
+import { summarizeDocument } from "../../../utils/successSummaries.js";
 import additionalNotes from "./additional-notes.md?raw";
 
 export default createBackendCommand({
@@ -9,4 +10,5 @@ export default createBackendCommand({
   getCall: (backend) => backend.documents.create,
   arguments: [{ name: "definition", description: "Document definition" }],
   additionalNotes,
+  summarizeSuccessData: summarizeDocument,
 });

--- a/packages/apps/cli/src/utils/createBackendCommand.ts
+++ b/packages/apps/cli/src/utils/createBackendCommand.ts
@@ -6,10 +6,18 @@ import { useMarkdownHelp } from "./markdownHelp.js";
 import { runCommand, unsuccessfulResult } from "./results.js";
 
 type CliBackend = Awaited<ReturnType<typeof createBackend>>;
-type BackendCall = (...args: any[]) => Promise<{ success: boolean }>;
 type BackendUsecaseClass = new (...args: any[]) => {
   argumentsSchema: v.GenericSchema<unknown, any[]>;
+  exec: (...args: any[]) => Promise<{ success: boolean; data: unknown }>;
 };
+type SuccessData<UsecaseClass extends BackendUsecaseClass> = Extract<
+  Awaited<ReturnType<InstanceType<UsecaseClass>["exec"]>>,
+  { success: true }
+>["data"];
+type BackendCall = (...args: any[]) => Promise<{
+  success: boolean;
+  data?: unknown;
+}>;
 type TupleSchemaWithItems = v.GenericSchema<unknown, any[]> & {
   items?: v.GenericSchema<unknown, unknown>[];
 };
@@ -21,23 +29,27 @@ interface BackendCommandArgument {
   fixedValue?: unknown;
 }
 
-interface BackendCommandOptions {
+interface BackendCommandOptions<UsecaseClass extends BackendUsecaseClass> {
   name: string;
   description: string;
-  UsecaseClass: BackendUsecaseClass;
+  UsecaseClass: UsecaseClass;
   getCall: (backend: CliBackend) => BackendCall;
   arguments?: BackendCommandArgument[];
   additionalNotes?: string;
+  summarizeSuccessData?: (data: SuccessData<UsecaseClass>) => unknown;
 }
 
-export default function createBackendCommand({
+export default function createBackendCommand<
+  UsecaseClass extends BackendUsecaseClass,
+>({
   name,
   description,
   UsecaseClass,
   getCall,
   arguments: commandArguments = [],
   additionalNotes,
-}: BackendCommandOptions): Command {
+  summarizeSuccessData,
+}: BackendCommandOptions<UsecaseClass>): Command {
   let command = new Command(name).description(description);
 
   if (hasInputArguments(commandArguments)) {
@@ -78,7 +90,17 @@ export default function createBackendCommand({
         });
       }
 
-      return getCall(await createBackend())(...validationResult.output);
+      const result = await getCall(await createBackend())(
+        ...validationResult.output,
+      );
+      return result.success && summarizeSuccessData
+        ? {
+            ...result,
+            data: summarizeSuccessData(
+              result.data as SuccessData<UsecaseClass>,
+            ),
+          }
+        : result;
     });
   });
 

--- a/packages/apps/cli/src/utils/successSummaries.test.ts
+++ b/packages/apps/cli/src/utils/successSummaries.test.ts
@@ -1,0 +1,186 @@
+import { DocumentVersionCreator } from "@superego/backend";
+import type {
+  Collection,
+  CollectionCategory,
+  Document,
+} from "@superego/backend";
+import { describe, expect, it } from "vitest";
+import {
+  summarizeCollection,
+  summarizeCollectionCategory,
+  summarizeCollections,
+  summarizeDocument,
+  summarizeDocuments,
+} from "./successSummaries.js";
+
+describe("successSummaries", () => {
+  it("summarizes documents without content or timestamps", () => {
+    // Setup SUT
+    const document = makeDocument();
+
+    // Exercise
+    const summary = summarizeDocument(document);
+
+    // Verify
+    expect(summary).toEqual({
+      id: "Document_1",
+      collectionId: "Collection_1",
+      latestVersionId: "DocumentVersion_2",
+      previousVersionId: "DocumentVersion_1",
+      collectionVersionId: "CollectionVersion_1",
+    });
+    expect(summary).not.toHaveProperty("latestVersion");
+    expect(summary).not.toHaveProperty("createdAt");
+  });
+
+  it("summarizes document arrays", () => {
+    // Setup SUT
+    const documents = [
+      makeDocument({
+        id: "Document_1",
+        latestVersionId: "DocumentVersion_1",
+      }),
+      makeDocument({
+        id: "Document_2",
+        latestVersionId: "DocumentVersion_2",
+      }),
+    ];
+
+    // Exercise
+    const summaries = summarizeDocuments(documents);
+
+    // Verify
+    expect(summaries).toEqual([
+      {
+        id: "Document_1",
+        collectionId: "Collection_1",
+        latestVersionId: "DocumentVersion_1",
+        previousVersionId: "DocumentVersion_1",
+        collectionVersionId: "CollectionVersion_1",
+      },
+      {
+        id: "Document_2",
+        collectionId: "Collection_1",
+        latestVersionId: "DocumentVersion_2",
+        previousVersionId: "DocumentVersion_1",
+        collectionVersionId: "CollectionVersion_1",
+      },
+    ]);
+  });
+
+  it("summarizes collections without schema, settings, migration, or timestamps", () => {
+    // Setup SUT
+    const collection = makeCollection();
+
+    // Exercise
+    const summary = summarizeCollection(collection);
+
+    // Verify
+    expect(summary).toEqual({
+      id: "Collection_1",
+      latestVersionId: "CollectionVersion_2",
+      previousVersionId: "CollectionVersion_1",
+    });
+    expect(summary).not.toHaveProperty("latestVersion");
+    expect(summary).not.toHaveProperty("settings");
+    expect(summary).not.toHaveProperty("createdAt");
+  });
+
+  it("summarizes collection arrays", () => {
+    // Setup SUT
+    const collections = [
+      makeCollection({
+        id: "Collection_1",
+        latestVersionId: "CollectionVersion_1",
+      }),
+      makeCollection({
+        id: "Collection_2",
+        latestVersionId: "CollectionVersion_2",
+      }),
+    ];
+
+    // Exercise
+    const summaries = summarizeCollections(collections);
+
+    // Verify
+    expect(summaries).toEqual([
+      {
+        id: "Collection_1",
+        latestVersionId: "CollectionVersion_1",
+        previousVersionId: "CollectionVersion_1",
+      },
+      {
+        id: "Collection_2",
+        latestVersionId: "CollectionVersion_2",
+        previousVersionId: "CollectionVersion_1",
+      },
+    ]);
+  });
+
+  it("summarizes collection categories to id only", () => {
+    // Setup SUT
+    const collectionCategory = {
+      id: "CollectionCategory_1",
+      name: "Finance",
+      icon: "credit-card",
+      parentId: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    } as CollectionCategory;
+
+    // Exercise
+    const summary = summarizeCollectionCategory(collectionCategory);
+
+    // Verify
+    expect(summary).toEqual({ id: "CollectionCategory_1" });
+  });
+});
+
+function makeDocument(
+  overrides: { id?: string; latestVersionId?: string } = {},
+): Document {
+  return {
+    id: overrides.id ?? "Document_1",
+    collectionId: "Collection_1",
+    latestVersion: {
+      id: overrides.latestVersionId ?? "DocumentVersion_2",
+      collectionVersionId: "CollectionVersion_1",
+      previousVersionId: "DocumentVersion_1",
+      conversationId: null,
+      content: { title: "Hidden" },
+      contentSummary: { success: true, data: {}, error: null },
+      createdBy: DocumentVersionCreator.User,
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    },
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  } as Document;
+}
+
+function makeCollection(
+  overrides: { id?: string; latestVersionId?: string } = {},
+): Collection {
+  return {
+    id: overrides.id ?? "Collection_1",
+    latestVersion: {
+      id: overrides.latestVersionId ?? "CollectionVersion_2",
+      previousVersionId: "CollectionVersion_1",
+      schema: { types: {}, rootType: "Root" },
+      settings: {
+        contentSummaryGetter: { source: "", compiled: "" },
+        contentBlockingKeysGetter: null,
+        defaultDocumentViewUiOptions: null,
+      },
+      migration: null,
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    },
+    settings: {
+      name: "Expenses",
+      icon: null,
+      collectionCategoryId: null,
+      defaultCollectionViewAppId: null,
+      description: null,
+      assistantInstructions: null,
+      redirectToCollectionAfterDocumentCreation: false,
+    },
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  } as Collection;
+}

--- a/packages/apps/cli/src/utils/successSummaries.ts
+++ b/packages/apps/cli/src/utils/successSummaries.ts
@@ -1,0 +1,61 @@
+import type {
+  Collection,
+  CollectionCategory,
+  Document,
+} from "@superego/backend";
+
+export interface DocumentSuccessSummary {
+  id: Document["id"];
+  collectionId: Document["collectionId"];
+  collectionVersionId: Document["latestVersion"]["collectionVersionId"];
+  latestVersionId: Document["latestVersion"]["id"];
+  previousVersionId: Document["latestVersion"]["previousVersionId"];
+}
+
+export interface CollectionSuccessSummary {
+  id: Collection["id"];
+  latestVersionId: Collection["latestVersion"]["id"];
+  previousVersionId: Collection["latestVersion"]["previousVersionId"];
+}
+
+export interface CollectionCategorySuccessSummary {
+  id: CollectionCategory["id"];
+}
+
+export function summarizeDocument(document: Document): DocumentSuccessSummary {
+  return {
+    id: document.id,
+    collectionId: document.collectionId,
+    collectionVersionId: document.latestVersion.collectionVersionId,
+    latestVersionId: document.latestVersion.id,
+    previousVersionId: document.latestVersion.previousVersionId,
+  };
+}
+
+export function summarizeDocuments(
+  documents: Document[],
+): DocumentSuccessSummary[] {
+  return documents.map(summarizeDocument);
+}
+
+export function summarizeCollection(
+  collection: Collection,
+): CollectionSuccessSummary {
+  return {
+    id: collection.id,
+    latestVersionId: collection.latestVersion.id,
+    previousVersionId: collection.latestVersion.previousVersionId,
+  };
+}
+
+export function summarizeCollections(
+  collections: Collection[],
+): CollectionSuccessSummary[] {
+  return collections.map(summarizeCollection);
+}
+
+export function summarizeCollectionCategory(
+  collectionCategory: CollectionCategory,
+): CollectionCategorySuccessSummary {
+  return { id: collectionCategory.id };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6876,6 +6876,7 @@ __metadata:
     mime-types: "npm:^3.0.2"
     typescript: "npm:^6.0.3"
     valibot: "npm:^1.4.1"
+    vitest: "npm:^4.1.7"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Add CLI success-data summarizers for object write commands.
- Return compact identity/version handles for document, collection, and collection-category writes.
- Keep backend usecase return values unchanged and leave read/error output untouched.

Closes #149.

## Validation

- yarn fix-formatting
- yarn workspace @superego/cli run test
- yarn workspace @superego/cli run check-types
- yarn check-linting
- yarn check-types
