### PR TITLE
[codex] Fix packaged CLI TypeScript resolution and Tile height

### DIFF
--- a/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
+++ b/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
@@ -4,7 +4,6 @@ import { vars } from "../../themes.css.js";
 export const Tile = {
   root: style({
     minWidth: "100%",
-    minHeight: "100%",
     padding: vars.spacing._4,
     background: vars.colors.background.subtleSurface,
     border: `${vars.borders.width.thin} solid ${vars.colors.border.default}`,

--- a/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
+++ b/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
@@ -9,4 +9,7 @@ export const Tile = {
     border: `${vars.borders.width.thin} solid ${vars.colors.border.default}`,
     borderRadius: vars.borders.radius.md,
   }),
+  fillHeight: style({
+    minHeight: "100%",
+  }),
 };

--- a/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.tsx
+++ b/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.tsx
@@ -1,13 +1,18 @@
+import clsx from "clsx";
 import type { CSSProperties, ReactNode } from "react";
 import * as cs from "./Tile.css.js";
 
 interface Props {
+  fillHeight?: boolean;
   style?: CSSProperties;
   children: ReactNode;
 }
-export default function Tile({ style, children }: Props) {
+export default function Tile({ fillHeight, style, children }: Props) {
   return (
-    <div style={style} className={cs.Tile.root}>
+    <div
+      style={style}
+      className={clsx(cs.Tile.root, fillHeight && cs.Tile.fillHeight)}
+    >
       {children}
     </div>
   );

--- a/packages/apps/app-sandbox/src/sandbox/components/index.d.ts
+++ b/packages/apps/app-sandbox/src/sandbox/components/index.d.ts
@@ -536,6 +536,8 @@ export declare namespace KanbanBoard {
  * imposing structure (no header/body/footer) or layout semantics.
  */
 export declare function Tile(props: {
+  /** Whether the tile should fill the available height. */
+  fillHeight?: boolean;
   style?: CSSProperties;
   children: ReactNode;
 }): JSX.Element;

--- a/packages/code-execution/tsc-typescript-compiler/package.json
+++ b/packages/code-execution/tsc-typescript-compiler/package.json
@@ -21,6 +21,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "vitest": "^4.1.7"
   }
 }

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
@@ -1,7 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { registerTypescriptCompilerTests } from "@superego/executing-backend/tests";
-import TscTypescriptCompiler from "./TscTypescriptCompiler.js";
+import { afterEach, describe, expect, it } from "vitest";
+import TscTypescriptCompiler, {
+  getPackagedElectronTypescriptLibDirectory,
+} from "./TscTypescriptCompiler.js";
 
 registerTypescriptCompilerTests(() => {
   const typescriptCompiler = new TscTypescriptCompiler();
   return { typescriptCompiler };
+});
+
+describe("getPackagedElectronTypescriptLibDirectory", () => {
+  const testDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const testDirectory of testDirectories) {
+      rmSync(testDirectory, { recursive: true, force: true });
+    }
+    testDirectories.length = 0;
+  });
+
+  it("returns undefined when resourcesPath is missing", () => {
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(undefined);
+
+    // Verify
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when packaged TypeScript lib directory is missing", () => {
+    // Setup
+    const resourcesPath = mkdtempSync(
+      join(tmpdir(), "superego-test-resources-missing-"),
+    );
+    testDirectories.push(resourcesPath);
+
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
+
+    // Verify
+    expect(result).toBeUndefined();
+  });
+
+  it("returns packaged TypeScript lib directory when it exists", () => {
+    // Setup
+    const resourcesPath = mkdtempSync(
+      join(tmpdir(), "superego-test-resources-existing-"),
+    );
+    const typescriptLibDirectory = join(
+      resourcesPath,
+      "app.asar",
+      "node_modules",
+      "typescript",
+      "lib",
+    );
+    testDirectories.push(resourcesPath);
+    mkdirSync(typescriptLibDirectory, { recursive: true });
+
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
+
+    // Verify
+    expect(result).toBe(typescriptLibDirectory);
+  });
 });

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type {
   TypescriptCompilationFailed,
   TypescriptFile,
@@ -15,15 +17,41 @@ import * as tsvfs from "@typescript/vfs";
 import ts from "typescript";
 import stringifyDiagnostic from "./stringifyDiagnostic.js";
 
+export function getPackagedElectronTypescriptLibDirectory(
+  resourcesPath = (process as typeof process & { resourcesPath?: string })
+    .resourcesPath,
+): string | undefined {
+  if (!resourcesPath) {
+    return undefined;
+  }
+
+  const typescriptLibDirectory = join(
+    resourcesPath,
+    "app.asar",
+    "node_modules",
+    "typescript",
+    "lib",
+  );
+  if (!existsSync(typescriptLibDirectory)) {
+    return undefined;
+  }
+
+  return typescriptLibDirectory;
+}
+
 export default class TscTypescriptCompiler implements TypescriptCompiler {
   async compile(
     main: TypescriptFile,
     libs: TypescriptFile[],
   ): ResultPromise<string, TypescriptCompilationFailed | UnexpectedError> {
     try {
-      const fs = tsvfs.createDefaultMapFromNodeModules({
-        target: ts.ScriptTarget.ESNext,
-      });
+      const fs = tsvfs.createDefaultMapFromNodeModules(
+        {
+          target: ts.ScriptTarget.ESNext,
+        },
+        ts,
+        getPackagedElectronTypescriptLibDirectory(),
+      );
       fs.set(main.path, main.source);
       for (const lib of libs) {
         fs.set(lib.path, lib.source);

--- a/packages/code-execution/tsc-typescript-compiler/tsconfig.json
+++ b/packages/code-execution/tsc-typescript-compiler/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["../../../tsconfig.common.json"]
+  "extends": ["../../../tsconfig.common.json"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7172,6 +7172,7 @@ __metadata:
     "@superego/executing-backend": "workspace:*"
     "@superego/global-types": "workspace:*"
     "@superego/shared-utils": "workspace:*"
+    "@types/node": "npm:^25.9.1"
     "@typescript/vfs": "npm:^1.6.4"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.7"


### PR DESCRIPTION
## Summary

- Pass an explicit packaged Electron TypeScript lib directory to the TSC VFS compiler when available.
- Add compiler package Node typings and unit coverage for packaged resource path resolution.
- Remove Tile's default full-height minimum so embedded card grids can size naturally.

Closes #153.
Closes #154.

## Checks

- yarn install
- yarn workspace @superego/tsc-typescript-compiler run test
- yarn workspace @superego/tsc-typescript-compiler run check-types
- yarn workspace @superego/app-sandbox run check-types
- yarn check-linting
- yarn check-types

Earlier, before replacing the branch base, the same two logical commits also passed yarn fix-formatting and yarn test.