### PR TITLE
[codex] Fix packaged CLI TypeScript resolution and Tile height

### DIFF
--- a/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
+++ b/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.css.ts
@@ -4,10 +4,13 @@ import { vars } from "../../themes.css.js";
 export const Tile = {
   root: style({
     minWidth: "100%",
-    minHeight: "100%",
     padding: vars.spacing._4,
     background: vars.colors.background.subtleSurface,
     border: `${vars.borders.width.thin} solid ${vars.colors.border.default}`,
     borderRadius: vars.borders.radius.md,
+  }),
+
+  fillHeight: style({
+    minHeight: "100%",
   }),
 };

--- a/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.tsx
+++ b/packages/apps/app-sandbox/src/sandbox/components/Tile/Tile.tsx
@@ -1,13 +1,18 @@
+import clsx from "clsx";
 import type { CSSProperties, ReactNode } from "react";
 import * as cs from "./Tile.css.js";
 
 interface Props {
+  fillHeight?: boolean;
   style?: CSSProperties;
   children: ReactNode;
 }
-export default function Tile({ style, children }: Props) {
+export default function Tile({ fillHeight, style, children }: Props) {
   return (
-    <div style={style} className={cs.Tile.root}>
+    <div
+      style={style}
+      className={clsx(cs.Tile.root, fillHeight && cs.Tile.fillHeight)}
+    >
       {children}
     </div>
   );

--- a/packages/apps/app-sandbox/src/sandbox/components/index.d.ts
+++ b/packages/apps/app-sandbox/src/sandbox/components/index.d.ts
@@ -536,6 +536,8 @@ export declare namespace KanbanBoard {
  * imposing structure (no header/body/footer) or layout semantics.
  */
 export declare function Tile(props: {
+  /** Whether the tile should fill the available height. */
+  fillHeight?: boolean;
   style?: CSSProperties;
   children: ReactNode;
 }): JSX.Element;

--- a/packages/code-execution/tsc-typescript-compiler/package.json
+++ b/packages/code-execution/tsc-typescript-compiler/package.json
@@ -21,6 +21,7 @@
     "typescript": "^6.0.3"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "vitest": "^4.1.7"
   }
 }

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
@@ -1,68 +1,77 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { registerTypescriptCompilerTests } from "@superego/executing-backend/tests";
-import { afterEach, describe, expect, it } from "vitest";
-import TscTypescriptCompiler, {
-  getPackagedElectronTypescriptLibDirectory,
-} from "./TscTypescriptCompiler.js";
+import * as tsvfs from "@typescript/vfs";
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+import TscTypescriptCompiler from "./TscTypescriptCompiler.js";
 
 registerTypescriptCompilerTests(() => {
   const typescriptCompiler = new TscTypescriptCompiler();
   return { typescriptCompiler };
 });
 
-describe("getPackagedElectronTypescriptLibDirectory", () => {
-  const testDirectories: string[] = [];
-
-  afterEach(() => {
-    for (const testDirectory of testDirectories) {
-      rmSync(testDirectory, { recursive: true, force: true });
-    }
-    testDirectories.length = 0;
-  });
-
-  it("returns undefined when resourcesPath is missing", () => {
-    // Exercise
-    const result = getPackagedElectronTypescriptLibDirectory(undefined);
-
-    // Verify
-    expect(result).toBeUndefined();
-  });
-
-  it("returns undefined when packaged TypeScript lib directory is missing", () => {
+describe("compile in packaged Electron", () => {
+  it("passes the packaged TypeScript lib directory to the VFS", async () => {
     // Setup
-    const resourcesPath = mkdtempSync(
-      join(tmpdir(), "superego-test-resources-missing-"),
-    );
-    testDirectories.push(resourcesPath);
-
-    // Exercise
-    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
-
-    // Verify
-    expect(result).toBeUndefined();
-  });
-
-  it("returns packaged TypeScript lib directory when it exists", () => {
-    // Setup
-    const resourcesPath = mkdtempSync(
-      join(tmpdir(), "superego-test-resources-existing-"),
+    const resourcesPath = mkdtempSync(join(tmpdir(), "superego-resources-"));
+    const packagedTypescriptDirectory = join(
+      resourcesPath,
+      "app.asar/node_modules/typescript",
     );
     const typescriptLibDirectory = join(
-      resourcesPath,
-      "app.asar",
-      "node_modules",
-      "typescript",
+      packagedTypescriptDirectory,
       "lib",
     );
-    testDirectories.push(resourcesPath);
-    mkdirSync(typescriptLibDirectory, { recursive: true });
+    const realTypescriptLibDirectory = dirname(
+      createRequire(import.meta.url).resolve("typescript"),
+    );
+    mkdirSync(packagedTypescriptDirectory, { recursive: true });
+    symlinkSync(realTypescriptLibDirectory, typescriptLibDirectory, "dir");
+    const createDefaultMapFromNodeModulesSpy = vi.spyOn(
+      tsvfs,
+      "createDefaultMapFromNodeModules",
+    );
+    const processResourcesPathDescriptor = Object.getOwnPropertyDescriptor(
+      process,
+      "resourcesPath",
+    );
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: resourcesPath,
+    });
 
-    // Exercise
-    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
+    try {
+      const typescriptCompiler = new TscTypescriptCompiler();
 
-    // Verify
-    expect(result).toBe(typescriptLibDirectory);
+      // Exercise
+      const result = await typescriptCompiler.compile(
+        { path: "/main.ts", source: "export default 1;" },
+        [],
+      );
+
+      // Verify
+      expect(result.success).toBe(true);
+      expect(createDefaultMapFromNodeModulesSpy).toHaveBeenCalledWith(
+        { target: ts.ScriptTarget.ESNext },
+        ts,
+        typescriptLibDirectory,
+      );
+    } finally {
+      createDefaultMapFromNodeModulesSpy.mockRestore();
+      if (processResourcesPathDescriptor) {
+        Object.defineProperty(
+          process,
+          "resourcesPath",
+          processResourcesPathDescriptor,
+        );
+      } else {
+        delete (process as typeof process & { resourcesPath?: string })
+          .resourcesPath;
+      }
+      rmSync(resourcesPath, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
@@ -15,7 +15,7 @@ registerTypescriptCompilerTests(() => {
 
 describe("compile in packaged Electron", () => {
   it("passes the packaged TypeScript lib directory to the VFS", async () => {
-    // Setup
+    // Setup mocks
     const resourcesPath = mkdtempSync(join(tmpdir(), "superego-resources-"));
     const packagedTypescriptDirectory = join(
       resourcesPath,
@@ -41,6 +41,7 @@ describe("compile in packaged Electron", () => {
     });
 
     try {
+      // Setup SUT
       const typescriptCompiler = new TscTypescriptCompiler();
 
       // Exercise

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
@@ -1,7 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { registerTypescriptCompilerTests } from "@superego/executing-backend/tests";
-import TscTypescriptCompiler from "./TscTypescriptCompiler.js";
+import { afterEach, describe, expect, it } from "vitest";
+import TscTypescriptCompiler, {
+  getPackagedElectronTypescriptLibDirectory,
+} from "./TscTypescriptCompiler.js";
 
 registerTypescriptCompilerTests(() => {
   const typescriptCompiler = new TscTypescriptCompiler();
   return { typescriptCompiler };
+});
+
+describe("getPackagedElectronTypescriptLibDirectory", () => {
+  const testDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const testDirectory of testDirectories) {
+      rmSync(testDirectory, { recursive: true, force: true });
+    }
+    testDirectories.length = 0;
+  });
+
+  it("returns undefined when resourcesPath is missing", () => {
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(undefined);
+
+    // Verify
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when packaged TypeScript lib directory is missing", () => {
+    // Setup
+    const resourcesPath = mkdtempSync(
+      join(tmpdir(), "superego-test-resources-missing-"),
+    );
+    testDirectories.push(resourcesPath);
+
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
+
+    // Verify
+    expect(result).toBeUndefined();
+  });
+
+  it("returns packaged TypeScript lib directory when it exists", () => {
+    // Setup
+    const resourcesPath = mkdtempSync(
+      join(tmpdir(), "superego-test-resources-existing-"),
+    );
+    const typescriptLibDirectory = join(
+      resourcesPath,
+      "app.asar",
+      "node_modules",
+      "typescript",
+      "lib",
+    );
+    testDirectories.push(resourcesPath);
+    mkdirSync(typescriptLibDirectory, { recursive: true });
+
+    // Exercise
+    const result = getPackagedElectronTypescriptLibDirectory(resourcesPath);
+
+    // Verify
+    expect(result).toBe(typescriptLibDirectory);
+  });
 });

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.test.ts
@@ -21,10 +21,7 @@ describe("compile in packaged Electron", () => {
       resourcesPath,
       "app.asar/node_modules/typescript",
     );
-    const typescriptLibDirectory = join(
-      packagedTypescriptDirectory,
-      "lib",
-    );
+    const typescriptLibDirectory = join(packagedTypescriptDirectory, "lib");
     const realTypescriptLibDirectory = dirname(
       createRequire(import.meta.url).resolve("typescript"),
     );

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type {
   TypescriptCompilationFailed,
   TypescriptFile,
@@ -15,15 +17,41 @@ import * as tsvfs from "@typescript/vfs";
 import ts from "typescript";
 import stringifyDiagnostic from "./stringifyDiagnostic.js";
 
+export function getPackagedElectronTypescriptLibDirectory(
+  resourcesPath = (process as typeof process & { resourcesPath?: string })
+    .resourcesPath,
+): string | undefined {
+  if (!resourcesPath) {
+    return undefined;
+  }
+
+  const typescriptLibDirectory = join(
+    resourcesPath,
+    "app.asar",
+    "node_modules",
+    "typescript",
+    "lib",
+  );
+  if (!existsSync(typescriptLibDirectory)) {
+    return undefined;
+  }
+
+  return typescriptLibDirectory;
+}
+
 export default class TscTypescriptCompiler implements TypescriptCompiler {
   async compile(
     main: TypescriptFile,
     libs: TypescriptFile[],
   ): ResultPromise<string, TypescriptCompilationFailed | UnexpectedError> {
     try {
-      const fs = tsvfs.createDefaultMapFromNodeModules({
-        target: ts.ScriptTarget.ESNext,
-      });
+      const fs = tsvfs.createDefaultMapFromNodeModules(
+        {
+          target: ts.ScriptTarget.ESNext,
+        },
+        ts,
+        getPackagedElectronTypescriptLibDirectory(),
+      );
       fs.set(main.path, main.source);
       for (const lib of libs) {
         fs.set(lib.path, lib.source);

--- a/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
+++ b/packages/code-execution/tsc-typescript-compiler/src/TscTypescriptCompiler.ts
@@ -17,28 +17,6 @@ import * as tsvfs from "@typescript/vfs";
 import ts from "typescript";
 import stringifyDiagnostic from "./stringifyDiagnostic.js";
 
-export function getPackagedElectronTypescriptLibDirectory(
-  resourcesPath = (process as typeof process & { resourcesPath?: string })
-    .resourcesPath,
-): string | undefined {
-  if (!resourcesPath) {
-    return undefined;
-  }
-
-  const typescriptLibDirectory = join(
-    resourcesPath,
-    "app.asar",
-    "node_modules",
-    "typescript",
-    "lib",
-  );
-  if (!existsSync(typescriptLibDirectory)) {
-    return undefined;
-  }
-
-  return typescriptLibDirectory;
-}
-
 export default class TscTypescriptCompiler implements TypescriptCompiler {
   async compile(
     main: TypescriptFile,
@@ -46,11 +24,9 @@ export default class TscTypescriptCompiler implements TypescriptCompiler {
   ): ResultPromise<string, TypescriptCompilationFailed | UnexpectedError> {
     try {
       const fs = tsvfs.createDefaultMapFromNodeModules(
-        {
-          target: ts.ScriptTarget.ESNext,
-        },
+        { target: ts.ScriptTarget.ESNext },
         ts,
-        getPackagedElectronTypescriptLibDirectory(),
+        this.getPackagedElectronTypescriptLibDirectory(),
       );
       fs.set(main.path, main.source);
       for (const lib of libs) {
@@ -100,5 +76,22 @@ export default class TscTypescriptCompiler implements TypescriptCompiler {
         details: { cause: extractErrorDetails(error) },
       });
     }
+  }
+
+  private getPackagedElectronTypescriptLibDirectory(): string | undefined {
+    const resourcesPath = (
+      process as typeof process & { resourcesPath?: string }
+    ).resourcesPath;
+    if (!resourcesPath) {
+      return undefined;
+    }
+
+    const typescriptLibDirectory = join(
+      resourcesPath,
+      "app.asar/node_modules/typescript/lib",
+    );
+    return existsSync(typescriptLibDirectory)
+      ? typescriptLibDirectory
+      : undefined;
   }
 }

--- a/packages/code-execution/tsc-typescript-compiler/tsconfig.json
+++ b/packages/code-execution/tsc-typescript-compiler/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["../../../tsconfig.common.json"]
+  "extends": ["../../../tsconfig.common.json"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.appCompiled.js
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.appCompiled.js
@@ -153,7 +153,7 @@ export default function App(props) {
         { span: { sm: 12, md: 12, lg: 12 } },
         React.createElement(
           Tile,
-          null,
+          { fillHeight: true },
           React.createElement(
             "div",
             {
@@ -271,7 +271,7 @@ export default function App(props) {
       { span: { sm: 12, md: 12, lg: 12 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           "div",
           {
@@ -324,7 +324,7 @@ export default function App(props) {
       { span: { sm: 6, md: 6, lg: 3 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -350,7 +350,7 @@ export default function App(props) {
       { span: { sm: 6, md: 6, lg: 3 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -376,7 +376,7 @@ export default function App(props) {
       { span: { sm: 6, md: 6, lg: 3 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -400,7 +400,7 @@ export default function App(props) {
       { span: { sm: 6, md: 6, lg: 3 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -424,7 +424,7 @@ export default function App(props) {
       { span: { sm: 12, md: 12, lg: 12 } },
       React.createElement(
         Tile,
-        { style: { height: "400px" } },
+        { fillHeight: true, style: { height: "400px" } },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -466,7 +466,7 @@ export default function App(props) {
         { span: { sm: 12, md: 12, lg: 6 } },
         React.createElement(
           Tile,
-          null,
+          { fillHeight: true },
           React.createElement(
             Text,
             { element: "h3", size: "lg", weight: "semibold" },
@@ -508,7 +508,7 @@ export default function App(props) {
       { span: { sm: 12, md: 12, lg: efficiencyData.length > 0 ? 6 : 12 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },
@@ -548,7 +548,7 @@ export default function App(props) {
       { span: { sm: 12, md: 12, lg: 12 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { element: "h3", size: "lg", weight: "semibold" },

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.appSource.tsx
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/car/fuelLogs.appSource.tsx
@@ -190,7 +190,7 @@ export default function App(props: Props): React.ReactElement | null {
     return (
       <Grid>
         <Grid.Col span={{ sm: 12, md: 12, lg: 12 }}>
-          <Tile>
+          <Tile fillHeight={true}>
             <div
               style={{
                 display: "flex",
@@ -294,7 +294,7 @@ export default function App(props: Props): React.ReactElement | null {
     <Grid>
       {/* Period Controls */}
       <Grid.Col span={{ sm: 12, md: 12, lg: 12 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <div
             style={{
               display: "flex",
@@ -334,7 +334,7 @@ export default function App(props: Props): React.ReactElement | null {
 
       {/* Statistics Cards */}
       <Grid.Col span={{ sm: 6, md: 6, lg: 3 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Total Fuel
           </Text>
@@ -348,7 +348,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 6, md: 6, lg: 3 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Total Cost
           </Text>
@@ -362,7 +362,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 6, md: 6, lg: 3 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Distance
           </Text>
@@ -376,7 +376,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 6, md: 6, lg: 3 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Avg Efficiency
           </Text>
@@ -391,7 +391,7 @@ export default function App(props: Props): React.ReactElement | null {
 
       {/* Cost per Liter Over Time */}
       <Grid.Col span={{ sm: 12, md: 12, lg: 12 }}>
-        <Tile style={{ height: "400px" }}>
+        <Tile fillHeight style={{ height: "400px" }}>
           <Text element="h3" size="lg" weight="semibold">
             Cost per Liter Over Time
           </Text>
@@ -429,7 +429,7 @@ export default function App(props: Props): React.ReactElement | null {
       {/* Fuel Efficiency Trend */}
       {efficiencyData.length > 0 && (
         <Grid.Col span={{ sm: 12, md: 12, lg: 6 }}>
-          <Tile>
+          <Tile fillHeight={true}>
             <Text element="h3" size="lg" weight="semibold">
               Fuel Efficiency Trend
             </Text>
@@ -473,7 +473,7 @@ export default function App(props: Props): React.ReactElement | null {
       <Grid.Col
         span={{ sm: 12, md: 12, lg: efficiencyData.length > 0 ? 6 : 12 }}
       >
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Fuel Volume Over Time
           </Text>
@@ -509,7 +509,7 @@ export default function App(props: Props): React.ReactElement | null {
 
       {/* Recent Fuel Logs Table */}
       <Grid.Col span={{ sm: 12, md: 12, lg: 12 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text element="h3" size="lg" weight="semibold">
             Fuel Logs in Selected Period
           </Text>

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.appCompiled.js
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.appCompiled.js
@@ -148,7 +148,7 @@ export default function App(props) {
         { span: { sm: 12 } },
         React.createElement(
           Tile,
-          null,
+          { fillHeight: true },
           React.createElement(
             Text,
             { element: "p", color: "secondary" },
@@ -178,7 +178,7 @@ export default function App(props) {
       { span: { sm: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           {
@@ -214,7 +214,7 @@ export default function App(props) {
       { span: { sm: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           {
@@ -249,7 +249,7 @@ export default function App(props) {
       { span: { sm: 12, md: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           {
@@ -272,7 +272,7 @@ export default function App(props) {
       { span: { sm: 12, md: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           {
@@ -295,7 +295,7 @@ export default function App(props) {
       { span: { sm: 12 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           {

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.appSource.tsx
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/expenses.appSource.tsx
@@ -174,7 +174,7 @@ export default function App(props: Props): React.ReactElement | null {
     return (
       <Grid>
         <Grid.Col span={{ sm: 12 }}>
-          <Tile>
+          <Tile fillHeight={true}>
             <Text element="p" color="secondary">
               No expense data available.
             </Text>
@@ -198,7 +198,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text
             element="h3"
             size="lg"
@@ -223,7 +223,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text
             element="h3"
             size="lg"
@@ -248,7 +248,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 12, md: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text
             element="h3"
             size="lg"
@@ -262,7 +262,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 12, md: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text
             element="h3"
             size="lg"
@@ -276,7 +276,7 @@ export default function App(props: Props): React.ReactElement | null {
       </Grid.Col>
 
       <Grid.Col span={{ sm: 12 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text
             element="h3"
             size="lg"

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/portfolioDashboard.appCompiled.js
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/portfolioDashboard.appCompiled.js
@@ -133,7 +133,7 @@ function SummaryStats({ rows }) {
       { span: { sm: 12, md: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { color: "secondary", size: "sm" },
@@ -166,7 +166,7 @@ function SummaryStats({ rows }) {
       { span: { sm: 12, md: 6 } },
       React.createElement(
         Tile,
-        null,
+        { fillHeight: true },
         React.createElement(
           Text,
           { color: "secondary", size: "sm" },
@@ -233,7 +233,7 @@ function TopGainers({ rows }) {
 
   return React.createElement(
     Tile,
-    null,
+    { fillHeight: true },
     React.createElement(
       Text,
       {
@@ -304,7 +304,7 @@ function TopLosers({ rows }) {
 
   return React.createElement(
     Tile,
-    null,
+    { fillHeight: true },
     React.createElement(
       Text,
       {
@@ -413,7 +413,7 @@ function AllocationChart({ rows, groupBy, onGroupByChange }) {
 
   return React.createElement(
     Tile,
-    null,
+    { fillHeight: true },
     React.createElement(
       "div",
       {
@@ -519,7 +519,7 @@ function PortfolioValueChart({ props }) {
 
   return React.createElement(
     Tile,
-    null,
+    { fillHeight: true },
     React.createElement(
       Text,
       {
@@ -537,7 +537,7 @@ function PortfolioValueChart({ props }) {
 function HoldingsTable({ rows }) {
   return React.createElement(
     Tile,
-    null,
+    { fillHeight: true },
     React.createElement(
       Text,
       { element: "h2", size: "lg", weight: "semibold" },

--- a/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/portfolioDashboard.appSource.tsx
+++ b/packages/misc/boutique/src/packs/dev/superego/boutique/personal-finance/portfolioDashboard.appSource.tsx
@@ -196,7 +196,7 @@ function SummaryStats({ rows }: { rows: HoldingRow[] }) {
     <Grid>
       <style>{`.summary-grid { --cols: 1; } .summary-grid p { margin: 8px 0 0 0; } @media (min-width: 768px) { .summary-grid { --cols: 2; } }`}</style>
       <Grid.Col span={{ sm: 12, md: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text color="secondary" size="sm">
             Total Value
           </Text>
@@ -217,7 +217,7 @@ function SummaryStats({ rows }: { rows: HoldingRow[] }) {
         </Tile>
       </Grid.Col>
       <Grid.Col span={{ sm: 12, md: 6 }}>
-        <Tile>
+        <Tile fillHeight={true}>
           <Text color="secondary" size="sm">
             Total Gain/Loss
           </Text>
@@ -273,7 +273,7 @@ function TopGainers({ rows }: { rows: HoldingRow[] }) {
   const gainers = sorted.slice(0, 5);
 
   return (
-    <Tile>
+    <Tile fillHeight={true}>
       <Text
         element="h2"
         size="lg"
@@ -325,7 +325,7 @@ function TopLosers({ rows }: { rows: HoldingRow[] }) {
   const losers = sorted.slice(0, 5);
 
   return (
-    <Tile>
+    <Tile fillHeight={true}>
       <Text
         element="h2"
         size="lg"
@@ -421,7 +421,7 @@ function AllocationChart({
   };
 
   return (
-    <Tile>
+    <Tile fillHeight={true}>
       <div
         style={{
           display: "flex",
@@ -527,7 +527,7 @@ function PortfolioValueChart({ props }: { props: Props }) {
   };
 
   return (
-    <Tile>
+    <Tile fillHeight={true}>
       <Text
         element="h2"
         size="lg"
@@ -543,7 +543,7 @@ function PortfolioValueChart({ props }: { props: Props }) {
 
 function HoldingsTable({ rows }: { rows: HoldingRow[] }) {
   return (
-    <Tile>
+    <Tile fillHeight={true}>
       <Text element="h2" size="lg" weight="semibold">
         Holdings
       </Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7172,6 +7172,7 @@ __metadata:
     "@superego/executing-backend": "workspace:*"
     "@superego/global-types": "workspace:*"
     "@superego/shared-utils": "workspace:*"
+    "@types/node": "npm:^25.9.1"
     "@typescript/vfs": "npm:^1.6.4"
     typescript: "npm:^6.0.3"
     vitest: "npm:^4.1.7"


### PR DESCRIPTION
## Summary

- Pass an explicit packaged Electron TypeScript lib directory to the TSC VFS compiler when available.
- Add compiler package Node typings and unit coverage for packaged resource path resolution.
- Make Tile height filling opt-in through a new fillHeight prop, while keeping the default height natural for compact grids.

Closes #153.
Closes #154.

## Checks

- yarn fix-formatting
- yarn workspace @superego/tsc-typescript-compiler run test
- yarn workspace @superego/tsc-typescript-compiler run check-types
- yarn workspace @superego/app-sandbox run check-types
- yarn check-linting