### PR TITLE
[codex] Refactor conversations to node graph events

### DIFF
--- a/packages/apps/browser-app/src/components/routes/Conversation/Conversation.tsx
+++ b/packages/apps/browser-app/src/components/routes/Conversation/Conversation.tsx
@@ -152,7 +152,8 @@ const MemoizedConversation = memo(
     prev.screenSize === next.screenSize &&
     prev.conversation.id === next.conversation.id &&
     prev.conversation.status === next.conversation.status &&
-    prev.conversation.messages.length === next.conversation.messages.length &&
+    prev.conversation.nodes.length === next.conversation.nodes.length &&
+    prev.conversation.activeNodeId === next.conversation.activeNodeId &&
     prev.conversation.hasOutdatedContext ===
       next.conversation.hasOutdatedContext,
 );

--- a/packages/apps/browser-app/src/components/widgets/Chat/Chat.tsx
+++ b/packages/apps/browser-app/src/components/widgets/Chat/Chat.tsx
@@ -10,6 +10,7 @@ import { useContinueConversation } from "../../../business-logic/backend/hooks.j
 import toasts from "../../../business-logic/toasts/toasts.js";
 import ToastType from "../../../business-logic/toasts/ToastType.js";
 import classnames from "../../../utils/classnames.js";
+import ConversationUtils from "../../../utils/ConversationUtils.js";
 import last from "../../../utils/last.js";
 import ConversationMessages from "../ConversationMessages/ConversationMessages.js";
 import UserMessageContentInput from "../UserMessageContentInput/UserMessageContentInput.js";
@@ -32,7 +33,8 @@ export default function Chat({
 
   // When messages change, scroll to bottom and - if the last message is an
   // assistant message - focus the input.
-  const lastMessage = last(conversation.messages);
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
+  const lastMessage = last(messages);
   const lastMessageId =
     lastMessage && "id" in lastMessage ? lastMessage.id : null;
   const lastMessageCreatedAtTime =

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/AssistantContentMessage/AssistantContentMessage.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/AssistantContentMessage/AssistantContentMessage.tsx
@@ -29,10 +29,8 @@ export default function AssistantContentMessage({
 }: Props) {
   const [textPart] = message.content;
   const overrides = useOverrides(conversation);
-  const generationStats = aggregateGenerationStats(
-    conversation.messages,
-    message,
-  );
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
+  const generationStats = aggregateGenerationStats(messages, message);
   return (
     <div className={cs.AssistantContentMessage.root}>
       <Markdown text={textPart.text} overrides={overrides} />
@@ -55,8 +53,9 @@ export default function AssistantContentMessage({
 
 function useOverrides(conversation: Conversation): MarkdownToJSX.Overrides {
   return useMemo(() => {
+    const messages = ConversationUtils.getActiveBranchMessages(conversation);
     const Chart = ({ id }: { id: string }) => {
-      const toolResult = conversation.messages
+      const toolResult = messages
         .filter((message) => message.role === MessageRole.Tool)
         .flatMap((message) => message.toolResults)
         .filter(ConversationUtils.isSuccessfulCreateChartToolResult)
@@ -71,7 +70,7 @@ function useOverrides(conversation: Conversation): MarkdownToJSX.Overrides {
     const DocumentsTable = ({ id }: { id: string }) => {
       let collectionId: CollectionId | null = null;
       let documents: LiteDocument[] | null = null;
-      conversation.messages
+      messages
         .filter((message) => message.role === MessageRole.Tool)
         .flatMap((message) => message.toolResults)
         .filter(ConversationUtils.isSuccessfulCreateDocumentsTablesToolResult)
@@ -97,7 +96,7 @@ function useOverrides(conversation: Conversation): MarkdownToJSX.Overrides {
     };
 
     const GeoJSONMap = ({ id }: { id: string }) => {
-      const toolResult = conversation.messages
+      const toolResult = messages
         .filter((message) => message.role === MessageRole.Tool)
         .flatMap((message) => message.toolResults)
         .filter(ConversationUtils.isSuccessfulCreateGeoJSONMapToolResult)

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/AssistantContentMessage/RetryButton.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/AssistantContentMessage/RetryButton.tsx
@@ -6,6 +6,7 @@ import { useRetryLastResponse } from "../../../../business-logic/backend/hooks.j
 import useDefaultInferenceOptions from "../../../../business-logic/inference/useDefaultInferenceOptions.js";
 import toasts from "../../../../business-logic/toasts/toasts.js";
 import ToastType from "../../../../business-logic/toasts/ToastType.js";
+import ConversationUtils from "../../../../utils/ConversationUtils.js";
 import isEmpty from "../../../../utils/isEmpty.js";
 import last from "../../../../utils/last.js";
 import IconButton from "../../../design-system/IconButton/IconButton.js";
@@ -33,7 +34,9 @@ export default function RetryButton({
     message.inferenceOptions.completion.providerModelRef,
   );
 
-  const lastMessage = last(conversation.messages);
+  const lastMessage = last(
+    ConversationUtils.getActiveBranchMessages(conversation),
+  );
   return conversation.canRetryLastResponse &&
     lastMessage !== null &&
     "id" in lastMessage &&

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/ConversationMessages.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/ConversationMessages.tsx
@@ -25,22 +25,21 @@ export default function ConversationMessages({
 }: Props) {
   const { isRecovering, setIsRecovering } =
     useRecoveringConversation(conversation);
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
 
-  const lastUserMessageIndex = conversation.messages.findLastIndex(
+  const lastUserMessageIndex = messages.findLastIndex(
     (message) => message.role === MessageRole.User,
   );
 
   const { tailMinHeight, lastUserMessageRef, tailRef } = useTailMinHeight([
-    conversation.messages.length,
+    messages.length,
     conversation.status,
   ]);
 
-  const headMessages = conversation.messages.slice(0, lastUserMessageIndex);
+  const headMessages = messages.slice(0, lastUserMessageIndex);
   const lastUserMessage =
-    lastUserMessageIndex >= 0
-      ? conversation.messages[lastUserMessageIndex]
-      : null;
-  const tailMessages = conversation.messages.slice(lastUserMessageIndex + 1);
+    lastUserMessageIndex >= 0 ? messages[lastUserMessageIndex] : null;
+  const tailMessages = messages.slice(lastUserMessageIndex + 1);
 
   const tailContent = (
     <>

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/ErrorMessage.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/ErrorMessage.tsx
@@ -11,6 +11,7 @@ import { useRecoverConversation } from "../../../business-logic/backend/hooks.js
 import useDefaultInferenceOptions from "../../../business-logic/inference/useDefaultInferenceOptions.js";
 import toasts from "../../../business-logic/toasts/toasts.js";
 import ToastType from "../../../business-logic/toasts/ToastType.js";
+import ConversationUtils from "../../../utils/ConversationUtils.js";
 import isEmpty from "../../../utils/isEmpty.js";
 import CodeBlock from "../../design-system/CodeBlock/CodeBlock.js";
 import Disclosure from "../../design-system/Disclosure/Disclosure.js";
@@ -30,9 +31,9 @@ export default function ErrorMessage({ conversation }: Props) {
   const { mutate } = useRecoverConversation();
   const { cause } = conversation.error.details;
 
-  const lastAssistantMessage = conversation.messages.findLast(
-    (message) => message.role === MessageRole.Assistant,
-  );
+  const lastAssistantMessage = ConversationUtils.getActiveBranchMessages(
+    conversation,
+  ).findLast((message) => message.role === MessageRole.Assistant);
   const models = makeModelActionMenuItems(
     globalSettings.inference.providers,
     lastAssistantMessage?.inferenceOptions.completion.providerModelRef ?? null,

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/StuckProcessingMessage.tsx
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/StuckProcessingMessage.tsx
@@ -10,6 +10,7 @@ import { useRecoverConversation } from "../../../business-logic/backend/hooks.js
 import useDefaultInferenceOptions from "../../../business-logic/inference/useDefaultInferenceOptions.js";
 import toasts from "../../../business-logic/toasts/toasts.js";
 import ToastType from "../../../business-logic/toasts/ToastType.js";
+import ConversationUtils from "../../../utils/ConversationUtils.js";
 import isEmpty from "../../../utils/isEmpty.js";
 import IconButton from "../../design-system/IconButton/IconButton.js";
 import * as cs from "./ConversationMessages.css.js";
@@ -30,9 +31,9 @@ export default function StuckProcessingMessage({
   const defaultInferenceOptions = useDefaultInferenceOptions();
   const { mutate } = useRecoverConversation();
 
-  const lastAssistantMessage = conversation.messages.findLast(
-    (message) => message.role === MessageRole.Assistant,
-  );
+  const lastAssistantMessage = ConversationUtils.getActiveBranchMessages(
+    conversation,
+  ).findLast((message) => message.role === MessageRole.Assistant);
   const models = makeModelActionMenuItems(
     globalSettings.inference.providers,
     lastAssistantMessage?.inferenceOptions.completion.providerModelRef ?? null,

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/ThinkingMessage/getReasoningTrace.ts
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/ThinkingMessage/getReasoningTrace.ts
@@ -1,10 +1,12 @@
 import { type Conversation, MessageRole } from "@superego/backend";
+import ConversationUtils from "../../../../utils/ConversationUtils.js";
 
 export default function getReasoningTrace(
   conversation: Conversation,
 ): string | null {
-  for (let i = conversation.messages.length - 1; i >= 0; i--) {
-    const message = conversation.messages[i]!;
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
     if (message.role === MessageRole.User) {
       return null;
     }

--- a/packages/apps/browser-app/src/components/widgets/ConversationMessages/ThinkingMessage/getStatusText.ts
+++ b/packages/apps/browser-app/src/components/widgets/ConversationMessages/ThinkingMessage/getStatusText.ts
@@ -1,11 +1,13 @@
 import { type Conversation, MessageRole, ToolName } from "@superego/backend";
 import type { IntlShape } from "react-intl";
+import ConversationUtils from "../../../../utils/ConversationUtils.js";
 
 export default function getStatusText(
   intl: IntlShape,
   conversation: Conversation,
 ): string {
-  const lastMessage = conversation.messages.at(-1);
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
+  const lastMessage = messages.at(-1);
 
   let tools: string[] = [];
   if (
@@ -51,8 +53,9 @@ function countToolCallsSinceLastUserMessage(
   conversation: Conversation,
 ): Map<string, number> {
   const counts = new Map<string, number>();
-  for (let i = conversation.messages.length - 1; i >= 0; i--) {
-    const message = conversation.messages[i]!;
+  const messages = ConversationUtils.getActiveBranchMessages(conversation);
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
     if (message.role === MessageRole.User) {
       break;
     }

--- a/packages/apps/browser-app/src/utils/ConversationUtils.ts
+++ b/packages/apps/browser-app/src/utils/ConversationUtils.ts
@@ -1,5 +1,8 @@
 import {
   type Conversation,
+  type ConversationNode,
+  type ConversationNodeId,
+  type Message,
   type ToolCall,
   ToolName,
   type ToolResult,
@@ -29,19 +32,19 @@ export default {
   },
 
   findToolResult(
-    { messages }: Conversation,
+    conversation: Conversation,
     { id }: ToolCall,
   ): ToolResult | null {
     return (
-      messages
+      this.getActiveBranchMessages(conversation)
         .filter((message) => "toolResults" in message)
         .flatMap(({ toolResults }) => toolResults)
         .find(({ toolCallId }) => toolCallId === id) ?? null
     );
   },
 
-  findToolCall({ messages }: Conversation, toolResult: ToolResult): ToolCall {
-    const toolCall = messages
+  findToolCall(conversation: Conversation, toolResult: ToolResult): ToolCall {
+    const toolCall = this.getActiveBranchMessages(conversation)
       .filter((message) => "toolCalls" in message)
       .flatMap(({ toolCalls }) => toolCalls)
       .find(
@@ -187,5 +190,32 @@ export default {
       );
     }
     return false;
+  },
+
+  getActiveBranchNodes({
+    nodes,
+    activeNodeId,
+  }: Conversation): ConversationNode[] {
+    if (activeNodeId === null) {
+      return [];
+    }
+    const nodesById = new Map(nodes.map((node) => [node.id, node]));
+    const branch: ConversationNode[] = [];
+    let currentNodeId: ConversationNodeId | null = activeNodeId;
+    while (currentNodeId !== null) {
+      const node = nodesById.get(currentNodeId);
+      if (!node) {
+        break;
+      }
+      branch.push(node);
+      currentNodeId = node.previousNodeId;
+    }
+    return branch.reverse();
+  },
+
+  getActiveBranchMessages(conversation: Conversation): Message[] {
+    return this.getActiveBranchNodes(conversation).flatMap((node) =>
+      node.type === "Message" ? [node.message] : [],
+    );
   },
 };

--- a/packages/core/backend/src/ids/ConversationNodeId.ts
+++ b/packages/core/backend/src/ids/ConversationNodeId.ts
@@ -1,0 +1,4 @@
+import type ConversationId from "./ConversationId.js";
+
+type ConversationNodeId = `${ConversationId}:${number}`;
+export default ConversationNodeId;

--- a/packages/core/backend/src/index.ts
+++ b/packages/core/backend/src/index.ts
@@ -80,6 +80,7 @@ export type { default as CollectionCategoryId } from "./ids/CollectionCategoryId
 export type { default as CollectionId } from "./ids/CollectionId.js";
 export type { default as CollectionVersionId } from "./ids/CollectionVersionId.js";
 export type { default as ConversationId } from "./ids/ConversationId.js";
+export type { default as ConversationNodeId } from "./ids/ConversationNodeId.js";
 export type { default as DocumentId } from "./ids/DocumentId.js";
 export type { default as DocumentVersionId } from "./ids/DocumentVersionId.js";
 export type { default as FileId } from "./ids/FileId.js";
@@ -106,7 +107,10 @@ export type { default as CollectionSettings } from "./types/CollectionSettings.j
 export type { default as CollectionVersion } from "./types/CollectionVersion.js";
 export type { default as CollectionVersionSettings } from "./types/CollectionVersionSettings.js";
 export type { default as ContentSummary } from "./types/ContentSummary.js";
-export type { default as Conversation } from "./types/Conversation.js";
+export type {
+  ConversationNode,
+  default as Conversation,
+} from "./types/Conversation.js";
 export type { default as DefaultDocumentViewUiOptions } from "./types/DefaultDocumentViewUiOptions.js";
 export type { default as DeveloperPrompts } from "./types/DeveloperPrompts.js";
 export type { default as Document } from "./types/Document.js";

--- a/packages/core/backend/src/types/Conversation.ts
+++ b/packages/core/backend/src/types/Conversation.ts
@@ -1,7 +1,30 @@
+import type { ResultError } from "@superego/global-types";
 import type AssistantName from "../enums/AssistantName.js";
 import type ConversationStatus from "../enums/ConversationStatus.js";
 import type ConversationId from "../ids/ConversationId.js";
+import type ConversationNodeId from "../ids/ConversationNodeId.js";
 import type Message from "./Message.js";
+
+export namespace ConversationNode {
+  export interface MessageNode {
+    type: "Message";
+    id: ConversationNodeId;
+    previousNodeId: ConversationNodeId | null;
+    message: Message;
+    createdAt: Date;
+  }
+
+  export interface ErrorNode {
+    type: "Error";
+    id: ConversationNodeId;
+    previousNodeId: ConversationNodeId | null;
+    error: ResultError<any, any>;
+    createdAt: Date;
+  }
+}
+export type ConversationNode =
+  | ConversationNode.MessageNode
+  | ConversationNode.ErrorNode;
 
 type Conversation = {
   id: ConversationId;
@@ -9,7 +32,8 @@ type Conversation = {
   title: string | null;
   hasOutdatedContext: boolean;
   canRetryLastResponse: boolean;
-  messages: Message[];
+  nodes: ConversationNode[];
+  activeNodeId: ConversationNodeId | null;
   status: ConversationStatus;
   processingStartedAt: Date | null;
   error: { name: string; details: any } | null;

--- a/packages/core/backend/src/types/LiteConversation.ts
+++ b/packages/core/backend/src/types/LiteConversation.ts
@@ -1,4 +1,4 @@
 import type Conversation from "./Conversation.js";
 
-type LiteConversation = Omit<Conversation, "messages">;
+type LiteConversation = Omit<Conversation, "nodes">;
 export default LiteConversation;

--- a/packages/core/executing-backend/src/entities/ConversationEntity.ts
+++ b/packages/core/executing-backend/src/entities/ConversationEntity.ts
@@ -1,8 +1,9 @@
 import type {
   AssistantName,
   ConversationId,
+  ConversationNode,
+  ConversationNodeId,
   ConversationStatus,
-  Message,
 } from "@superego/backend";
 
 type ConversationEntity = {
@@ -10,7 +11,8 @@ type ConversationEntity = {
   assistant: AssistantName;
   title: string | null;
   contextFingerprint: string;
-  messages: Message[];
+  nodes: ConversationNode[];
+  activeNodeId: ConversationNodeId | null;
   status: ConversationStatus;
   processingStartedAt: Date | null;
   error: { name: string; details: any } | null;

--- a/packages/core/executing-backend/src/makers/makeConversation.ts
+++ b/packages/core/executing-backend/src/makers/makeConversation.ts
@@ -8,12 +8,16 @@ export default function makeConversation(
 ): Conversation {
   const { contextFingerprint, ...rest } = conversation;
   const hasOutdatedContext = contextFingerprint !== currentContextFingerprint;
+  const activeBranchMessages = ConversationUtils.getActiveBranchMessages(
+    rest.nodes,
+    rest.activeNodeId,
+  );
   return {
     ...rest,
     hasOutdatedContext: hasOutdatedContext,
     canRetryLastResponse:
       rest.status === ConversationStatus.Idle &&
       !hasOutdatedContext &&
-      !ConversationUtils.lastResponseHadSideEffects(rest.messages),
+      !ConversationUtils.lastResponseHadSideEffects(activeBranchMessages),
   };
 }

--- a/packages/core/executing-backend/src/requirements/ConversationRepository.ts
+++ b/packages/core/executing-backend/src/requirements/ConversationRepository.ts
@@ -1,8 +1,40 @@
-import type { ConversationId } from "@superego/backend";
+import type {
+  AssistantName,
+  ConversationId,
+  ConversationNodeId,
+  Message,
+} from "@superego/backend";
 import type ConversationEntity from "../entities/ConversationEntity.js";
 
 export default interface ConversationRepository {
-  upsert(conversation: ConversationEntity): Promise<void>;
+  create(conversation: {
+    id: ConversationId;
+    assistant: AssistantName;
+    contextFingerprint: string;
+    createdAt: Date;
+  }): Promise<void>;
+  appendMessage(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    message: Message,
+  ): Promise<ConversationNodeId>;
+  updateMessage(
+    conversationId: ConversationId,
+    nodeId: ConversationNodeId,
+    message: Message,
+  ): Promise<void>;
+  setTitle(conversationId: ConversationId, title: string): Promise<void>;
+  markProcessingStarted(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    startedAt: Date,
+  ): Promise<void>;
+  markProcessingCompleted(conversationId: ConversationId): Promise<void>;
+  markProcessingFailed(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    error: { name: string; details: any },
+  ): Promise<ConversationNodeId>;
   delete(id: ConversationId): Promise<ConversationId>;
   exists(id: ConversationId): Promise<boolean>;
   find(id: ConversationId): Promise<ConversationEntity | null>;

--- a/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/conversations.ts
+++ b/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/conversations.ts
@@ -2,21 +2,21 @@ import {
   AssistantName,
   type AudioContent,
   ConversationStatus,
+  type Message,
   MessageContentPartType,
   MessageRole,
 } from "@superego/backend";
 import { Id } from "@superego/shared-utils";
 import { registeredDescribe as rd } from "@superego/vitest-registered";
 import { describe, expect, it } from "vitest";
-import type ConversationEntity from "../../../entities/ConversationEntity.js";
 import type GetDependencies from "../GetDependencies.js";
 
 export default rd<GetDependencies>("Conversations", (deps) => {
-  it("inserting (via upsert)", async () => {
+  it("creating and appending a message", async () => {
     // Setup SUT
     const { dataRepositoriesManager } = deps();
-
-    // Exercise
+    const conversationId = Id.generate.conversation();
+    const createdAt = new Date();
     const audio: AudioContent = {
       // Smallest possible WAV.
       content: new Uint8Array([
@@ -27,31 +27,31 @@ export default rd<GetDependencies>("Conversations", (deps) => {
       ]),
       contentType: "audio/wav",
     };
-    const conversation: ConversationEntity = {
-      id: Id.generate.conversation(),
-      assistant: AssistantName.Factotum,
-      title: "title",
-      contextFingerprint: "contextFingerprint",
-      messages: [
-        {
-          id: Id.generate.message(),
-          role: MessageRole.User,
-          content: [
-            { type: MessageContentPartType.Text, text: "text", audio },
-            { type: MessageContentPartType.Audio, audio },
-          ],
-          createdAt: new Date(),
-        },
+    const message = {
+      id: Id.generate.message(),
+      role: MessageRole.User,
+      content: [
+        { type: MessageContentPartType.Text, text: "text", audio },
+        { type: MessageContentPartType.Audio, audio },
       ],
-      status: ConversationStatus.Idle,
-      processingStartedAt: null,
-      error: null,
-      createdAt: new Date(),
-    };
-    await dataRepositoriesManager.runInSerializableTransaction(
+      createdAt,
+    } satisfies Message.User;
+
+    // Exercise
+    const nodeId = await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => {
-        await repos.conversation.upsert(conversation);
-        return { action: "commit", returnValue: null };
+        await repos.conversation.create({
+          id: conversationId,
+          assistant: AssistantName.Factotum,
+          contextFingerprint: "contextFingerprint",
+          createdAt,
+        });
+        const appendedNodeId = await repos.conversation.appendMessage(
+          conversationId,
+          null,
+          message,
+        );
+        return { action: "commit", returnValue: appendedNodeId };
       },
     );
 
@@ -59,41 +59,72 @@ export default rd<GetDependencies>("Conversations", (deps) => {
     const found = await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => ({
         action: "commit",
-        returnValue: await repos.conversation.find(conversation.id),
+        returnValue: await repos.conversation.find(conversationId),
       }),
     );
-    expect(found).toEqual(conversation);
-  });
-
-  it("updating (via upsert)", async () => {
-    // Setup SUT
-    const { dataRepositoriesManager } = deps();
-    const conversation: ConversationEntity = {
-      id: Id.generate.conversation(),
+    expect(found).toEqual({
+      id: conversationId,
       assistant: AssistantName.Factotum,
-      title: "original title",
+      title: null,
       contextFingerprint: "contextFingerprint",
-      messages: [],
+      nodes: [
+        {
+          type: "Message",
+          id: nodeId,
+          previousNodeId: null,
+          message,
+          createdAt,
+        },
+      ],
+      activeNodeId: nodeId,
       status: ConversationStatus.Idle,
       processingStartedAt: null,
       error: null,
-      createdAt: new Date(),
-    };
-    await dataRepositoriesManager.runInSerializableTransaction(
+      createdAt,
+    });
+  });
+
+  it("updating a message and setting a title", async () => {
+    // Setup SUT
+    const { dataRepositoriesManager } = deps();
+    const conversationId = Id.generate.conversation();
+    const createdAt = new Date();
+    const message = {
+      id: Id.generate.message(),
+      role: MessageRole.User,
+      content: [{ type: MessageContentPartType.Text, text: "original" }],
+      createdAt,
+    } satisfies Message.User;
+    const updatedMessage = {
+      ...message,
+      content: [{ type: MessageContentPartType.Text, text: "updated" }],
+    } satisfies Message.User;
+    const nodeId = await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => {
-        await repos.conversation.upsert(conversation);
-        return { action: "commit", returnValue: null };
+        await repos.conversation.create({
+          id: conversationId,
+          assistant: AssistantName.Factotum,
+          contextFingerprint: "contextFingerprint",
+          createdAt,
+        });
+        const appendedNodeId = await repos.conversation.appendMessage(
+          conversationId,
+          null,
+          message,
+        );
+        return { action: "commit", returnValue: appendedNodeId };
       },
     );
 
     // Exercise
-    const updatedConversation: ConversationEntity = {
-      ...conversation,
-      title: "updated title",
-    };
     await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => {
-        await repos.conversation.upsert(updatedConversation);
+        await repos.conversation.updateMessage(
+          conversationId,
+          nodeId,
+          updatedMessage,
+        );
+        await repos.conversation.setTitle(conversationId, "updated title");
         return { action: "commit", returnValue: null };
       },
     );
@@ -102,29 +133,200 @@ export default rd<GetDependencies>("Conversations", (deps) => {
     const found = await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => ({
         action: "commit",
-        returnValue: await repos.conversation.find(conversation.id),
+        returnValue: await repos.conversation.find(conversationId),
       }),
     );
-    expect(found).toEqual(updatedConversation);
+    expect(found?.title).toEqual("updated title");
+    expect(found?.nodes).toMatchObject([
+      { id: nodeId, message: updatedMessage },
+    ]);
   });
 
-  it("deleting", async () => {
+  it("branching from an earlier node", async () => {
     // Setup SUT
     const { dataRepositoriesManager } = deps();
-    const conversation: ConversationEntity = {
-      id: Id.generate.conversation(),
-      assistant: AssistantName.Factotum,
-      title: "title",
-      contextFingerprint: "contextFingerprint",
-      messages: [],
-      status: ConversationStatus.Idle,
+    const conversationId = Id.generate.conversation();
+    const createdAt = new Date();
+    const messages = ["U1", "A1", "U2", "A2", "A2 retry"].map(
+      (text, index) =>
+        ({
+          id: Id.generate.message(),
+          role:
+            index === 1 || index >= 3
+              ? MessageRole.Assistant
+              : MessageRole.User,
+          content: [{ type: MessageContentPartType.Text, text }],
+          reasoning: {},
+          inferenceOptions: {
+            completion: {
+              providerModelRef: { providerName: "p", modelName: "m" },
+              reasoningEffort: "Medium",
+            },
+            transcription: null,
+            fileInspection: null,
+          },
+          generationStats: {
+            timeTaken: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+          },
+          createdAt: new Date(index),
+        }) as any,
+    );
+
+    // Exercise
+    const nodeIds = await dataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => {
+        await repos.conversation.create({
+          id: conversationId,
+          assistant: AssistantName.Factotum,
+          contextFingerprint: "contextFingerprint",
+          createdAt,
+        });
+        const node1 = await repos.conversation.appendMessage(
+          conversationId,
+          null,
+          messages[0]!,
+        );
+        const node2 = await repos.conversation.appendMessage(
+          conversationId,
+          node1,
+          messages[1]!,
+        );
+        const node3 = await repos.conversation.appendMessage(
+          conversationId,
+          node2,
+          messages[2]!,
+        );
+        const node4 = await repos.conversation.appendMessage(
+          conversationId,
+          node3,
+          messages[3]!,
+        );
+        const node5 = await repos.conversation.appendMessage(
+          conversationId,
+          node3,
+          messages[4]!,
+        );
+        return {
+          action: "commit",
+          returnValue: [node1, node2, node3, node4, node5],
+        };
+      },
+    );
+
+    // Verify
+    const found = await dataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => ({
+        action: "commit",
+        returnValue: await repos.conversation.find(conversationId),
+      }),
+    );
+    expect(found?.nodes).toHaveLength(5);
+    expect(found?.nodes.find((node) => node.id === nodeIds[3])).toMatchObject({
+      previousNodeId: nodeIds[2],
+    });
+    expect(found?.nodes.find((node) => node.id === nodeIds[4])).toMatchObject({
+      previousNodeId: nodeIds[2],
+    });
+    expect(found?.activeNodeId).toEqual(nodeIds[4]);
+  });
+
+  it("processing transitions and branch-local errors", async () => {
+    // Setup SUT
+    const { dataRepositoriesManager } = deps();
+    const conversationId = Id.generate.conversation();
+    const createdAt = new Date();
+    const message = {
+      id: Id.generate.message(),
+      role: MessageRole.User,
+      content: [{ type: MessageContentPartType.Text, text: "text" }],
+      createdAt,
+    } satisfies Message.User;
+    const error = { name: "UnexpectedError", details: { cause: "test" } };
+
+    // Exercise
+    const { nodeId, errorNodeId, processingStartedAt } =
+      await dataRepositoriesManager.runInSerializableTransaction(
+        async (repos) => {
+          await repos.conversation.create({
+            id: conversationId,
+            assistant: AssistantName.Factotum,
+            contextFingerprint: "contextFingerprint",
+            createdAt,
+          });
+          const appendedNodeId = await repos.conversation.appendMessage(
+            conversationId,
+            null,
+            message,
+          );
+          const startedAt = new Date();
+          await repos.conversation.markProcessingStarted(
+            conversationId,
+            appendedNodeId,
+            startedAt,
+          );
+          await repos.conversation.markProcessingCompleted(conversationId);
+          await repos.conversation.markProcessingStarted(
+            conversationId,
+            appendedNodeId,
+            startedAt,
+          );
+          const appendedErrorNodeId =
+            await repos.conversation.markProcessingFailed(
+              conversationId,
+              appendedNodeId,
+              error,
+            );
+          return {
+            action: "commit",
+            returnValue: {
+              nodeId: appendedNodeId,
+              errorNodeId: appendedErrorNodeId,
+              processingStartedAt: startedAt,
+            },
+          };
+        },
+      );
+
+    // Verify
+    const found = await dataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => ({
+        action: "commit",
+        returnValue: await repos.conversation.find(conversationId),
+      }),
+    );
+    expect(processingStartedAt).toBeInstanceOf(Date);
+    expect(found).toMatchObject({
+      status: ConversationStatus.Error,
+      activeNodeId: errorNodeId,
+      error,
       processingStartedAt: null,
-      error: null,
-      createdAt: new Date(),
-    };
+    });
+    expect(found?.nodes).toEqual([
+      expect.objectContaining({ id: nodeId, type: "Message" }),
+      expect.objectContaining({
+        id: errorNodeId,
+        type: "Error",
+        previousNodeId: nodeId,
+        error,
+      }),
+    ]);
+  });
+
+  it("deleting hides the conversation", async () => {
+    // Setup SUT
+    const { dataRepositoriesManager } = deps();
+    const conversationId = Id.generate.conversation();
     await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => {
-        await repos.conversation.upsert(conversation);
+        await repos.conversation.create({
+          id: conversationId,
+          assistant: AssistantName.Factotum,
+          contextFingerprint: "contextFingerprint",
+          createdAt: new Date(),
+        });
         return { action: "commit", returnValue: null };
       },
     );
@@ -134,16 +336,16 @@ export default rd<GetDependencies>("Conversations", (deps) => {
       await dataRepositoriesManager.runInSerializableTransaction(
         async (repos) => ({
           action: "commit",
-          returnValue: await repos.conversation.delete(conversation.id),
+          returnValue: await repos.conversation.delete(conversationId),
         }),
       );
 
     // Verify
-    expect(deletedId).toEqual(conversation.id);
+    expect(deletedId).toEqual(conversationId);
     const found = await dataRepositoriesManager.runInSerializableTransaction(
       async (repos) => ({
         action: "commit",
-        returnValue: await repos.conversation.find(conversation.id),
+        returnValue: await repos.conversation.find(conversationId),
       }),
     );
     expect(found).toEqual(null);
@@ -153,20 +355,15 @@ export default rd<GetDependencies>("Conversations", (deps) => {
     it("case: exists", async () => {
       // Setup SUT
       const { dataRepositoriesManager } = deps();
-      const conversation: ConversationEntity = {
-        id: Id.generate.conversation(),
-        assistant: AssistantName.Factotum,
-        title: "title",
-        contextFingerprint: "contextFingerprint",
-        messages: [],
-        status: ConversationStatus.Idle,
-        processingStartedAt: null,
-        error: null,
-        createdAt: new Date(),
-      };
+      const conversationId = Id.generate.conversation();
       await dataRepositoriesManager.runInSerializableTransaction(
         async (repos) => {
-          await repos.conversation.upsert(conversation);
+          await repos.conversation.create({
+            id: conversationId,
+            assistant: AssistantName.Factotum,
+            contextFingerprint: "contextFingerprint",
+            createdAt: new Date(),
+          });
           return { action: "commit", returnValue: null };
         },
       );
@@ -175,7 +372,7 @@ export default rd<GetDependencies>("Conversations", (deps) => {
       const exists = await dataRepositoriesManager.runInSerializableTransaction(
         async (repos) => ({
           action: "commit",
-          returnValue: await repos.conversation.exists(conversation.id),
+          returnValue: await repos.conversation.exists(conversationId),
         }),
       );
 
@@ -202,59 +399,6 @@ export default rd<GetDependencies>("Conversations", (deps) => {
     });
   });
 
-  describe("finding one", () => {
-    it("case: exists => returns it", async () => {
-      // Setup SUT
-      const { dataRepositoriesManager } = deps();
-      const conversation: ConversationEntity = {
-        id: Id.generate.conversation(),
-        assistant: AssistantName.Factotum,
-        title: "title",
-        contextFingerprint: "contextFingerprint",
-        messages: [],
-        status: ConversationStatus.Idle,
-        processingStartedAt: null,
-        error: null,
-        createdAt: new Date(),
-      };
-      await dataRepositoriesManager.runInSerializableTransaction(
-        async (repos) => {
-          await repos.conversation.upsert(conversation);
-          return { action: "commit", returnValue: null };
-        },
-      );
-
-      // Exercise
-      const found = await dataRepositoriesManager.runInSerializableTransaction(
-        async (repos) => ({
-          action: "commit",
-          returnValue: await repos.conversation.find(conversation.id),
-        }),
-      );
-
-      // Verify
-      expect(found).toEqual(conversation);
-    });
-
-    it("case: doesn't exist => returns null", async () => {
-      // Setup SUT
-      const { dataRepositoriesManager } = deps();
-
-      // Exercise
-      const found = await dataRepositoriesManager.runInSerializableTransaction(
-        async (repos) => ({
-          action: "commit",
-          returnValue: await repos.conversation.find(
-            Id.generate.conversation(),
-          ),
-        }),
-      );
-
-      // Verify
-      expect(found).toEqual(null);
-    });
-  });
-
   describe("finding all", () => {
     it("case: no conversations => returns empty array", async () => {
       // Setup SUT
@@ -275,32 +419,22 @@ export default rd<GetDependencies>("Conversations", (deps) => {
     it("case: some conversations => returns them (ordered by createdAt, desc)", async () => {
       // Setup SUT
       const { dataRepositoriesManager } = deps();
-      const conversation1: ConversationEntity = {
-        id: Id.generate.conversation(),
-        assistant: AssistantName.Factotum,
-        title: "title 1",
-        contextFingerprint: "contextFingerprint",
-        messages: [],
-        status: ConversationStatus.Idle,
-        processingStartedAt: null,
-        error: null,
-        createdAt: new Date(1),
-      };
-      const conversation2: ConversationEntity = {
-        id: Id.generate.conversation(),
-        assistant: AssistantName.Factotum,
-        title: "title 2",
-        contextFingerprint: "contextFingerprint",
-        messages: [],
-        status: ConversationStatus.Idle,
-        processingStartedAt: null,
-        error: null,
-        createdAt: new Date(2),
-      };
+      const conversation1Id = Id.generate.conversation();
+      const conversation2Id = Id.generate.conversation();
       await dataRepositoriesManager.runInSerializableTransaction(
         async (repos) => {
-          await repos.conversation.upsert(conversation1);
-          await repos.conversation.upsert(conversation2);
+          await repos.conversation.create({
+            id: conversation1Id,
+            assistant: AssistantName.Factotum,
+            contextFingerprint: "contextFingerprint",
+            createdAt: new Date(1),
+          });
+          await repos.conversation.create({
+            id: conversation2Id,
+            assistant: AssistantName.Factotum,
+            contextFingerprint: "contextFingerprint",
+            createdAt: new Date(2),
+          });
           return { action: "commit", returnValue: null };
         },
       );
@@ -314,7 +448,10 @@ export default rd<GetDependencies>("Conversations", (deps) => {
       );
 
       // Verify
-      expect(found).toEqual([conversation2, conversation1]);
+      expect(found.map(({ id }) => id)).toEqual([
+        conversation2Id,
+        conversation1Id,
+      ]);
     });
   });
 });

--- a/packages/core/executing-backend/src/structural-schemas/backend/ids.ts
+++ b/packages/core/executing-backend/src/structural-schemas/backend/ids.ts
@@ -6,6 +6,7 @@ import type {
   CollectionId,
   CollectionVersionId,
   ConversationId,
+  ConversationNodeId,
   DocumentId,
   DocumentVersionId,
   FileId,
@@ -45,6 +46,15 @@ export function collectionVersionId(): v.GenericSchema<
 }
 export function conversationId(): v.GenericSchema<unknown, ConversationId> {
   return v.custom<ConversationId>(Id.is.conversation);
+}
+export function conversationNodeId(): v.GenericSchema<
+  unknown,
+  ConversationNodeId
+> {
+  return v.pipe(
+    v.string(),
+    v.regex(/^Conversation_[1-9A-HJ-NP-Za-km-z]{21}:\d+$/),
+  ) as unknown as v.GenericSchema<unknown, ConversationNodeId>;
 }
 export function documentId(): v.GenericSchema<unknown, DocumentId> {
   return v.custom<DocumentId>(Id.is.document);

--- a/packages/core/executing-backend/src/structural-schemas/backend/types/conversation.ts
+++ b/packages/core/executing-backend/src/structural-schemas/backend/types/conversation.ts
@@ -1,6 +1,7 @@
 import {
   AssistantName,
   type Conversation,
+  type ConversationNode,
   ConversationStatus,
   type DeveloperPrompts,
   type LiteConversation,
@@ -15,7 +16,7 @@ import {
 } from "@superego/backend";
 import * as v from "valibot";
 import unknownResultError from "../../global/unknownResultError.js";
-import { conversationId, messageId } from "../ids.js";
+import { conversationId, conversationNodeId, messageId } from "../ids.js";
 import { audioContent } from "./audioContent.js";
 import { inferenceOptions } from "./inference.js";
 
@@ -177,6 +178,31 @@ export function message(): v.GenericSchema<unknown, Message> {
   ]) as v.GenericSchema<unknown, Message>;
 }
 
+const messageNode = () =>
+  v.strictObject({
+    type: v.literal("Message"),
+    id: conversationNodeId(),
+    previousNodeId: v.nullable(conversationNodeId()),
+    message: message(),
+    createdAt: v.date(),
+  }) as v.GenericSchema<unknown, ConversationNode.MessageNode>;
+
+const errorNode = () =>
+  v.strictObject({
+    type: v.literal("Error"),
+    id: conversationNodeId(),
+    previousNodeId: v.nullable(conversationNodeId()),
+    error: unknownResultError(),
+    createdAt: v.date(),
+  }) as v.GenericSchema<unknown, ConversationNode.ErrorNode>;
+
+export function conversationNode(): v.GenericSchema<unknown, ConversationNode> {
+  return v.union([messageNode(), errorNode()]) as v.GenericSchema<
+    unknown,
+    ConversationNode
+  >;
+}
+
 export function conversation(): v.GenericSchema<unknown, Conversation> {
   return v.union([
     v.strictObject({
@@ -185,7 +211,8 @@ export function conversation(): v.GenericSchema<unknown, Conversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
-      messages: v.array(message()),
+      nodes: v.array(conversationNode()),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Idle),
       processingStartedAt: v.null(),
@@ -197,7 +224,8 @@ export function conversation(): v.GenericSchema<unknown, Conversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
-      messages: v.array(message()),
+      nodes: v.array(conversationNode()),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Processing),
       processingStartedAt: v.date(),
@@ -209,7 +237,8 @@ export function conversation(): v.GenericSchema<unknown, Conversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
-      messages: v.array(message()),
+      nodes: v.array(conversationNode()),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Error),
       processingStartedAt: v.null(),
@@ -226,6 +255,7 @@ export function liteConversation(): v.GenericSchema<unknown, LiteConversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Idle),
       processingStartedAt: v.null(),
@@ -237,6 +267,7 @@ export function liteConversation(): v.GenericSchema<unknown, LiteConversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Processing),
       processingStartedAt: v.date(),
@@ -248,6 +279,7 @@ export function liteConversation(): v.GenericSchema<unknown, LiteConversation> {
       title: v.nullable(v.string()),
       hasOutdatedContext: v.boolean(),
       canRetryLastResponse: v.boolean(),
+      activeNodeId: v.nullable(conversationNodeId()),
       createdAt: v.date(),
       status: v.literal(ConversationStatus.Error),
       processingStartedAt: v.null(),

--- a/packages/core/executing-backend/src/usecases/assistants/ContinueConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/ContinueConversation.ts
@@ -23,7 +23,6 @@ import {
   validateInferenceOptions,
 } from "@superego/shared-utils";
 import * as v from "valibot";
-import type ConversationEntity from "../../entities/ConversationEntity.js";
 import type FileEntity from "../../entities/FileEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
@@ -134,12 +133,6 @@ export default class AssistantsContinueConversation extends BackendUsecase<
       content: convertedMessageContent as NonEmptyArray<MessageContentPart>,
       createdAt: now,
     };
-    const updatedConversation: ConversationEntity = {
-      ...conversation,
-      messages: [...conversation.messages, userMessage],
-      status: ConversationStatus.Processing,
-      processingStartedAt: now,
-    };
     const conversationReference: FileEntity.ConversationReference = {
       conversationId: conversation.id,
     };
@@ -152,7 +145,16 @@ export default class AssistantsContinueConversation extends BackendUsecase<
       content: protoFileWithId.content,
     }));
 
-    await this.repos.conversation.upsert(updatedConversation);
+    const userMessageNodeId = await this.repos.conversation.appendMessage(
+      id,
+      conversation.activeNodeId,
+      userMessage,
+    );
+    await this.repos.conversation.markProcessingStarted(
+      id,
+      userMessageNodeId,
+      now,
+    );
     await this.repos.file.insertAll(filesWithContent);
     await this.repos.file.addReferenceToAll(
       referencedFileIds,
@@ -164,6 +166,10 @@ export default class AssistantsContinueConversation extends BackendUsecase<
       input: { id, inferenceOptions },
     });
 
+    const updatedConversation = await this.repos.conversation.find(id);
+    if (!updatedConversation) {
+      throw new UnexpectedAssistantError("Updated conversation not found.");
+    }
     return makeSuccessfulResult(
       makeConversation(updatedConversation, contextFingerprint),
     );

--- a/packages/core/executing-backend/src/usecases/assistants/DeleteConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/DeleteConversation.ts
@@ -53,7 +53,6 @@ export default class AssistantsDeleteConversation extends BackendUsecase<
     }
 
     await this.repos.conversation.delete(id);
-    await this.repos.file.deleteReferenceFromAll({ conversationId: id });
     await this.repos.conversationTextSearchIndex.remove(id);
     this.liveConversationStore.delete(id);
 

--- a/packages/core/executing-backend/src/usecases/assistants/ListConversations.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/ListConversations.ts
@@ -37,7 +37,7 @@ export default class AssistantsListConversations extends BackendUsecase<
         .map((conversation) =>
           makeConversation(conversation, contextFingerprint),
         )
-        .map(({ messages, ...conversation }) => conversation),
+        .map(({ nodes, ...conversation }) => conversation),
     );
   }
 }

--- a/packages/core/executing-backend/src/usecases/assistants/ProcessConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/ProcessConversation.ts
@@ -3,7 +3,9 @@ import {
   type CannotTranscribeAudioMessage,
   type Collection,
   type CollectionCategory,
+  type Conversation,
   type ConversationId,
+  type ConversationNodeId,
   type ConversationNotFound,
   ConversationStatus,
   type ConversationStatusNotProcessing,
@@ -29,7 +31,6 @@ import pMap from "p-map";
 import type Assistant from "../../assistants/Assistant.js";
 import CollectionCreatorAssistant from "../../assistants/CollectionCreatorAssistant/CollectionCreatorAssistant.js";
 import FactotumAssistant from "../../assistants/FactotumAssistant/FactotumAssistant.js";
-import type ConversationEntity from "../../entities/ConversationEntity.js";
 import makeResultError from "../../makers/makeResultError.js";
 import type InferenceService from "../../requirements/InferenceService.js";
 import ConversationTextUtils from "../../utils/ConversationTextUtils.js";
@@ -95,24 +96,23 @@ export default class AssistantsProcessConversation extends Usecase {
 
     const globalSettings = await this.repos.globalSettings.get();
 
+    const activeBranchMessages = ConversationUtils.getActiveBranchMessages(
+      conversation.nodes,
+      conversation.activeNodeId,
+    );
     const onMessagesUpdated = (messages: Message[]) =>
       this.liveConversationStore.set(id, {
-        id: conversation.id,
-        assistant: conversation.assistant,
-        title: conversation.title,
+        ...this.makeLiveConversation(conversation, messages),
         hasOutdatedContext: false,
         canRetryLastResponse: false,
-        messages: messages,
         status: ConversationStatus.Processing,
         processingStartedAt: conversation.processingStartedAt,
         error: null,
-        createdAt: conversation.createdAt,
       });
 
     // Set initial live state with the current messages (before generation).
-    onMessagesUpdated(conversation.messages);
+    onMessagesUpdated(activeBranchMessages);
 
-    let updatedConversation: ConversationEntity;
     const beforeGenerateAndProcessSavepoint =
       await this.repos.createSavepoint();
     try {
@@ -147,11 +147,28 @@ export default class AssistantsProcessConversation extends Usecase {
       const { data: transcribedMessages, error: cannotTranscribeAudioMessage } =
         await this.transcribeLastUserMessage(
           inferenceService,
-          conversation,
+          conversation.id,
+          activeBranchMessages,
           inferenceOptions,
         );
       if (cannotTranscribeAudioMessage) {
         throw cannotTranscribeAudioMessage;
+      }
+      if (transcribedMessages !== activeBranchMessages) {
+        const lastUserNode = ConversationUtils.findLastUserNode(
+          conversation.nodes,
+          conversation.activeNodeId,
+        );
+        const transcribedLastUserMessage = transcribedMessages.findLast(
+          (message) => message.role === MessageRole.User,
+        );
+        if (lastUserNode && transcribedLastUserMessage) {
+          await this.repos.conversation.updateMessage(
+            conversation.id,
+            lastUserNode.id,
+            transcribedLastUserMessage,
+          );
+        }
       }
 
       const [messages, title] = await Promise.all([
@@ -172,34 +189,45 @@ export default class AssistantsProcessConversation extends Usecase {
           : conversation.title,
       ]);
 
-      updatedConversation = {
-        ...conversation,
-        title: title,
-        status: ConversationStatus.Idle,
-        processingStartedAt: null,
-        messages: messages,
-      };
+      let previousNodeId = conversation.activeNodeId;
+      for (const message of messages.slice(transcribedMessages.length)) {
+        previousNodeId = await this.repos.conversation.appendMessage(
+          conversation.id,
+          previousNodeId,
+          message,
+        );
+      }
+      if (title !== null && title !== conversation.title) {
+        await this.repos.conversation.setTitle(conversation.id, title);
+      }
+      await this.repos.conversation.markProcessingCompleted(conversation.id);
     } catch (error) {
       await this.repos.rollbackToSavepoint(beforeGenerateAndProcessSavepoint);
-      updatedConversation = {
-        ...conversation,
-        status: ConversationStatus.Error,
-        processingStartedAt: null,
-        error: makeResultError("UnexpectedError", {
+      await this.repos.conversation.markProcessingFailed(
+        conversation.id,
+        conversation.activeNodeId,
+        makeResultError("UnexpectedError", {
           cause: extractErrorDetails(error),
         }),
-      };
+      );
     } finally {
       this.liveConversationStore.delete(id);
     }
 
-    await this.repos.conversation.upsert(updatedConversation);
+    const updatedConversation = await this.repos.conversation.find(id);
+    if (!updatedConversation) {
+      return makeUnsuccessfulResult(
+        makeResultError("ConversationNotFound", { conversationId: id }),
+      );
+    }
 
     // Index Factotum conversations for search.
     if (updatedConversation.assistant === AssistantName.Factotum) {
       const textChunks = ConversationTextUtils.extractTextChunks(
         updatedConversation.title,
-        updatedConversation.messages,
+        updatedConversation.nodes.flatMap((node) =>
+          node.type === "Message" ? [node.message] : [],
+        ),
       );
       await this.repos.conversationTextSearchIndex.upsert(
         updatedConversation.id,
@@ -265,10 +293,11 @@ export default class AssistantsProcessConversation extends Usecase {
 
   private async transcribeLastUserMessage(
     inferenceService: InferenceService,
-    conversation: ConversationEntity,
+    conversationId: ConversationId,
+    messages: Message[],
     inferenceOptions: InferenceOptions<"completion">,
   ): ResultPromise<Message[], CannotTranscribeAudioMessage> {
-    const otherMessages = [...conversation.messages];
+    const otherMessages = [...messages];
     const lastMessage = otherMessages.pop();
 
     // Skip transcription if:
@@ -285,13 +314,13 @@ export default class AssistantsProcessConversation extends Usecase {
         (part) => part.type === MessageContentPartType.Audio,
       )
     ) {
-      return makeSuccessfulResult(conversation.messages);
+      return makeSuccessfulResult(messages);
     }
 
     if (!inferenceOptionsHas(inferenceOptions, "transcription")) {
       return makeUnsuccessfulResult(
         makeResultError("CannotTranscribeAudioMessage", {
-          conversationId: conversation.id,
+          conversationId,
         }),
       );
     }
@@ -311,5 +340,40 @@ export default class AssistantsProcessConversation extends Usecase {
         )) as NonEmptyArray<MessageContentPart>,
       },
     ]);
+  }
+
+  private makeLiveConversation(
+    conversation: {
+      id: ConversationId;
+      assistant: AssistantName;
+      title: string | null;
+      createdAt: Date;
+    },
+    messages: Message[],
+  ): Pick<
+    Conversation,
+    "id" | "assistant" | "title" | "nodes" | "activeNodeId" | "createdAt"
+  > {
+    let previousNodeId: ConversationNodeId | null = null;
+    const nodes = messages.map((message, index) => {
+      const id = `${conversation.id}:${index + 1}` as ConversationNodeId;
+      const node = {
+        type: "Message" as const,
+        id,
+        previousNodeId,
+        message,
+        createdAt: "createdAt" in message ? message.createdAt : new Date(),
+      };
+      previousNodeId = id;
+      return node;
+    });
+    return {
+      id: conversation.id,
+      assistant: conversation.assistant,
+      title: conversation.title,
+      nodes,
+      activeNodeId: previousNodeId,
+      createdAt: conversation.createdAt,
+    };
   }
 }

--- a/packages/core/executing-backend/src/usecases/assistants/RecoverConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/RecoverConversation.ts
@@ -17,7 +17,6 @@ import {
   validateInferenceOptions,
 } from "@superego/shared-utils";
 import * as v from "valibot";
-import type ConversationEntity from "../../entities/ConversationEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
@@ -102,19 +101,27 @@ export default class AssistantsRecoverConversation extends BackendUsecase<
       );
     }
 
-    const updatedConversation: ConversationEntity = {
-      ...conversation,
-      status: ConversationStatus.Processing,
-      processingStartedAt: new Date(),
-      error: null,
-    };
-    await this.repos.conversation.upsert(updatedConversation);
+    const previousNodeId =
+      conversation.status === ConversationStatus.Error
+        ? (conversation.nodes.find(
+            (node) => node.id === conversation.activeNodeId,
+          )?.previousNodeId ?? null)
+        : conversation.activeNodeId;
+    await this.repos.conversation.markProcessingStarted(
+      id,
+      previousNodeId,
+      new Date(),
+    );
 
     await this.enqueueBackgroundJob({
       name: BackgroundJobName.ProcessConversation,
       input: { id, inferenceOptions },
     });
 
+    const updatedConversation = await this.repos.conversation.find(id);
+    if (!updatedConversation) {
+      throw new UnexpectedAssistantError("Updated conversation not found.");
+    }
     return makeSuccessfulResult(
       makeConversation(updatedConversation, contextFingerprint),
     );

--- a/packages/core/executing-backend/src/usecases/assistants/RetryLastResponse.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/RetryLastResponse.ts
@@ -17,7 +17,6 @@ import {
   validateInferenceOptions,
 } from "@superego/shared-utils";
 import * as v from "valibot";
-import type ConversationEntity from "../../entities/ConversationEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
 import makeResultError from "../../makers/makeResultError.js";
@@ -81,9 +80,12 @@ export default class AssistantsRetryLastResponse extends BackendUsecase<
     }
     const contextFingerprint =
       await ConversationUtils.getContextFingerprint(collections);
-    const hadSideEffects = ConversationUtils.lastResponseHadSideEffects(
-      conversation.messages,
+    const activeBranchMessages = ConversationUtils.getActiveBranchMessages(
+      conversation.nodes,
+      conversation.activeNodeId,
     );
+    const hadSideEffects =
+      ConversationUtils.lastResponseHadSideEffects(activeBranchMessages);
     const canBeRetried =
       conversation.status === ConversationStatus.Idle &&
       conversation.contextFingerprint === contextFingerprint &&
@@ -103,20 +105,25 @@ export default class AssistantsRetryLastResponse extends BackendUsecase<
       );
     }
 
-    const updatedConversation: ConversationEntity = {
-      ...conversation,
-      messages: ConversationUtils.sliceOffLastResponse(conversation.messages),
-      status: ConversationStatus.Processing,
-      processingStartedAt: new Date(),
-      error: null,
-    };
-    await this.repos.conversation.upsert(updatedConversation);
+    const lastUserNode = ConversationUtils.findLastUserNode(
+      conversation.nodes,
+      conversation.activeNodeId,
+    );
+    await this.repos.conversation.markProcessingStarted(
+      id,
+      lastUserNode?.id ?? null,
+      new Date(),
+    );
 
     await this.enqueueBackgroundJob({
       name: BackgroundJobName.ProcessConversation,
       input: { id, inferenceOptions },
     });
 
+    const updatedConversation = await this.repos.conversation.find(id);
+    if (!updatedConversation) {
+      throw new UnexpectedAssistantError("Updated conversation not found.");
+    }
     return makeSuccessfulResult(
       makeConversation(updatedConversation, contextFingerprint),
     );

--- a/packages/core/executing-backend/src/usecases/assistants/SearchConversations.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/SearchConversations.ts
@@ -57,7 +57,7 @@ export default class AssistantsSearchConversations extends BackendUsecase<
       if (!conversation) {
         continue;
       }
-      const { messages, ...liteConversation } = makeConversation(
+      const { nodes, ...liteConversation } = makeConversation(
         conversation,
         contextFingerprint,
       );

--- a/packages/core/executing-backend/src/usecases/assistants/StartConversation.ts
+++ b/packages/core/executing-backend/src/usecases/assistants/StartConversation.ts
@@ -4,7 +4,6 @@ import {
   type Backend,
   BackgroundJobName,
   type Conversation,
-  ConversationStatus,
   type FilesNotFound,
   type InferenceOptions,
   type InferenceOptionsNotValid,
@@ -22,7 +21,6 @@ import {
   validateInferenceOptions,
 } from "@superego/shared-utils";
 import * as v from "valibot";
-import type ConversationEntity from "../../entities/ConversationEntity.js";
 import type FileEntity from "../../entities/FileEntity.js";
 import UnexpectedAssistantError from "../../errors/UnexpectedAssistantError.js";
 import makeConversation from "../../makers/makeConversation.js";
@@ -104,19 +102,9 @@ export default class AssistantsStartConversation extends BackendUsecase<
       content: convertedMessageContent as NonEmptyArray<MessageContentPart>,
       createdAt: now,
     };
-    const conversation: ConversationEntity = {
-      id: Id.generate.conversation(),
-      assistant: assistant,
-      title: null,
-      contextFingerprint: contextFingerprint,
-      messages: [userMessage],
-      status: ConversationStatus.Processing,
-      processingStartedAt: now,
-      error: null,
-      createdAt: now,
-    };
+    const conversationId = Id.generate.conversation();
     const conversationReference: FileEntity.ConversationReference = {
-      conversationId: conversation.id,
+      conversationId,
     };
     const filesWithContent: (FileEntity & {
       content: Uint8Array<ArrayBuffer>;
@@ -127,7 +115,22 @@ export default class AssistantsStartConversation extends BackendUsecase<
       content: protoFileWithId.content,
     }));
 
-    await this.repos.conversation.upsert(conversation);
+    await this.repos.conversation.create({
+      id: conversationId,
+      assistant,
+      contextFingerprint,
+      createdAt: now,
+    });
+    const userMessageNodeId = await this.repos.conversation.appendMessage(
+      conversationId,
+      null,
+      userMessage,
+    );
+    await this.repos.conversation.markProcessingStarted(
+      conversationId,
+      userMessageNodeId,
+      now,
+    );
     await this.repos.file.insertAll(filesWithContent);
     await this.repos.file.addReferenceToAll(
       referencedFileIds,
@@ -136,9 +139,13 @@ export default class AssistantsStartConversation extends BackendUsecase<
 
     await this.enqueueBackgroundJob({
       name: BackgroundJobName.ProcessConversation,
-      input: { id: conversation.id, inferenceOptions },
+      input: { id: conversationId, inferenceOptions },
     });
 
+    const conversation = await this.repos.conversation.find(conversationId);
+    if (!conversation) {
+      throw new UnexpectedAssistantError("Created conversation not found.");
+    }
     return makeSuccessfulResult(
       makeConversation(conversation, contextFingerprint),
     );

--- a/packages/core/executing-backend/src/utils/ConversationUtils.ts
+++ b/packages/core/executing-backend/src/utils/ConversationUtils.ts
@@ -1,12 +1,65 @@
 import {
   type Collection,
+  type ConversationNode,
+  type ConversationNodeId,
   type Message,
   MessageRole,
   ToolName,
 } from "@superego/backend";
 import sha256 from "./sha256.js";
 
+function getActiveBranchNodes(
+  nodes: ConversationNode[],
+  activeNodeId: ConversationNodeId | null,
+): ConversationNode[] {
+  if (activeNodeId === null) {
+    return [];
+  }
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const branch: ConversationNode[] = [];
+  let currentNodeId: ConversationNodeId | null = activeNodeId;
+  while (currentNodeId !== null) {
+    const node = nodesById.get(currentNodeId);
+    if (!node) {
+      break;
+    }
+    branch.push(node);
+    currentNodeId = node.previousNodeId;
+  }
+  return branch.reverse();
+}
+
 export default {
+  getActiveBranchNodes(
+    nodes: ConversationNode[],
+    activeNodeId: ConversationNodeId | null,
+  ): ConversationNode[] {
+    return getActiveBranchNodes(nodes, activeNodeId);
+  },
+
+  getActiveBranchMessages(
+    nodes: ConversationNode[],
+    activeNodeId: ConversationNodeId | null,
+  ): Message[] {
+    return getActiveBranchNodes(nodes, activeNodeId).flatMap((node) =>
+      node.type === "Message" ? [node.message] : [],
+    );
+  },
+
+  findLastUserNode(
+    nodes: ConversationNode[],
+    activeNodeId: ConversationNodeId | null,
+  ): ConversationNode.MessageNode | null {
+    const branchNodes = getActiveBranchNodes(nodes, activeNodeId);
+    for (let i = branchNodes.length - 1; i >= 0; i--) {
+      const node = branchNodes[i]!;
+      if (node.type === "Message" && node.message.role === MessageRole.User) {
+        return node;
+      }
+    }
+    return null;
+  },
+
   /**
    * Checks if the last response (i.e., all messages since the last user
    * message) had any side effects.

--- a/packages/data/demo-data-repositories/src/repositories/DemoConversationRepository.ts
+++ b/packages/data/demo-data-repositories/src/repositories/DemoConversationRepository.ts
@@ -1,4 +1,9 @@
-import type { ConversationId } from "@superego/backend";
+import {
+  ConversationStatus,
+  type ConversationId,
+  type ConversationNodeId,
+  type Message,
+} from "@superego/backend";
 import type {
   ConversationEntity,
   ConversationRepository,
@@ -18,10 +23,109 @@ export default class DemoConversationRepository
     super();
   }
 
-  async upsert(conversation: ConversationEntity): Promise<void> {
+  async create(
+    conversation: Pick<
+      ConversationEntity,
+      "id" | "assistant" | "contextFingerprint" | "createdAt"
+    >,
+  ): Promise<void> {
     this.ensureNotDisposed();
     this.onWrite();
-    this.conversations[conversation.id] = clone(conversation);
+    this.conversations[conversation.id] = {
+      ...clone(conversation),
+      title: null,
+      nodes: [],
+      activeNodeId: null,
+      status: ConversationStatus.Idle,
+      processingStartedAt: null,
+      error: null,
+    };
+  }
+
+  async appendMessage(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    message: Message,
+  ): Promise<ConversationNodeId> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    const conversation = this.conversations[conversationId]!;
+    const nodeId = this.makeNodeId(conversationId);
+    conversation.nodes.push({
+      type: "Message",
+      id: nodeId,
+      previousNodeId,
+      message: clone(message),
+      createdAt: new Date(),
+    });
+    conversation.activeNodeId = nodeId;
+    return nodeId;
+  }
+
+  async updateMessage(
+    conversationId: ConversationId,
+    nodeId: ConversationNodeId,
+    message: Message,
+  ): Promise<void> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    const conversation = this.conversations[conversationId]!;
+    const node = conversation.nodes.find((node) => node.id === nodeId);
+    if (node?.type === "Message") {
+      node.message = clone(message);
+    }
+  }
+
+  async setTitle(conversationId: ConversationId, title: string): Promise<void> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    this.conversations[conversationId]!.title = title;
+  }
+
+  async markProcessingStarted(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    startedAt: Date,
+  ): Promise<void> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    const conversation = this.conversations[conversationId]!;
+    conversation.activeNodeId = previousNodeId;
+    conversation.status = ConversationStatus.Processing;
+    conversation.processingStartedAt = startedAt;
+    conversation.error = null;
+  }
+
+  async markProcessingCompleted(conversationId: ConversationId): Promise<void> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    const conversation = this.conversations[conversationId]!;
+    conversation.status = ConversationStatus.Idle;
+    conversation.processingStartedAt = null;
+    conversation.error = null;
+  }
+
+  async markProcessingFailed(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    error: { name: string; details: any },
+  ): Promise<ConversationNodeId> {
+    this.ensureNotDisposed();
+    this.onWrite();
+    const conversation = this.conversations[conversationId]!;
+    const nodeId = this.makeNodeId(conversationId);
+    conversation.nodes.push({
+      type: "Error",
+      id: nodeId,
+      previousNodeId,
+      error,
+      createdAt: new Date(),
+    });
+    conversation.activeNodeId = nodeId;
+    conversation.status = ConversationStatus.Error;
+    conversation.processingStartedAt = null;
+    conversation.error = error;
+    return nodeId;
   }
 
   async delete(id: ConversationId): Promise<ConversationId> {
@@ -48,5 +152,11 @@ export default class DemoConversationRepository
         a.createdAt <= b.createdAt ? 1 : -1,
       ),
     );
+  }
+
+  private makeNodeId(conversationId: ConversationId): ConversationNodeId {
+    return `${conversationId}:${
+      (this.conversations[conversationId]?.nodes.length ?? 0) + 1
+    }` as ConversationNodeId;
   }
 }

--- a/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.test.ts
+++ b/packages/data/sqlite-data-repositories/src/SqliteDataRepositoriesManager.test.ts
@@ -2,7 +2,16 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { AssistantName, Theme } from "@superego/backend";
+import { encode } from "@msgpack/msgpack";
+import {
+  AssistantName,
+  ConversationStatus,
+  type Message,
+  MessageContentPartType,
+  MessageRole,
+  ReasoningEffort,
+  Theme,
+} from "@superego/backend";
 import { registerDataRepositoriesTests } from "@superego/executing-backend/tests";
 import { Id } from "@superego/shared-utils";
 import { afterAll, beforeAll, expect, it } from "vitest";
@@ -47,6 +56,158 @@ registerDataRepositoriesTests(() => {
   });
   dataRepositoriesManager.runMigrations();
   return { dataRepositoriesManager };
+});
+
+it("migrates mutable conversations to synthesized event history", async () => {
+  // Setup SUT
+  const fileName = join(databasesTmpDir, `${crypto.randomUUID()}.sqlite`);
+  const db = new DatabaseSync(fileName);
+  db.exec(`
+    CREATE TABLE "migrations" (
+      "file_name" TEXT PRIMARY KEY,
+      "applied_at" TEXT NOT NULL
+    );
+
+    CREATE TABLE "conversations" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "assistant" TEXT NOT NULL,
+      "title" TEXT,
+      "context_fingerprint" TEXT NOT NULL,
+      "messages" BLOB NOT NULL,
+      "status" TEXT NOT NULL,
+      "error" TEXT,
+      "created_at" TEXT NOT NULL,
+      "processing_started_at" TEXT,
+      CHECK (json_valid("error"))
+    );
+  `);
+  const insertMigration = db.prepare(`
+    INSERT INTO "migrations" ("file_name", "applied_at")
+    VALUES (?, ?)
+  `);
+  for (const migrationFileName of [
+    "0000.sql",
+    "0001.sql",
+    "0002.sql",
+    "0003.sql",
+    "0004.sql",
+    "0005.sql",
+    "0006.sql",
+    "0007.sql",
+    "0008.sql",
+    "0009.sql",
+    "0010.sql",
+    "0011.sql",
+  ]) {
+    insertMigration.run(migrationFileName, new Date(0).toISOString());
+  }
+
+  const conversationId = Id.generate.conversation();
+  const userMessage = {
+    id: Id.generate.message(),
+    role: MessageRole.User,
+    content: [{ type: MessageContentPartType.Text, text: "Question" }],
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  } satisfies Message.User;
+  const assistantMessage = {
+    id: Id.generate.message(),
+    role: MessageRole.Assistant,
+    content: [{ type: MessageContentPartType.Text, text: "Answer" }],
+    reasoning: {},
+    inferenceOptions: {
+      completion: {
+        providerModelRef: { providerName: "provider", modelId: "model" },
+        reasoningEffort: ReasoningEffort.Medium,
+      },
+      transcription: null,
+      fileInspection: null,
+    },
+    generationStats: {
+      timeTaken: 0,
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+    },
+    createdAt: new Date("2026-01-01T00:01:00.000Z"),
+  } satisfies Message.Assistant;
+  const error = { name: "UnexpectedError", details: { message: "Failed" } };
+  db.prepare(`
+    INSERT INTO "conversations"
+      (
+        "id",
+        "assistant",
+        "title",
+        "context_fingerprint",
+        "messages",
+        "status",
+        "error",
+        "created_at",
+        "processing_started_at"
+      )
+    VALUES
+      (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    conversationId,
+    AssistantName.Factotum,
+    "Migrated title",
+    "contextFingerprint",
+    Buffer.from(encode([userMessage, assistantMessage] satisfies Message[])),
+    ConversationStatus.Error,
+    JSON.stringify(error),
+    "2026-01-01T00:00:00.000Z",
+    null,
+  );
+  db.close();
+
+  const dataRepositoriesManager = new SqliteDataRepositoriesManager({
+    fileName,
+    defaultGlobalSettings,
+    enableForeignKeyConstraints: false,
+  });
+
+  // Exercise
+  dataRepositoriesManager.runMigrations();
+
+  // Verify
+  const found = await dataRepositoriesManager.runInSerializableTransaction(
+    async (repos) => ({
+      action: "commit",
+      returnValue: await repos.conversation.find(conversationId),
+    }),
+  );
+  expect(found).toMatchObject({
+    id: conversationId,
+    assistant: AssistantName.Factotum,
+    title: "Migrated title",
+    contextFingerprint: "contextFingerprint",
+    activeNodeId: `${conversationId}:4`,
+    status: ConversationStatus.Error,
+    error,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  });
+  expect(found?.nodes).toEqual([
+    {
+      type: "Message",
+      id: `${conversationId}:1`,
+      previousNodeId: null,
+      message: userMessage,
+      createdAt: userMessage.createdAt,
+    },
+    {
+      type: "Message",
+      id: `${conversationId}:2`,
+      previousNodeId: `${conversationId}:1`,
+      message: assistantMessage,
+      createdAt: assistantMessage.createdAt,
+    },
+    {
+      type: "Error",
+      id: `${conversationId}:4`,
+      previousNodeId: `${conversationId}:2`,
+      error,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    },
+  ]);
 });
 
 it("returns a clear error when SQLite is locked", async () => {

--- a/packages/data/sqlite-data-repositories/src/migrations/0012.ts
+++ b/packages/data/sqlite-data-repositories/src/migrations/0012.ts
@@ -1,0 +1,134 @@
+import type { DatabaseSync } from "node:sqlite";
+import { decode, encode } from "@msgpack/msgpack";
+import { ConversationStatus, type Message } from "@superego/backend";
+import { makeConversationNodeId } from "../types/SqliteConversation.js";
+
+type OldSqliteConversation = {
+  id: string;
+  assistant: string;
+  title: string | null;
+  context_fingerprint: string;
+  messages: Buffer;
+  status: ConversationStatus;
+  processing_started_at: string | null;
+  error: string | null;
+  created_at: string;
+};
+
+export default function m0012(db: DatabaseSync): void {
+  db.exec(`ALTER TABLE "conversations" RENAME TO "conversations_old"`);
+  db.exec(`
+    CREATE TABLE "conversations" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "assistant" TEXT NOT NULL,
+      "context_fingerprint" TEXT NOT NULL,
+      "created_at" TEXT NOT NULL
+    );
+
+    CREATE TABLE "conversation_events" (
+      "conversation_id" TEXT NOT NULL,
+      "position" INTEGER NOT NULL,
+      "type" TEXT NOT NULL,
+      "payload" BLOB NOT NULL,
+      "created_at" TEXT NOT NULL,
+      PRIMARY KEY ("conversation_id", "position"),
+      FOREIGN KEY ("conversation_id") REFERENCES "conversations" ("id")
+    );
+
+    CREATE INDEX "idx__conversation_events__on__conversation_id" ON "conversation_events" (
+      "conversation_id"
+    );
+
+    CREATE INDEX "idx__conversation_events__on__type" ON "conversation_events" (
+      "type"
+    );
+  `);
+
+  const oldConversations = db
+    .prepare(`SELECT * FROM "conversations_old" ORDER BY "created_at" ASC`)
+    .all() as OldSqliteConversation[];
+  const insertConversation = db.prepare(`
+    INSERT INTO "conversations"
+      ("id", "assistant", "context_fingerprint", "created_at")
+    VALUES
+      (?, ?, ?, ?)
+  `);
+  const insertEvent = db.prepare(`
+    INSERT INTO "conversation_events"
+      ("conversation_id", "position", "type", "payload", "created_at")
+    VALUES
+      (?, ?, ?, ?, ?)
+  `);
+
+  for (const conversation of oldConversations) {
+    insertConversation.run(
+      conversation.id,
+      conversation.assistant,
+      conversation.context_fingerprint,
+      conversation.created_at,
+    );
+
+    let position = 1;
+    let previousNodeId: string | null = null;
+    const messages = decode(conversation.messages) as Message[];
+    for (const message of messages) {
+      insertEvent.run(
+        conversation.id,
+        position,
+        "MessageAdded",
+        Buffer.from(encode({ previousNodeId, message })),
+        "createdAt" in message
+          ? new Date(message.createdAt).toISOString()
+          : conversation.created_at,
+      );
+      previousNodeId = makeConversationNodeId(conversation.id as any, position);
+      position++;
+    }
+
+    if (conversation.title !== null) {
+      insertEvent.run(
+        conversation.id,
+        position++,
+        "TitleSet",
+        Buffer.from(encode({ title: conversation.title })),
+        conversation.created_at,
+      );
+    }
+
+    if (conversation.status === ConversationStatus.Processing) {
+      const processingStartedAt =
+        conversation.processing_started_at ?? conversation.created_at;
+      insertEvent.run(
+        conversation.id,
+        position++,
+        "ProcessingStarted",
+        Buffer.from(
+          encode({
+            previousNodeId,
+            processingStartedAt: new Date(processingStartedAt),
+          }),
+        ),
+        processingStartedAt,
+      );
+    }
+
+    if (conversation.status === ConversationStatus.Error) {
+      insertEvent.run(
+        conversation.id,
+        position++,
+        "ProcessingFailed",
+        Buffer.from(
+          encode({
+            previousNodeId,
+            error: conversation.error
+              ? JSON.parse(conversation.error)
+              : { name: "UnexpectedError", details: null },
+          }),
+        ),
+        conversation.created_at,
+      );
+    }
+  }
+
+  db.exec(`DROP TABLE "conversations_old"`);
+}

--- a/packages/data/sqlite-data-repositories/src/migrations/migrate.ts
+++ b/packages/data/sqlite-data-repositories/src/migrations/migrate.ts
@@ -11,6 +11,7 @@ import m0008 from "./0008.sql?raw";
 import m0009 from "./0009.sql?raw";
 import m0010 from "./0010.sql?raw";
 import m0011 from "./0011.sql?raw";
+import m0012 from "./0012.js";
 
 const migrationFiles = {
   "0000.sql": m0000,
@@ -25,6 +26,7 @@ const migrationFiles = {
   "0009.sql": m0009,
   "0010.sql": m0010,
   "0011.sql": m0011,
+  "0012.ts": m0012,
 };
 const table = "migrations";
 
@@ -60,7 +62,12 @@ export default function migrate(db: DatabaseSync) {
     if (appliedMigrations.some(({ file_name }) => file_name === fileName)) {
       continue;
     }
-    db.exec(migrationFiles[fileName]);
+    const migration = migrationFiles[fileName];
+    if (typeof migration === "string") {
+      db.exec(migration);
+    } else {
+      migration(db);
+    }
     insertMigration.run(fileName, new Date().toISOString());
   }
   db.exec("COMMIT");

--- a/packages/data/sqlite-data-repositories/src/repositories/SqliteConversationRepository.ts
+++ b/packages/data/sqlite-data-repositories/src/repositories/SqliteConversationRepository.ts
@@ -1,81 +1,325 @@
 import type { DatabaseSync } from "node:sqlite";
-import { encode } from "@msgpack/msgpack";
-import type { ConversationId } from "@superego/backend";
+import { decode, encode } from "@msgpack/msgpack";
+import {
+  ConversationStatus,
+  type ConversationId,
+  type ConversationNode,
+  type ConversationNodeId,
+  type Message,
+} from "@superego/backend";
 import type {
   ConversationEntity,
   ConversationRepository,
 } from "@superego/executing-backend";
 import type SqliteConversation from "../types/SqliteConversation.js";
-import { toEntity } from "../types/SqliteConversation.js";
+import type { SqliteConversationEvent } from "../types/SqliteConversation.js";
+import { makeConversationNodeId } from "../types/SqliteConversation.js";
 
-const table = "conversations";
+const conversationsTable = "conversations";
+const conversationEventsTable = "conversation_events";
+
+enum ConversationEventType {
+  MessageAdded = "MessageAdded",
+  MessageUpdated = "MessageUpdated",
+  TitleSet = "TitleSet",
+  ProcessingStarted = "ProcessingStarted",
+  ProcessingCompleted = "ProcessingCompleted",
+  ProcessingFailed = "ProcessingFailed",
+  ConversationDeleted = "ConversationDeleted",
+}
+
+type MessageAddedPayload = {
+  previousNodeId: ConversationNodeId | null;
+  message: Message;
+};
+type MessageUpdatedPayload = {
+  nodeId: ConversationNodeId;
+  message: Message;
+};
+type TitleSetPayload = { title: string };
+type ProcessingStartedPayload = {
+  previousNodeId: ConversationNodeId | null;
+  processingStartedAt: Date;
+};
+type ProcessingFailedPayload = {
+  previousNodeId: ConversationNodeId | null;
+  error: { name: string; details: any };
+};
 
 export default class SqliteConversationRepository implements ConversationRepository {
   constructor(private db: DatabaseSync) {}
 
-  async upsert(conversation: ConversationEntity): Promise<void> {
+  async create(
+    conversation: Pick<
+      ConversationEntity,
+      "id" | "assistant" | "contextFingerprint" | "createdAt"
+    >,
+  ): Promise<void> {
     this.db
       .prepare(`
-        INSERT INTO "${table}"
-          (
-            "id",
-            "assistant",
-            "title",
-            "context_fingerprint",
-            "messages",
-            "status",
-            "processing_started_at",
-            "error",
-            "created_at"
-          )
+        INSERT INTO "${conversationsTable}"
+          ("id", "assistant", "context_fingerprint", "created_at")
         VALUES
-          (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT("id") DO UPDATE SET
-          "assistant" = excluded."assistant",
-          "title" = excluded."title",
-          "context_fingerprint" = excluded."context_fingerprint",
-          "messages" = excluded."messages",
-          "status" = excluded."status",
-          "processing_started_at" = excluded."processing_started_at",
-          "error" = excluded."error",
-          "created_at" = excluded."created_at"
+          (?, ?, ?, ?)
       `)
       .run(
         conversation.id,
         conversation.assistant,
-        conversation.title,
         conversation.contextFingerprint,
-        encode(conversation.messages),
-        conversation.status,
-        conversation.processingStartedAt?.toISOString() ?? null,
-        conversation.error ? JSON.stringify(conversation.error) : null,
         conversation.createdAt.toISOString(),
       );
   }
 
+  async appendMessage(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    message: Message,
+  ): Promise<ConversationNodeId> {
+    const position = this.appendEvent(
+      conversationId,
+      ConversationEventType.MessageAdded,
+      { previousNodeId, message } satisfies MessageAddedPayload,
+    );
+    return makeConversationNodeId(conversationId, position);
+  }
+
+  async updateMessage(
+    conversationId: ConversationId,
+    nodeId: ConversationNodeId,
+    message: Message,
+  ): Promise<void> {
+    this.appendEvent(conversationId, ConversationEventType.MessageUpdated, {
+      nodeId,
+      message,
+    } satisfies MessageUpdatedPayload);
+  }
+
+  async setTitle(conversationId: ConversationId, title: string): Promise<void> {
+    this.appendEvent(conversationId, ConversationEventType.TitleSet, {
+      title,
+    } satisfies TitleSetPayload);
+  }
+
+  async markProcessingStarted(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    startedAt: Date,
+  ): Promise<void> {
+    this.appendEvent(conversationId, ConversationEventType.ProcessingStarted, {
+      previousNodeId,
+      processingStartedAt: startedAt,
+    } satisfies ProcessingStartedPayload);
+  }
+
+  async markProcessingCompleted(conversationId: ConversationId): Promise<void> {
+    this.appendEvent(
+      conversationId,
+      ConversationEventType.ProcessingCompleted,
+      null,
+    );
+  }
+
+  async markProcessingFailed(
+    conversationId: ConversationId,
+    previousNodeId: ConversationNodeId | null,
+    error: { name: string; details: any },
+  ): Promise<ConversationNodeId> {
+    const position = this.appendEvent(
+      conversationId,
+      ConversationEventType.ProcessingFailed,
+      { previousNodeId, error } satisfies ProcessingFailedPayload,
+    );
+    return makeConversationNodeId(conversationId, position);
+  }
+
   async delete(id: ConversationId): Promise<ConversationId> {
-    this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    this.appendEvent(id, ConversationEventType.ConversationDeleted, null);
     return id;
   }
 
   async exists(id: ConversationId): Promise<boolean> {
-    const result = this.db
-      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
-      .get(id) as 1 | undefined;
-    return result !== undefined;
+    return (await this.find(id)) !== null;
   }
 
   async find(id: ConversationId): Promise<ConversationEntity | null> {
     const conversation = this.db
-      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .prepare(`SELECT * FROM "${conversationsTable}" WHERE "id" = ?`)
       .get(id) as SqliteConversation | undefined;
-    return conversation ? toEntity(conversation) : null;
+    if (!conversation) {
+      return null;
+    }
+    return this.projectConversation(conversation);
   }
 
   async findAll(): Promise<ConversationEntity[]> {
     const conversations = this.db
-      .prepare(`SELECT * FROM "${table}" ORDER BY "created_at" DESC`)
+      .prepare(
+        `SELECT * FROM "${conversationsTable}" ORDER BY "created_at" DESC`,
+      )
       .all() as SqliteConversation[];
-    return conversations.map(toEntity);
+    const projectedConversations = conversations.map((conversation) =>
+      this.projectConversation(conversation),
+    );
+    return projectedConversations.filter(
+      (conversation) => conversation !== null,
+    );
+  }
+
+  private appendEvent(
+    conversationId: ConversationId,
+    type: ConversationEventType,
+    payload: unknown,
+  ): number {
+    const position = this.nextPosition(conversationId);
+    this.db
+      .prepare(`
+        INSERT INTO "${conversationEventsTable}"
+          ("conversation_id", "position", "type", "payload", "created_at")
+        VALUES
+          (?, ?, ?, ?, ?)
+      `)
+      .run(
+        conversationId,
+        position,
+        type,
+        Buffer.from(encode(payload)),
+        new Date().toISOString(),
+      );
+    return position;
+  }
+
+  private nextPosition(conversationId: ConversationId): number {
+    const result = this.db
+      .prepare(`
+        SELECT COALESCE(MAX("position"), 0) + 1 AS "position"
+        FROM "${conversationEventsTable}"
+        WHERE "conversation_id" = ?
+      `)
+      .get(conversationId) as { position: number };
+    return result.position;
+  }
+
+  private projectConversation(
+    conversation: SqliteConversation,
+  ): ConversationEntity | null {
+    const events = this.db
+      .prepare(`
+        SELECT *
+        FROM "${conversationEventsTable}"
+        WHERE "conversation_id" = ?
+        ORDER BY "position" ASC
+      `)
+      .all(conversation.id) as SqliteConversationEvent[];
+
+    const nodes: ConversationNode[] = [];
+    const nodesById = new Map<ConversationNodeId, ConversationNode>();
+    let title: string | null = null;
+    let activeNodeId: ConversationNodeId | null = null;
+    let status = ConversationStatus.Idle;
+    let processingStartedAt: Date | null = null;
+    let error: { name: string; details: any } | null = null;
+    let deleted = false;
+
+    for (const event of events) {
+      switch (event.type) {
+        case ConversationEventType.MessageAdded: {
+          const payload = decode(event.payload) as MessageAddedPayload;
+          this.assertPreviousNodeExists(nodesById, payload.previousNodeId);
+          const node: ConversationNode.MessageNode = {
+            type: "Message",
+            id: makeConversationNodeId(event.conversation_id, event.position),
+            previousNodeId: payload.previousNodeId,
+            message: payload.message,
+            createdAt:
+              "createdAt" in payload.message
+                ? payload.message.createdAt
+                : new Date(event.created_at),
+          };
+          nodes.push(node);
+          nodesById.set(node.id, node);
+          activeNodeId = node.id;
+          break;
+        }
+        case ConversationEventType.MessageUpdated: {
+          const payload = decode(event.payload) as MessageUpdatedPayload;
+          const node = nodesById.get(payload.nodeId);
+          if (!node || node.type !== "Message") {
+            throw new Error(`Message node ${payload.nodeId} not found.`);
+          }
+          node.message = payload.message;
+          break;
+        }
+        case ConversationEventType.TitleSet: {
+          const payload = decode(event.payload) as TitleSetPayload;
+          title = payload.title;
+          break;
+        }
+        case ConversationEventType.ProcessingStarted: {
+          const payload = decode(event.payload) as ProcessingStartedPayload;
+          this.assertPreviousNodeExists(nodesById, payload.previousNodeId);
+          activeNodeId = payload.previousNodeId;
+          status = ConversationStatus.Processing;
+          processingStartedAt = new Date(payload.processingStartedAt);
+          error = null;
+          break;
+        }
+        case ConversationEventType.ProcessingCompleted:
+          status = ConversationStatus.Idle;
+          processingStartedAt = null;
+          error = null;
+          break;
+        case ConversationEventType.ProcessingFailed: {
+          const payload = decode(event.payload) as ProcessingFailedPayload;
+          this.assertPreviousNodeExists(nodesById, payload.previousNodeId);
+          const node: ConversationNode.ErrorNode = {
+            type: "Error",
+            id: makeConversationNodeId(event.conversation_id, event.position),
+            previousNodeId: payload.previousNodeId,
+            error: payload.error,
+            createdAt: new Date(event.created_at),
+          };
+          nodes.push(node);
+          nodesById.set(node.id, node);
+          activeNodeId = node.id;
+          status = ConversationStatus.Error;
+          processingStartedAt = null;
+          error = payload.error;
+          break;
+        }
+        case ConversationEventType.ConversationDeleted:
+          deleted = true;
+          break;
+        default:
+          throw new Error(`Unknown conversation event type ${event.type}.`);
+      }
+    }
+
+    if (deleted) {
+      return null;
+    }
+
+    return {
+      id: conversation.id,
+      assistant: conversation.assistant,
+      title,
+      contextFingerprint: conversation.context_fingerprint,
+      nodes,
+      activeNodeId,
+      status,
+      processingStartedAt,
+      error,
+      createdAt: new Date(conversation.created_at),
+    } as ConversationEntity;
+  }
+
+  private assertPreviousNodeExists(
+    nodesById: Map<ConversationNodeId, ConversationNode>,
+    previousNodeId: ConversationNodeId | null,
+  ): void {
+    if (previousNodeId !== null && !nodesById.has(previousNodeId)) {
+      throw new Error(
+        `Previous conversation node ${previousNodeId} not found.`,
+      );
+    }
   }
 }

--- a/packages/data/sqlite-data-repositories/src/types/SqliteConversation.ts
+++ b/packages/data/sqlite-data-repositories/src/types/SqliteConversation.ts
@@ -1,41 +1,31 @@
-import { decode } from "@msgpack/msgpack";
 import type {
   AssistantName,
   ConversationId,
-  ConversationStatus,
-  Message,
+  ConversationNodeId,
 } from "@superego/backend";
-import type { ConversationEntity } from "@superego/executing-backend";
 
 type SqliteConversation = {
   id: ConversationId;
   assistant: AssistantName;
-  title: string | null;
   context_fingerprint: string;
-  /** MessagePack */
-  messages: Buffer;
-  status: ConversationStatus;
-  /** ISO 8601 */
-  processing_started_at: string | null;
-  /** JSON */
-  error: string | null;
   /** ISO 8601 */
   created_at: string;
 };
 export default SqliteConversation;
 
-export function toEntity(conversation: SqliteConversation): ConversationEntity {
-  return {
-    id: conversation.id,
-    assistant: conversation.assistant,
-    title: conversation.title,
-    contextFingerprint: conversation.context_fingerprint,
-    messages: decode(conversation.messages) as Message[],
-    status: conversation.status,
-    processingStartedAt: conversation.processing_started_at
-      ? new Date(conversation.processing_started_at)
-      : null,
-    error: conversation.error ? JSON.parse(conversation.error) : null,
-    createdAt: new Date(conversation.created_at),
-  } as ConversationEntity;
+export type SqliteConversationEvent = {
+  conversation_id: ConversationId;
+  position: number;
+  type: string;
+  /** MessagePack */
+  payload: Buffer;
+  /** ISO 8601 */
+  created_at: string;
+};
+
+export function makeConversationNodeId(
+  conversationId: ConversationId,
+  position: number,
+): ConversationNodeId {
+  return `${conversationId}:${position}`;
 }

--- a/packages/tests/assistants-e2e-tests/src/utils/FactotumObject.ts
+++ b/packages/tests/assistants-e2e-tests/src/utils/FactotumObject.ts
@@ -4,10 +4,12 @@ import {
   type Collection,
   type CollectionId,
   type Conversation,
+  type ConversationNodeId,
   ConversationStatus,
   type Document,
   type DocumentId,
   type InferenceOptions,
+  type Message,
   MessageContentPartType,
 } from "@superego/backend";
 import type { Schema } from "@superego/schema";
@@ -251,8 +253,8 @@ class FactotumObject {
       this.conversation,
       "You must say something before expecting a reply",
     );
-    const lastMessage =
-      this.conversation.messages[this.conversation.messages.length - 1];
+    const messages = this.getActiveBranchMessages(this.conversation);
+    const lastMessage = messages[messages.length - 1];
     assertIsContentAssistantMessage(lastMessage);
 
     const reply = lastMessage.content[0].text;
@@ -298,6 +300,28 @@ Give a score from 0 to 1 by calling the ${Evaluator.ToolName.GiveScore} tool.
 
   getConversation() {
     return this.conversation;
+  }
+
+  private getActiveBranchMessages(conversation: Conversation): Message[] {
+    if (conversation.activeNodeId === null) {
+      return [];
+    }
+    const nodesById = new Map(
+      conversation.nodes.map((node) => [node.id, node]),
+    );
+    const messages: Message[] = [];
+    let currentNodeId: ConversationNodeId | null = conversation.activeNodeId;
+    while (currentNodeId !== null) {
+      const node = nodesById.get(currentNodeId);
+      if (!node) {
+        break;
+      }
+      if (node.type === "Message") {
+        messages.push(node.message);
+      }
+      currentNodeId = node.previousNodeId;
+    }
+    return messages.reverse();
   }
 }
 

--- a/packages/tests/backend-e2e-tests/src/suites/assistants.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/assistants.ts
@@ -1,8 +1,11 @@
 import {
   AssistantName,
   BackgroundJobStatus,
+  type Conversation,
+  type ConversationNodeId,
   ConversationStatus,
   InferenceProviderDriver,
+  type Message,
   MessageContentPartType,
   MessageRole,
   ReasoningEffort,
@@ -27,6 +30,28 @@ export default rd<GetDependencies>("Assistants", (deps) => {
     },
     transcription: null,
     fileInspection: null,
+  };
+
+  const getActiveBranchMessages = (conversation: Conversation) => {
+    if (conversation.activeNodeId === null) {
+      return [];
+    }
+    const nodesById = new Map(
+      conversation.nodes.map((node) => [node.id, node]),
+    );
+    const messages: Message[] = [];
+    let currentNodeId: ConversationNodeId | null = conversation.activeNodeId;
+    while (currentNodeId !== null) {
+      const node = nodesById.get(currentNodeId);
+      if (!node) {
+        break;
+      }
+      if (node.type === "Message") {
+        messages.push(node.message);
+      }
+      currentNodeId = node.previousNodeId;
+    }
+    return messages.reverse();
   };
 
   const inferenceSettings = {
@@ -170,8 +195,9 @@ export default rd<GetDependencies>("Assistants", (deps) => {
           status: ConversationStatus.Processing,
         }),
       );
-      expect(result.data.messages).toHaveLength(1);
-      expect(result.data.messages[0]).toEqual(
+      const messages = getActiveBranchMessages(result.data);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual(
         expect.objectContaining({
           role: MessageRole.User,
           content: [{ type: MessageContentPartType.Text, text: "Hello" }],
@@ -1214,7 +1240,9 @@ export default rd<GetDependencies>("Assistants", (deps) => {
           status: ConversationStatus.Idle,
         }),
       );
-      expect(result.data.messages.length).toBeGreaterThanOrEqual(1);
+      expect(
+        getActiveBranchMessages(result.data).length,
+      ).toBeGreaterThanOrEqual(1);
     });
 
     it("success: gets conversation with tool result artifacts", async () => {
@@ -1319,7 +1347,7 @@ export default rd<GetDependencies>("Assistants", (deps) => {
 
       // Verify
       assert.isTrue(result.success);
-      const toolMessage = result.data.messages.find(
+      const toolMessage = getActiveBranchMessages(result.data).find(
         (message) => message.role === MessageRole.Tool,
       );
       assert.isDefined(toolMessage);


### PR DESCRIPTION
## Summary
- replace conversation ordered messages with node graph API and active node tracking
- persist conversations as append-only MessagePack events in SQLite, with migration from old mutable rows
- update assistant processing, retry/recover behavior, search indexing, browser rendering, and tests for active-branch semantics

## Impact
This intentionally changes the Backend API from `Conversation.messages` to `Conversation.nodes` plus `activeNodeId`. Raw conversation events stay internal to repositories.

## Validation
- `yarn workspace @superego/sqlite-data-repositories run test`
- `yarn workspace @superego/backend-e2e-tests run test`
- `yarn workspace @superego/browser-app translations:extract-and-compile`
- `yarn fix-formatting`
- `yarn check-linting`
- `yarn check-types`