### PR TITLE
Add Turso WASM data repositories

### DIFF
--- a/packages/data/turso-data-repositories/package.json
+++ b/packages/data/turso-data-repositories/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@superego/turso-data-repositories",
+  "version": "2026.6.3",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "test": "vitest --reporter=verbose"
+  },
+  "dependencies": {
+    "@msgpack/msgpack": "^3.1.3",
+    "@superego/backend": "workspace:*",
+    "@superego/executing-backend": "workspace:*",
+    "@superego/schema": "workspace:*",
+    "@tursodatabase/database-wasm": "0.7.0",
+    "es-toolkit": "^1.49.0",
+    "flexsearch": "^0.8.212",
+    "jsondiffpatch": "^0.7.6"
+  },
+  "devDependencies": {
+    "@vitest/browser": "^4.1.10",
+    "@vitest/browser-playwright": "^4.1.10",
+    "playwright": "^1.61.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/data/turso-data-repositories/src/TursoDataRepositories.ts
+++ b/packages/data/turso-data-repositories/src/TursoDataRepositories.ts
@@ -1,0 +1,89 @@
+import type { GlobalSettings } from "@superego/backend";
+import type {
+  BackgroundJobRepository,
+  DataRepositories,
+} from "@superego/executing-backend";
+import TursoAppRepository from "./repositories/TursoAppRepository.js";
+import TursoAppVersionRepository from "./repositories/TursoAppVersionRepository.js";
+import TursoBackgroundJobRepository from "./repositories/TursoBackgroundJobRepository.js";
+import TursoCollectionCategoryRepository from "./repositories/TursoCollectionCategoryRepository.js";
+import TursoCollectionRepository from "./repositories/TursoCollectionRepository.js";
+import TursoCollectionVersionRepository from "./repositories/TursoCollectionVersionRepository.js";
+import TursoConversationRepository from "./repositories/TursoConversationRepository.js";
+import TursoConversationTextSearchIndex, {
+  type SearchTextIndexState as ConversationSearchTextIndexState,
+} from "./repositories/TursoConversationTextSearchIndex.js";
+import TursoDocumentRepository from "./repositories/TursoDocumentRepository.js";
+import TursoDocumentTextSearchIndex, {
+  type SearchTextIndexState as DocumentSearchTextIndexState,
+} from "./repositories/TursoDocumentTextSearchIndex.js";
+import TursoDocumentVersionRepository from "./repositories/TursoDocumentVersionRepository.js";
+import TursoFileRepository from "./repositories/TursoFileRepository.js";
+import TursoGlobalSettingsRepository from "./repositories/TursoGlobalSettingsRepository.js";
+import TursoDatabase from "./TursoDatabase.js";
+
+export default class TursoDataRepositories implements DataRepositories {
+  app: TursoAppRepository;
+  appVersion: TursoAppVersionRepository;
+  backgroundJob: BackgroundJobRepository;
+  collectionCategory: TursoCollectionCategoryRepository;
+  collection: TursoCollectionRepository;
+  collectionVersion: TursoCollectionVersionRepository;
+  conversation: TursoConversationRepository;
+  conversationTextSearchIndex: TursoConversationTextSearchIndex;
+  document: TursoDocumentRepository;
+  documentVersion: TursoDocumentVersionRepository;
+  file: TursoFileRepository;
+  documentTextSearchIndex: TursoDocumentTextSearchIndex;
+  globalSettings: TursoGlobalSettingsRepository;
+
+  constructor(
+    private db: TursoDatabase,
+    defaultGlobalSettings: GlobalSettings,
+    searchTextIndexStates: {
+      conversation: ConversationSearchTextIndexState;
+      document: DocumentSearchTextIndexState;
+    },
+    onTransactionSucceeded: (callback: () => void) => void,
+  ) {
+    this.app = new TursoAppRepository(db);
+    this.appVersion = new TursoAppVersionRepository(db);
+    this.backgroundJob = new TursoBackgroundJobRepository(db);
+    this.collectionCategory = new TursoCollectionCategoryRepository(db);
+    this.collection = new TursoCollectionRepository(db);
+    this.collectionVersion = new TursoCollectionVersionRepository(db);
+    this.conversation = new TursoConversationRepository(db);
+    this.conversationTextSearchIndex = new TursoConversationTextSearchIndex(
+      db,
+      searchTextIndexStates.conversation,
+      onTransactionSucceeded,
+    );
+    this.document = new TursoDocumentRepository(db);
+    this.documentVersion = new TursoDocumentVersionRepository(db);
+    this.file = new TursoFileRepository(db);
+    this.documentTextSearchIndex = new TursoDocumentTextSearchIndex(
+      db,
+      searchTextIndexStates.document,
+      onTransactionSucceeded,
+    );
+    this.globalSettings = new TursoGlobalSettingsRepository(
+      db,
+      defaultGlobalSettings,
+    );
+  }
+
+  async export(fileName: string): Promise<void> {
+    await this.db.export(fileName);
+  }
+
+  async createSavepoint(): Promise<string> {
+    const name = crypto.randomUUID();
+    await this.db.prepare(`SAVEPOINT "${name}"`).run();
+    return name;
+  }
+
+  async rollbackToSavepoint(name: string): Promise<void> {
+    await this.db.prepare(`ROLLBACK TRANSACTION TO SAVEPOINT "${name}"`).run();
+    await this.db.prepare(`RELEASE SAVEPOINT "${name}"`).run();
+  }
+}

--- a/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.test.ts
+++ b/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.test.ts
@@ -1,0 +1,110 @@
+import { AssistantName, Theme } from "@superego/backend";
+import { registerDataRepositoriesTests } from "@superego/executing-backend/tests";
+import { beforeAll, beforeEach, expect, it } from "vitest";
+import TursoDataRepositoriesManager from "./TursoDataRepositoriesManager.js";
+
+const databaseFilePrefix = `superego-turso-data-repositories-tests-${crypto.randomUUID()}`;
+const defaultGlobalSettings = {
+  appearance: { theme: Theme.Auto },
+  inference: {
+    providers: [],
+    defaultInferenceOptions: {
+      completion: null,
+      transcription: null,
+      fileInspection: null,
+    },
+  },
+  assistants: {
+    userInfo: null,
+    userPreferences: null,
+    developerPrompts: {
+      [AssistantName.Factotum]: null,
+      [AssistantName.CollectionCreator]: null,
+    },
+  },
+};
+
+const dataRepositoriesManager = new TursoDataRepositoriesManager({
+  fileName: `${databaseFilePrefix}.sqlite`,
+  defaultGlobalSettings,
+  enableForeignKeyConstraints: false,
+});
+
+beforeAll(() => dataRepositoriesManager.runMigrations());
+beforeEach(() => dataRepositoriesManager.resetForTests());
+
+registerDataRepositoriesTests(() => ({ dataRepositoriesManager }));
+
+it("exports a logical copy to another OPFS database", async () => {
+  // Setup SUT
+  const exportedFileName = `${databaseFilePrefix}-export.sqlite`;
+  const exportedGlobalSettings = {
+    ...defaultGlobalSettings,
+    appearance: { theme: Theme.Dark },
+  };
+  await dataRepositoriesManager.runInSerializableTransaction(async (repos) => {
+    await repos.globalSettings.replace(exportedGlobalSettings);
+    return { action: "commit", returnValue: null };
+  });
+
+  // Exercise
+  await dataRepositoriesManager.runInSerializableTransaction(async (repos) => {
+    await repos.export(exportedFileName);
+    return { action: "commit", returnValue: null };
+  });
+
+  // Verify
+  const exportedDataRepositoriesManager = new TursoDataRepositoriesManager({
+    fileName: exportedFileName,
+    defaultGlobalSettings,
+  });
+  const foundGlobalSettings =
+    await exportedDataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => ({
+        action: "commit",
+        returnValue: await repos.globalSettings.get(),
+      }),
+    );
+  expect(foundGlobalSettings).toEqual(exportedGlobalSettings);
+});
+
+it("overwrites an existing exported OPFS database", async () => {
+  // Setup SUT
+  const exportedFileName = `${databaseFilePrefix}-overwritten-export.sqlite`;
+  await dataRepositoriesManager.runInSerializableTransaction(async (repos) => {
+    await repos.globalSettings.replace({
+      ...defaultGlobalSettings,
+      appearance: { theme: Theme.Dark },
+    });
+    await repos.export(exportedFileName);
+    return { action: "commit", returnValue: null };
+  });
+  const latestGlobalSettings = {
+    ...defaultGlobalSettings,
+    appearance: { theme: Theme.Light },
+  };
+  await dataRepositoriesManager.runInSerializableTransaction(async (repos) => {
+    await repos.globalSettings.replace(latestGlobalSettings);
+    return { action: "commit", returnValue: null };
+  });
+
+  // Exercise
+  await dataRepositoriesManager.runInSerializableTransaction(async (repos) => {
+    await repos.export(exportedFileName);
+    return { action: "commit", returnValue: null };
+  });
+
+  // Verify
+  const exportedDataRepositoriesManager = new TursoDataRepositoriesManager({
+    fileName: exportedFileName,
+    defaultGlobalSettings,
+  });
+  const foundGlobalSettings =
+    await exportedDataRepositoriesManager.runInSerializableTransaction(
+      async (repos) => ({
+        action: "commit",
+        returnValue: await repos.globalSettings.get(),
+      }),
+    );
+  expect(foundGlobalSettings).toEqual(latestGlobalSettings);
+});

--- a/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.ts
+++ b/packages/data/turso-data-repositories/src/TursoDataRepositoriesManager.ts
@@ -1,0 +1,162 @@
+import type { GlobalSettings } from "@superego/backend";
+import type {
+  DataRepositories,
+  DataRepositoriesManager,
+} from "@superego/executing-backend";
+import migrate from "./migrations/migrate.js";
+import TursoConversationTextSearchIndex from "./repositories/TursoConversationTextSearchIndex.js";
+import TursoDocumentTextSearchIndex from "./repositories/TursoDocumentTextSearchIndex.js";
+import toTursoLockedError from "./toTursoLockedError.js";
+import TursoDatabase from "./TursoDatabase.js";
+import TursoDataRepositories from "./TursoDataRepositories.js";
+
+/**
+ * Browser/Electron-renderer data repositories backed by Turso WASM and OPFS.
+ */
+export default class TursoDataRepositoriesManager implements DataRepositoriesManager {
+  private migrationPromise: Promise<void> | null = null;
+  private searchTextIndexStates = {
+    conversation: TursoConversationTextSearchIndex.getSearchTextIndexState(),
+    document: TursoDocumentTextSearchIndex.getSearchTextIndexState(),
+  };
+
+  constructor(
+    private options: {
+      /** OPFS file name, not an operating-system file path. */
+      fileName: string;
+      defaultGlobalSettings: GlobalSettings;
+      /** Busy timeout in milliseconds. */
+      timeout?: number;
+      /** @internal Only used for tests. */
+      enableForeignKeyConstraints?: boolean;
+    },
+  ) {}
+
+  async runInSerializableTransaction<ReturnValue>(
+    fn: (
+      repos: DataRepositories,
+    ) => Promise<{ action: "commit" | "rollback"; returnValue: ReturnValue }>,
+  ): Promise<ReturnValue> {
+    if (this.migrationPromise) {
+      await this.migrationPromise;
+    }
+    const transactionSucceededCallbacks: (() => void)[] = [];
+    const db = await this.openDb();
+    try {
+      await db.exec("BEGIN");
+      const repos = new TursoDataRepositories(
+        db,
+        this.options.defaultGlobalSettings,
+        this.searchTextIndexStates,
+        (callback) => transactionSucceededCallbacks.push(callback),
+      );
+      const { action, returnValue } = await fn(repos);
+      await db.exec(action === "commit" ? "COMMIT" : "ROLLBACK");
+      if (action === "commit") {
+        TursoDataRepositoriesManager.runTransactionSucceededCallbacks(
+          transactionSucceededCallbacks,
+        );
+      }
+      return returnValue;
+    } catch (error) {
+      if (db.isTransaction) {
+        await db.exec("ROLLBACK");
+      }
+      throw toTursoLockedError(error);
+    } finally {
+      await db.close();
+    }
+  }
+
+  runMigrations(): Promise<void> {
+    this.migrationPromise ??= this.doRunMigrations();
+    return this.migrationPromise;
+  }
+
+  /** @internal Only used by the repository conformance tests. */
+  async resetForTests(): Promise<void> {
+    if (this.migrationPromise) {
+      await this.migrationPromise;
+    }
+    const db = await this.openDb();
+    try {
+      await db.exec("BEGIN IMMEDIATE");
+      await db.exec(`
+        DELETE FROM "document_version_content_blocking_keys";
+        DELETE FROM "document_versions";
+        DELETE FROM "documents";
+        DELETE FROM "collection_versions";
+        DELETE FROM "collections";
+        DELETE FROM "collection_categories";
+        DELETE FROM "app_versions";
+        DELETE FROM "apps";
+        DELETE FROM "conversation_text_search_texts";
+        DELETE FROM "conversations";
+        DELETE FROM "background_jobs";
+        DELETE FROM "files";
+        DELETE FROM "document_text_search_texts";
+        DELETE FROM "singleton__global_settings";
+      `);
+      await db.exec("COMMIT");
+      this.searchTextIndexStates = {
+        conversation:
+          TursoConversationTextSearchIndex.getSearchTextIndexState(),
+        document: TursoDocumentTextSearchIndex.getSearchTextIndexState(),
+      };
+    } catch (error) {
+      if (db.isTransaction) {
+        await db.exec("ROLLBACK");
+      }
+      throw toTursoLockedError(error);
+    } finally {
+      await db.close();
+    }
+  }
+
+  private async doRunMigrations(): Promise<void> {
+    const db = await this.openDb();
+    try {
+      await migrate(db);
+    } catch (error) {
+      if (db.isTransaction) {
+        await db.exec("ROLLBACK");
+      }
+      throw toTursoLockedError(error);
+    } finally {
+      await db.close();
+    }
+  }
+
+  private async openDb(): Promise<TursoDatabase> {
+    const {
+      fileName,
+      timeout,
+      enableForeignKeyConstraints = true,
+    } = this.options;
+    const db = await TursoDatabase.open(fileName, { timeout });
+    try {
+      await db.exec(
+        `PRAGMA foreign_keys = ${enableForeignKeyConstraints ? "ON" : "OFF"}`,
+      );
+      await db.exec("PRAGMA journal_mode = WAL");
+      await db.exec("PRAGMA synchronous = FULL");
+      return db;
+    } catch (error) {
+      await db.close();
+      throw toTursoLockedError(error);
+    }
+  }
+
+  private static runTransactionSucceededCallbacks(callbacks: (() => void)[]) {
+    callbacks.forEach((callback) => {
+      try {
+        callback();
+      } catch (error) {
+        console.error(
+          "Uncaught error running transaction succeeded callback",
+          error,
+        );
+      }
+    });
+  }
+}

--- a/packages/data/turso-data-repositories/src/TursoDatabase.ts
+++ b/packages/data/turso-data-repositories/src/TursoDatabase.ts
@@ -1,0 +1,255 @@
+import {
+  connect,
+  type Database as TursoWasmDatabase,
+} from "@tursodatabase/database-wasm/bundle";
+
+type TursoWasmStatement = Awaited<ReturnType<TursoWasmDatabase["prepare"]>>;
+
+type ConnectionPool = {
+  availableConnections: TursoWasmDatabase[];
+  activeConnectionCount: number;
+};
+
+class TursoStatement {
+  private statementPromise: Promise<TursoWasmStatement> | null = null;
+
+  constructor(
+    private database: TursoWasmDatabase,
+    private sql: string,
+    private ensureOpen: () => void,
+  ) {}
+
+  async run(...bindParameters: unknown[]): Promise<unknown> {
+    return TursoDatabase.runExclusive(async () => {
+      const statement = await this.getStatement();
+      return statement.run(...bindParameters);
+    });
+  }
+
+  async get(...bindParameters: unknown[]): Promise<unknown> {
+    return TursoDatabase.runExclusive(async () => {
+      const statement = await this.getStatement();
+      return statement.get(...bindParameters);
+    });
+  }
+
+  async all(...bindParameters: unknown[]): Promise<unknown[]> {
+    return TursoDatabase.runExclusive(async () => {
+      const statement = await this.getStatement();
+      return statement.all(...bindParameters);
+    });
+  }
+
+  private async getStatement(): Promise<TursoWasmStatement> {
+    this.ensureOpen();
+    this.statementPromise ??= Promise.resolve(
+      this.database.prepare(this.sql) as unknown as TursoWasmStatement,
+    );
+    return this.statementPromise;
+  }
+}
+
+/**
+ * Small adapter around Turso's promise API. It keeps repository code close to
+ * the synchronous node:sqlite implementation while making every execution
+ * operation explicitly awaitable.
+ */
+export default class TursoDatabase {
+  private static operationTail: Promise<void> = Promise.resolve();
+  private static connectionPools = new Map<string, ConnectionPool>();
+  private closed = false;
+
+  private constructor(
+    private database: TursoWasmDatabase,
+    private fileName: string,
+    private connectionPool: ConnectionPool,
+  ) {}
+
+  static async open(
+    fileName: string,
+    options: { timeout?: number } = {},
+  ): Promise<TursoDatabase> {
+    const connectionPool = TursoDatabase.connectionPools.get(fileName) ?? {
+      availableConnections: [],
+      activeConnectionCount: 0,
+    };
+    TursoDatabase.connectionPools.set(fileName, connectionPool);
+    const database =
+      connectionPool.availableConnections.pop() ??
+      (await TursoDatabase.runExclusive(() => connect(fileName, options)));
+    connectionPool.activeConnectionCount += 1;
+    return new TursoDatabase(database, fileName, connectionPool);
+  }
+
+  prepare(sql: string): TursoStatement {
+    this.ensureOpen();
+    return new TursoStatement(this.database, sql, () => this.ensureOpen());
+  }
+
+  async exec(sql: string): Promise<void> {
+    await TursoDatabase.runExclusive(async () => {
+      this.ensureOpen();
+      await this.database.exec(sql);
+    });
+  }
+
+  /**
+   * Creates a logical copy in OPFS. Turso's JavaScript backup and serialize
+   * APIs are not implemented yet, so copying through SQL keeps export support
+   * available without relying on native bindings.
+   */
+  async export(fileName: string): Promise<void> {
+    if (fileName === this.fileName) {
+      throw new Error("Cannot export a Turso database over itself.");
+    }
+
+    await TursoDatabase.removeDatabaseIfExists(fileName);
+
+    const schemaEntries = (await this.prepare(`
+      SELECT "type", "name", "sql"
+      FROM "sqlite_schema"
+      WHERE "sql" IS NOT NULL
+        AND "name" NOT LIKE 'sqlite_%'
+        AND "name" NOT LIKE '__turso_internal_%'
+      ORDER BY CASE "type"
+        WHEN 'table' THEN 0
+        WHEN 'view' THEN 1
+        WHEN 'index' THEN 2
+        WHEN 'trigger' THEN 3
+        ELSE 4
+      END
+    `).all()) as {
+      type: "index" | "table" | "trigger" | "view";
+      name: string;
+      sql: string;
+    }[];
+    const destination = await TursoDatabase.open(fileName);
+    try {
+      await destination.exec("PRAGMA foreign_keys = OFF");
+      await destination.exec("BEGIN IMMEDIATE");
+
+      const tableEntries = schemaEntries.filter(({ type }) => type === "table");
+      for (const { name, sql } of tableEntries) {
+        await destination.exec(sql);
+        await this.copyTableTo(destination, name);
+      }
+      for (const { sql, type } of schemaEntries) {
+        if (type !== "table") {
+          await destination.exec(sql);
+        }
+      }
+
+      await destination.exec("COMMIT");
+    } catch (error) {
+      if (destination.isTransaction) {
+        await destination.exec("ROLLBACK");
+      }
+      throw error;
+    } finally {
+      await destination.close();
+    }
+  }
+
+  get isTransaction(): boolean {
+    this.ensureOpen();
+    return this.database.inTransaction;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.connectionPool.activeConnectionCount -= 1;
+    this.connectionPool.availableConnections.push(this.database);
+  }
+
+  static async runExclusive<ReturnValue>(
+    operation: () => Promise<ReturnValue>,
+  ): Promise<ReturnValue> {
+    const previousOperation = TursoDatabase.operationTail;
+    let release: () => void = () => undefined;
+    TursoDatabase.operationTail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previousOperation;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async copyTableTo(
+    destination: TursoDatabase,
+    tableName: string,
+  ): Promise<void> {
+    const escapedTableName = TursoDatabase.escapeIdentifier(tableName);
+    const columns = (await this.prepare(
+      `PRAGMA table_info(${escapedTableName})`,
+    ).all()) as { name: string }[];
+    if (columns.length === 0) {
+      return;
+    }
+
+    const rows = (await this.prepare(
+      `SELECT * FROM ${escapedTableName}`,
+    ).all()) as Record<string, unknown>[];
+    if (rows.length === 0) {
+      return;
+    }
+
+    const escapedColumnNames = columns
+      .map(({ name }) => TursoDatabase.escapeIdentifier(name))
+      .join(", ");
+    const placeholders = columns.map(() => "?").join(", ");
+    const insert = destination.prepare(
+      `INSERT INTO ${escapedTableName} (${escapedColumnNames}) VALUES (${placeholders})`,
+    );
+    for (const row of rows) {
+      await insert.run(columns.map(({ name }) => row[name]));
+    }
+  }
+
+  private static escapeIdentifier(identifier: string): string {
+    return `"${identifier.replaceAll('"', '""')}"`;
+  }
+
+  private ensureOpen(): void {
+    if (this.closed) {
+      throw new TypeError("The database connection is not open");
+    }
+  }
+
+  private static async removeOpfsFileIfExists(
+    opfsRoot: FileSystemDirectoryHandle,
+    fileName: string,
+  ): Promise<void> {
+    try {
+      await opfsRoot.removeEntry(fileName);
+    } catch (error) {
+      if (!(error instanceof DOMException && error.name === "NotFoundError")) {
+        throw error;
+      }
+    }
+  }
+
+  private static async removeDatabaseIfExists(fileName: string): Promise<void> {
+    await TursoDatabase.runExclusive(async () => {
+      const connectionPool = TursoDatabase.connectionPools.get(fileName);
+      if (connectionPool?.activeConnectionCount) {
+        throw new Error(
+          "Cannot export over a database that is currently open.",
+        );
+      }
+      TursoDatabase.connectionPools.delete(fileName);
+      for (const database of connectionPool?.availableConnections ?? []) {
+        await database.close();
+      }
+
+      const opfsRoot = await navigator.storage.getDirectory();
+      await TursoDatabase.removeOpfsFileIfExists(opfsRoot, fileName);
+      await TursoDatabase.removeOpfsFileIfExists(opfsRoot, `${fileName}-wal`);
+    });
+  }
+}

--- a/packages/data/turso-data-repositories/src/database-wasm-bundle.d.ts
+++ b/packages/data/turso-data-repositories/src/database-wasm-bundle.d.ts
@@ -1,0 +1,3 @@
+declare module "@tursodatabase/database-wasm/bundle" {
+  export { connect, Database, SqliteError } from "@tursodatabase/database-wasm";
+}

--- a/packages/data/turso-data-repositories/src/index.ts
+++ b/packages/data/turso-data-repositories/src/index.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+export { default as TursoDataRepositoriesManager } from "./TursoDataRepositoriesManager.js";

--- a/packages/data/turso-data-repositories/src/migrations/0000.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0000.sql
@@ -1,0 +1,141 @@
+-- Collection categories
+
+CREATE TABLE "collection_categories" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "icon" TEXT,
+  "parent_id" TEXT,
+  "created_at" TEXT NOT NULL,
+  FOREIGN KEY ("parent_id") REFERENCES "collection_categories" ("id")
+);
+
+CREATE INDEX "idx__collection_categories__on__parent_id" ON "collection_categories" (
+  "parent_id"
+);
+
+-- Collections
+
+CREATE TABLE "collections" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "settings" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  CHECK (json_valid("settings"))
+);
+
+CREATE INDEX "idx__collections__on__settings_collection_category_id" ON "collections" (
+  "settings" ->> '$.collectionCategoryId'
+);
+
+-- Collection versions
+
+CREATE TABLE "collection_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "collection_id" TEXT NOT NULL,
+  "schema" TEXT NOT NULL,
+  "settings" TEXT NOT NULL,
+  "migration" TEXT,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "collection_versions" ("id"),
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  CHECK (json_valid("schema")),
+  CHECK (json_valid("settings")),
+  CHECK (json_valid("migration"))
+);
+
+CREATE INDEX "idx__collection_versions__on__collection_id" ON "collection_versions" (
+  "collection_id"
+);
+
+CREATE INDEX "idx__collection_versions__on__is_latest" ON "collection_versions" (
+  "is_latest"
+);
+
+CREATE UNIQUE INDEX "idx__collection_versions__on__collection_id__unique_is_latest_true" ON "collection_versions" (
+  "collection_id"
+)
+WHERE "is_latest" = 1;
+
+-- Documents
+
+CREATE TABLE "documents" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id")
+);
+
+CREATE INDEX "idx__documents__on__collection_id" ON "documents" (
+  "collection_id"
+);
+
+-- Document versions
+
+CREATE TABLE "document_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "collection_id" TEXT NOT NULL,
+  "document_id" TEXT NOT NULL,
+  "collection_version_id" TEXT NOT NULL,
+  "content_delta" TEXT,
+  "content_snapshot" TEXT,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "document_versions" ("id"),
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  FOREIGN KEY ("document_id") REFERENCES "documents" ("id"),
+  FOREIGN KEY ("collection_version_id") REFERENCES "collection_versions" ("id"),
+  CHECK (json_valid("content_delta")),
+  CHECK (json_valid("content_snapshot"))
+);
+
+CREATE INDEX "idx__document_versions__on__collection_id" ON "document_versions" (
+  "collection_id"
+);
+
+CREATE INDEX "idx__document_versions__on__document_id" ON "document_versions" (
+  "document_id"
+);
+
+CREATE INDEX "idx__document_versions__on__is_latest" ON "document_versions" (
+  "is_latest"
+);
+
+CREATE INDEX "idx__document_versions__on__collection_id__is_latest_true" ON "document_versions" (
+  "collection_id"
+)
+WHERE "is_latest" = 1;
+
+CREATE UNIQUE INDEX "idx__document_versions__on__document_id__unique_is_latest_true" ON "document_versions" (
+  "document_id"
+)
+WHERE "is_latest" = 1;
+
+-- Files
+
+CREATE TABLE "files" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "document_id" TEXT NOT NULL,
+  "created_with_document_version_id" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "content" BLOB NOT NULL,
+  FOREIGN KEY ("collection_id") REFERENCES "collections" ("id"),
+  FOREIGN KEY ("document_id") REFERENCES "documents" ("id"),
+  FOREIGN KEY (
+    "created_with_document_version_id"
+  ) REFERENCES "document_versions" ("id")
+);
+
+CREATE INDEX "idx__files__on__collection_id" ON "files" ("collection_id");
+
+CREATE INDEX "idx__files__on__document_id" ON "files" ("document_id");
+
+-- Global settings
+
+CREATE TABLE "singleton__global_settings" (
+  "id" TEXT PRIMARY KEY DEFAULT 'singleton' NOT NULL,
+  "value" TEXT NOT NULL,
+  CHECK ("id" = 'singleton')
+);

--- a/packages/data/turso-data-repositories/src/migrations/0001.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0001.sql
@@ -1,0 +1,47 @@
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "conversation_id" TEXT;
+
+ALTER TABLE "document_versions"
+ADD COLUMN "created_by" TEXT NOT NULL DEFAULT 'User';
+
+-- Conversations
+
+CREATE TABLE "conversations" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "assistant" TEXT NOT NULL,
+  "format" TEXT NOT NULL,
+  "title" TEXT,
+  "context_fingerprint" TEXT NOT NULL,
+  "messages" BLOB NOT NULL,
+  "status" TEXT NOT NULL,
+  "error" TEXT,
+  "created_at" TEXT NOT NULL,
+  CHECK (json_valid("error"))
+);
+
+-- Background jobs
+
+CREATE TABLE "background_jobs" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "name" TEXT NOT NULL,
+  "input" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "enqueued_at" TEXT NOT NULL,
+  "started_processing_at" TEXT,
+  "finished_processing_at" TEXT,
+  "error" TEXT,
+  CHECK (json_valid("input")),
+  CHECK (json_valid("error"))
+);
+
+CREATE UNIQUE INDEX "idx__background_jobs__on__status__unique_status_processing" ON "background_jobs" (
+  "status"
+)
+WHERE "status" = 'Processing';
+
+CREATE INDEX "idx__background_jobs__on__enqueued_at__status_enqueued" ON "background_jobs" (
+  "enqueued_at"
+)
+WHERE "status" = 'Enqueued';

--- a/packages/data/turso-data-repositories/src/migrations/0002.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0002.sql
@@ -1,0 +1,29 @@
+-- Collections
+
+ALTER TABLE "collections"
+ADD COLUMN "remote" BLOB;
+
+-- Collection versions
+
+ALTER TABLE "collection_versions"
+ADD COLUMN "remote_converters" BLOB;
+
+-- Documents
+
+ALTER TABLE "documents"
+ADD COLUMN "remote_id" TEXT;
+ALTER TABLE "documents"
+ADD COLUMN "remote_url" TEXT;
+ALTER TABLE "documents"
+ADD COLUMN "latest_remote_document" BLOB;
+
+CREATE UNIQUE INDEX "idx__documents__on__collection_id_remote_id__unique" ON "documents" (
+  "collection_id",
+  "remote_id"
+)
+WHERE "remote_id" IS NOT NULL;
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "remote_id" TEXT;

--- a/packages/data/turso-data-repositories/src/migrations/0003.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0003.sql
@@ -1,0 +1,36 @@
+-- Apps
+
+CREATE TABLE "apps" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "type" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL
+);
+
+-- App versions
+
+CREATE TABLE "app_versions" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "previous_version_id" TEXT,
+  "app_id" TEXT NOT NULL,
+  "target_collections" BLOB NOT NULL,
+  "files" BLOB NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "is_latest" INTEGER NOT NULL,
+  FOREIGN KEY ("previous_version_id") REFERENCES "app_versions" ("id"),
+  FOREIGN KEY ("app_id") REFERENCES "apps" ("id")
+);
+
+CREATE INDEX "idx__app_versions__on__app_id" ON "app_versions" ("app_id");
+
+CREATE INDEX "idx__app_versions__on__is_latest" ON "app_versions" ("is_latest");
+
+CREATE UNIQUE INDEX "idx__app_versions__on__app_id__unique_is_latest_true" ON "app_versions" (
+  "app_id"
+)
+WHERE "is_latest" = 1;
+
+-- Collections
+
+UPDATE "collections"
+SET "settings" = json_set("settings", '$.defaultCollectionViewAppId', NULL);

--- a/packages/data/turso-data-repositories/src/migrations/0004.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0004.sql
@@ -1,0 +1,31 @@
+-- Files
+
+CREATE TABLE "files_new" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "referenced_by" TEXT NOT NULL,
+  "created_at" TEXT NOT NULL,
+  "content" BLOB NOT NULL,
+  CHECK (json_valid("referenced_by"))
+);
+
+INSERT INTO "files_new"
+  ("id", "referenced_by", "created_at", "content")
+SELECT
+  "id",
+  json_array(
+    json_object(
+      'collectionId',
+      "collection_id",
+      'documentId',
+      "document_id",
+      'documentVersionId',
+      "created_with_document_version_id"
+    )
+  ) AS "referenced_by",
+  "created_at",
+  "content"
+FROM "files";
+
+DROP TABLE "files";
+
+ALTER TABLE "files_new" RENAME TO "files";

--- a/packages/data/turso-data-repositories/src/migrations/0005.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0005.sql
@@ -1,0 +1,9 @@
+-- Flexsearch indexes
+
+CREATE TABLE "flexsearch_indexes" (
+  "key" TEXT NOT NULL,
+  "target" TEXT NOT NULL,
+  "data" TEXT NOT NULL,
+  PRIMARY KEY ("key", "target"),
+  CHECK ("target" IN ('document', 'conversation'))
+);

--- a/packages/data/turso-data-repositories/src/migrations/0006.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0006.sql
@@ -1,0 +1,35 @@
+-- Collection versions
+
+ALTER TABLE "collection_versions"
+ADD COLUMN "content_blocking_keys_getter" TEXT;
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "referenced_documents" TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE "document_versions"
+ADD COLUMN "content_blocking_keys" TEXT;
+
+-- Document version blocking keys. This is a lookup table used purely as an
+-- index for fast blocking key searches.
+
+CREATE TABLE "document_version_content_blocking_keys" (
+  "id" INTEGER PRIMARY KEY AUTOINCREMENT,
+  "document_version_id" TEXT NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "blocking_key" TEXT NOT NULL,
+  FOREIGN KEY ("document_version_id") REFERENCES "document_versions" ("id")
+    ON DELETE CASCADE
+);
+
+-- Index for duplicate detection: find any document with matching key in
+-- collection.
+CREATE INDEX "idx__document_version_content_blocking_keys__collection_id__blocking_key" ON "document_version_content_blocking_keys" (
+  "collection_id",
+  "blocking_key"
+);
+
+-- Index for cleanup when deleting document versions.
+CREATE INDEX "idx__document_version_content_blocking_keys__document_version_id" ON "document_version_content_blocking_keys" (
+  "document_version_id"
+);

--- a/packages/data/turso-data-repositories/src/migrations/0007.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0007.sql
@@ -1,0 +1,4 @@
+-- Conversations
+
+ALTER TABLE "conversations"
+DROP COLUMN "format";

--- a/packages/data/turso-data-repositories/src/migrations/0008.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0008.sql
@@ -1,0 +1,52 @@
+-- Document text search texts
+
+CREATE TABLE "document_text_search_texts" (
+  "document_id" TEXT PRIMARY KEY NOT NULL,
+  "collection_id" TEXT NOT NULL,
+  "text" TEXT NOT NULL
+);
+
+CREATE INDEX "idx__document_text_search_texts__collection_id" ON "document_text_search_texts" (
+  "collection_id"
+);
+
+-- Conversation text search texts
+
+CREATE TABLE "conversation_text_search_texts" (
+  "conversation_id" TEXT PRIMARY KEY NOT NULL,
+  "text" TEXT NOT NULL
+);
+
+-- Flexsearch indexes
+
+DROP TABLE "flexsearch_indexes";
+
+-- Document versions
+
+ALTER TABLE "document_versions"
+ADD COLUMN "content_summary" TEXT NOT NULL DEFAULT '{}';
+
+CREATE INDEX "idx__document_versions__on__collection_version_id" ON "document_versions" (
+  "collection_version_id"
+);
+
+-- Collection versions
+
+-- Migrate content_blocking_keys_getter from a separate column into the settings
+-- JSON column.
+
+-- Step 1: Update the settings column to include contentBlockingKeysGetter.
+UPDATE "collection_versions"
+SET "settings" = json_set(
+  "settings",
+  '$.contentBlockingKeysGetter',
+  CASE
+    WHEN "content_blocking_keys_getter" IS NOT NULL THEN json(
+      "content_blocking_keys_getter"
+    )
+    ELSE json('null')
+  END
+);
+
+-- Step 2: Drop the old column.
+ALTER TABLE "collection_versions" DROP COLUMN "content_blocking_keys_getter";

--- a/packages/data/turso-data-repositories/src/migrations/0009.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0009.sql
@@ -1,0 +1,4 @@
+-- Conversations
+
+ALTER TABLE "conversations"
+ADD COLUMN "processing_started_at" TEXT;

--- a/packages/data/turso-data-repositories/src/migrations/0010.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0010.sql
@@ -1,0 +1,16 @@
+-- Collections
+
+-- Add redirectToCollectionAfterDocumentCreation to collection settings,
+-- defaulting to false for existing collections.
+
+UPDATE "collections"
+SET "settings" = json_set(
+  "settings",
+  '$.redirectToCollectionAfterDocumentCreation',
+  json('false')
+)
+WHERE
+  json_extract(
+    "settings",
+    '$.redirectToCollectionAfterDocumentCreation'
+  ) IS NULL;

--- a/packages/data/turso-data-repositories/src/migrations/0011.sql
+++ b/packages/data/turso-data-repositories/src/migrations/0011.sql
@@ -1,0 +1,18 @@
+DELETE FROM "background_jobs"
+WHERE "name" = 'DownSyncCollection';
+
+UPDATE "document_versions"
+SET "created_by" = 'User'
+WHERE "created_by" = 'Connector';
+
+DROP INDEX "idx__documents__on__collection_id_remote_id__unique";
+
+ALTER TABLE "collections" DROP COLUMN "remote";
+
+ALTER TABLE "collection_versions" DROP COLUMN "remote_converters";
+
+ALTER TABLE "documents" DROP COLUMN "remote_id";
+ALTER TABLE "documents" DROP COLUMN "remote_url";
+ALTER TABLE "documents" DROP COLUMN "latest_remote_document";
+
+ALTER TABLE "document_versions" DROP COLUMN "remote_id";

--- a/packages/data/turso-data-repositories/src/migrations/migrate.ts
+++ b/packages/data/turso-data-repositories/src/migrations/migrate.ts
@@ -1,0 +1,109 @@
+import type TursoDatabase from "../TursoDatabase.js";
+import m0000 from "./0000.sql?raw";
+import m0001 from "./0001.sql?raw";
+import m0002 from "./0002.sql?raw";
+import m0003 from "./0003.sql?raw";
+import m0004 from "./0004.sql?raw";
+import m0005 from "./0005.sql?raw";
+import m0006 from "./0006.sql?raw";
+import m0007 from "./0007.sql?raw";
+import m0008 from "./0008.sql?raw";
+import m0009 from "./0009.sql?raw";
+import m0010 from "./0010.sql?raw";
+import m0011 from "./0011.sql?raw";
+
+const migrationFiles = {
+  "0000.sql": m0000,
+  "0001.sql": m0001,
+  "0002.sql": m0002,
+  "0003.sql": m0003,
+  "0004.sql": m0004,
+  "0005.sql": m0005,
+  "0006.sql": m0006,
+  "0007.sql": m0007,
+  "0008.sql": m0008,
+  "0009.sql": m0009,
+  "0010.sql": m0010,
+  "0011.sql": m0011,
+};
+const table = "migrations";
+
+interface TursoMigration {
+  file_name: string;
+  /** ISO 8601 */
+  applied_at: string;
+}
+
+export default async function migrate(db: TursoDatabase): Promise<void> {
+  await db.exec("BEGIN IMMEDIATE");
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS "${table}" (
+      "file_name" TEXT PRIMARY KEY,
+      "applied_at" TEXT NOT NULL
+    )
+  `);
+
+  const migrationFileNames = (
+    Object.keys(migrationFiles) as (keyof typeof migrationFiles)[]
+  ).sort();
+
+  const appliedMigrations = (await db
+    .prepare(`SELECT * FROM "${table}"`)
+    .all()) as any as TursoMigration[];
+
+  ensureIntegrity(appliedMigrations, migrationFileNames);
+
+  const insertMigration = db.prepare(
+    `INSERT INTO "${table}" ("file_name", "applied_at") VALUES (?, ?)`,
+  );
+  for (const fileName of migrationFileNames) {
+    if (appliedMigrations.some(({ file_name }) => file_name === fileName)) {
+      continue;
+    }
+    await db.exec(migrationFiles[fileName]);
+    await insertMigration.run(fileName, new Date().toISOString());
+  }
+  await db.exec("COMMIT");
+}
+
+/**
+ * Ensures that:
+ *
+ * 1. Every applied migration has a corresponding migration file.
+ * 2. No migrations were missed. That is, all migrations up to the latest
+ *    applied migration have been applied.
+ *
+ * Note: migrations are applied (and MUST be applied) in alphabetical order by
+ * their file name.
+ */
+function ensureIntegrity(
+  appliedMigrations: TursoMigration[],
+  migrationFileNames: string[],
+) {
+  // If no migrations have been applied, there are no checks to run.
+  if (appliedMigrations.length === 0) {
+    return;
+  }
+
+  // Check #1.
+  for (const { file_name } of appliedMigrations) {
+    if (!migrationFileNames.includes(file_name)) {
+      throw new Error(
+        `Applied migration "${file_name}" has no corresponding file in the migrations directory.`,
+      );
+    }
+  }
+
+  // Check #2.
+  const sortedAppliedMigrationFileNames = [...appliedMigrations]
+    .map(({ file_name }) => file_name)
+    .sort();
+  const sortedMigrationFileNames = [...migrationFileNames].sort();
+  for (let i = 0; i < sortedAppliedMigrationFileNames.length; i++) {
+    if (sortedAppliedMigrationFileNames[i] !== sortedMigrationFileNames[i]) {
+      throw new Error(
+        `Migration "${sortedMigrationFileNames[i]}" was not applied.`,
+      );
+    }
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoAppRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoAppRepository.ts
@@ -1,0 +1,61 @@
+import type { AppId } from "@superego/backend";
+import type { AppEntity, AppRepository } from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoApp from "../types/TursoApp.js";
+import { toEntity } from "../types/TursoApp.js";
+
+const table = "apps";
+
+export default class TursoAppRepository implements AppRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(app: AppEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "type", "name", "created_at")
+        VALUES
+          (?, ?, ?, ?)
+      `)
+      .run(app.id, app.type, app.name, app.createdAt.toISOString());
+  }
+
+  async replace(app: AppEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "type" = ?,
+          "name" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(app.type, app.name, app.createdAt.toISOString(), app.id);
+  }
+
+  async delete(id: AppId): Promise<AppId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: AppId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: AppId): Promise<AppEntity | null> {
+    const app = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoApp | undefined;
+    return app ? toEntity(app) : null;
+  }
+
+  async findAll(): Promise<AppEntity[]> {
+    const apps = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "name" ASC`)
+      .all()) as TursoApp[];
+    return apps.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoAppVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoAppVersionRepository.ts
@@ -1,0 +1,75 @@
+import { encode } from "@msgpack/msgpack";
+import type { AppId, AppVersionId } from "@superego/backend";
+import type {
+  AppVersionEntity,
+  AppVersionRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoAppVersion from "../types/TursoAppVersion.js";
+import { toEntity } from "../types/TursoAppVersion.js";
+
+const table = "app_versions";
+
+export default class TursoAppVersionRepository implements AppVersionRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(appVersion: AppVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET "is_latest" = 0
+        WHERE "app_id" = ? AND "is_latest" = 1
+      `)
+      .run(appVersion.appId);
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "previous_version_id",
+            "app_id",
+            "target_collections",
+            "files",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        appVersion.id,
+        appVersion.previousVersionId,
+        appVersion.appId,
+        encode(appVersion.targetCollections),
+        encode(appVersion.files),
+        appVersion.createdAt.toISOString(),
+        1,
+      );
+  }
+
+  async deleteAllWhereAppIdEq(appId: AppId): Promise<AppVersionId[]> {
+    const result = (await this.db
+      .prepare(`SELECT "id" FROM "${table}" WHERE "app_id" = ?`)
+      .all(appId)) as { id: AppVersionId }[];
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "app_id" = ?`)
+      .run(appId);
+    return result.map(({ id }) => id);
+  }
+
+  async findLatestWhereAppIdEq(appId: AppId): Promise<AppVersionEntity | null> {
+    const appVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "app_id" = ? AND "is_latest" = 1`,
+      )
+      .get(appId)) as TursoAppVersion | undefined;
+    return appVersion ? toEntity(appVersion) : null;
+  }
+
+  async findAllLatests(): Promise<AppVersionEntity[]> {
+    const appVersions = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "is_latest" = 1`)
+      .all()) as TursoAppVersion[];
+    return appVersions.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoBackgroundJobRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoBackgroundJobRepository.ts
@@ -1,0 +1,113 @@
+import { type BackgroundJobId, BackgroundJobStatus } from "@superego/backend";
+import type {
+  BackgroundJobEntity,
+  BackgroundJobRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoBackgroundJob from "../types/TursoBackgroundJob.js";
+import { toEntity } from "../types/TursoBackgroundJob.js";
+
+const table = "background_jobs";
+
+export default class TursoBackgroundJobRepository implements BackgroundJobRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(backgroundJob: BackgroundJobEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "name",
+            "input",
+            "status",
+            "enqueued_at",
+            "started_processing_at" ,
+            "finished_processing_at",
+            "error"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        backgroundJob.id,
+        backgroundJob.name,
+        JSON.stringify(backgroundJob.input),
+        backgroundJob.status,
+        backgroundJob.enqueuedAt.toISOString(),
+        backgroundJob.startedProcessingAt?.toISOString() ?? null,
+        backgroundJob.finishedProcessingAt?.toISOString() ?? null,
+        backgroundJob.error ? JSON.stringify(backgroundJob.error) : null,
+      );
+  }
+
+  async replace(backgroundJob: BackgroundJobEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "name" = ?,
+          "input" = ?,
+          "status" = ?,
+          "enqueued_at" = ?,
+          "started_processing_at"  = ?,
+          "finished_processing_at" = ?,
+          "error" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        backgroundJob.name,
+        JSON.stringify(backgroundJob.input),
+        backgroundJob.status,
+        backgroundJob.enqueuedAt.toISOString(),
+        backgroundJob.startedProcessingAt?.toISOString() ?? null,
+        backgroundJob.finishedProcessingAt?.toISOString() ?? null,
+        backgroundJob.error ? JSON.stringify(backgroundJob.error) : null,
+        backgroundJob.id,
+      );
+  }
+
+  async find(id: BackgroundJobId): Promise<BackgroundJobEntity | null> {
+    const backgroundJob = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoBackgroundJob | undefined;
+    return backgroundJob ? toEntity(backgroundJob) : null;
+  }
+
+  async findWhereStatusEqProcessing(): Promise<
+    (BackgroundJobEntity & { status: BackgroundJobStatus.Processing }) | null
+  > {
+    const backgroundJob = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "status" = '${BackgroundJobStatus.Processing}'`,
+      )
+      .get()) as TursoBackgroundJob | undefined;
+    return backgroundJob
+      ? (toEntity(backgroundJob) as BackgroundJobEntity & {
+          status: BackgroundJobStatus.Processing;
+        })
+      : null;
+  }
+
+  async findOldestWhereStatusEqEnqueued(): Promise<
+    (BackgroundJobEntity & { status: BackgroundJobStatus.Enqueued }) | null
+  > {
+    const backgroundJob = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "status" = '${BackgroundJobStatus.Enqueued}' ORDER BY "enqueued_at" ASC`,
+      )
+      .get()) as TursoBackgroundJob | undefined;
+    return backgroundJob
+      ? (toEntity(backgroundJob) as BackgroundJobEntity & {
+          status: BackgroundJobStatus.Enqueued;
+        })
+      : null;
+  }
+
+  async findAll(): Promise<BackgroundJobEntity[]> {
+    const backgroundJobs = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "enqueued_at" DESC`)
+      .all()) as TursoBackgroundJob[];
+    return backgroundJobs.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoCollectionCategoryRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoCollectionCategoryRepository.ts
@@ -1,0 +1,88 @@
+import type { CollectionCategoryId } from "@superego/backend";
+import type {
+  CollectionCategoryEntity,
+  CollectionCategoryRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoCollectionCategory from "../types/TursoCollectionCategory.js";
+import { toEntity } from "../types/TursoCollectionCategory.js";
+
+const table = "collection_categories";
+
+export default class TursoCollectionCategoryRepository implements CollectionCategoryRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(collectionCategory: CollectionCategoryEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "name", "icon", "parent_id", "created_at")
+        VALUES
+          (?, ?, ?, ?, ?)
+      `)
+      .run(
+        collectionCategory.id,
+        collectionCategory.name,
+        collectionCategory.icon,
+        collectionCategory.parentId,
+        collectionCategory.createdAt.toISOString(),
+      );
+  }
+
+  async replace(collectionCategory: CollectionCategoryEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "name" = ?,
+          "icon" = ?,
+          "parent_id" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        collectionCategory.name,
+        collectionCategory.icon,
+        collectionCategory.parentId,
+        collectionCategory.createdAt.toISOString(),
+        collectionCategory.id,
+      );
+  }
+
+  async delete(id: CollectionCategoryId): Promise<CollectionCategoryId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: CollectionCategoryId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async existsWhereParentIdEq(
+    parentId: CollectionCategoryId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "parent_id" = ?`)
+      .get(parentId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(
+    id: CollectionCategoryId,
+  ): Promise<CollectionCategoryEntity | null> {
+    const collectionCategory = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoCollectionCategory | undefined;
+    return collectionCategory ? toEntity(collectionCategory) : null;
+  }
+
+  async findAll(): Promise<CollectionCategoryEntity[]> {
+    const collectionCategories = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "name" ASC`)
+      .all()) as TursoCollectionCategory[];
+    return collectionCategories.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoCollectionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoCollectionRepository.ts
@@ -1,0 +1,82 @@
+import type { CollectionCategoryId, CollectionId } from "@superego/backend";
+import type {
+  CollectionEntity,
+  CollectionRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoCollection from "../types/TursoCollection.js";
+import { toEntity } from "../types/TursoCollection.js";
+
+const table = "collections";
+
+export default class TursoCollectionRepository implements CollectionRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(collection: CollectionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          ("id", "settings", "created_at")
+        VALUES
+          (?, ?, ?)
+      `)
+      .run(
+        collection.id,
+        JSON.stringify(collection.settings),
+        collection.createdAt.toISOString(),
+      );
+  }
+
+  async replace(collection: CollectionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "settings" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        JSON.stringify(collection.settings),
+        collection.createdAt.toISOString(),
+        collection.id,
+      );
+  }
+
+  async delete(id: CollectionId): Promise<CollectionId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: CollectionId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async existsWhereSettingsCollectionCategoryIdEq(
+    settingsCollectionCategoryId: CollectionCategoryId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(
+        `SELECT 1 FROM "${table}" WHERE "settings" ->> '$.collectionCategoryId' = ?`,
+      )
+      .get(settingsCollectionCategoryId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: CollectionId): Promise<CollectionEntity | null> {
+    const collection = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoCollection | undefined;
+    return collection ? toEntity(collection) : null;
+  }
+
+  async findAll(): Promise<CollectionEntity[]> {
+    const collections = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "settings" ->> '$.name' ASC`)
+      .all()) as TursoCollection[];
+    return collections.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoCollectionVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoCollectionVersionRepository.ts
@@ -1,0 +1,115 @@
+import type { CollectionId, CollectionVersionId } from "@superego/backend";
+import type {
+  CollectionVersionEntity,
+  CollectionVersionRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoCollectionVersion from "../types/TursoCollectionVersion.js";
+import { toEntity } from "../types/TursoCollectionVersion.js";
+
+const table = "collection_versions";
+
+export default class TursoCollectionVersionRepository implements CollectionVersionRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(collectionVersion: CollectionVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET "is_latest" = 0
+        WHERE "collection_id" = ? AND "is_latest" = 1
+      `)
+      .run(collectionVersion.collectionId);
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "previous_version_id",
+            "collection_id",
+            "schema",
+            "settings",
+            "migration",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        collectionVersion.id,
+        collectionVersion.previousVersionId,
+        collectionVersion.collectionId,
+        JSON.stringify(collectionVersion.schema),
+        JSON.stringify(collectionVersion.settings),
+        collectionVersion.migration
+          ? JSON.stringify(collectionVersion.migration)
+          : null,
+        collectionVersion.createdAt.toISOString(),
+        1,
+      );
+  }
+
+  async replace(collectionVersion: CollectionVersionEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        UPDATE "${table}"
+        SET
+          "previous_version_id" = ?,
+          "collection_id" = ?,
+          "schema" = ?,
+          "settings" = ?,
+          "migration" = ?,
+          "created_at" = ?
+        WHERE "id" = ?
+      `)
+      .run(
+        collectionVersion.previousVersionId,
+        collectionVersion.collectionId,
+        JSON.stringify(collectionVersion.schema),
+        JSON.stringify(collectionVersion.settings),
+        collectionVersion.migration
+          ? JSON.stringify(collectionVersion.migration)
+          : null,
+        collectionVersion.createdAt.toISOString(),
+        collectionVersion.id,
+      );
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<CollectionVersionId[]> {
+    const result = (await this.db
+      .prepare(`SELECT "id" FROM "${table}" WHERE "collection_id" = ?`)
+      .all(collectionId)) as { id: CollectionVersionId }[];
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "collection_id" = ?`)
+      .run(collectionId);
+    return result.map(({ id }) => id);
+  }
+
+  async find(id: CollectionVersionId): Promise<CollectionVersionEntity | null> {
+    const collectionVersion = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoCollectionVersion | undefined;
+    return collectionVersion ? toEntity(collectionVersion) : null;
+  }
+
+  async findLatestWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<CollectionVersionEntity | null> {
+    const collectionVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${table}" WHERE "collection_id" = ? AND "is_latest" = 1`,
+      )
+      .get(collectionId)) as TursoCollectionVersion | undefined;
+    return collectionVersion ? toEntity(collectionVersion) : null;
+  }
+
+  async findAllLatests(): Promise<CollectionVersionEntity[]> {
+    const collectionVersions = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "is_latest" = 1`)
+      .all()) as TursoCollectionVersion[];
+    return collectionVersions.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoConversationRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoConversationRepository.ts
@@ -1,0 +1,81 @@
+import { encode } from "@msgpack/msgpack";
+import type { ConversationId } from "@superego/backend";
+import type {
+  ConversationEntity,
+  ConversationRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoConversation from "../types/TursoConversation.js";
+import { toEntity } from "../types/TursoConversation.js";
+
+const table = "conversations";
+
+export default class TursoConversationRepository implements ConversationRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async upsert(conversation: ConversationEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "assistant",
+            "title",
+            "context_fingerprint",
+            "messages",
+            "status",
+            "processing_started_at",
+            "error",
+            "created_at"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT("id") DO UPDATE SET
+          "assistant" = excluded."assistant",
+          "title" = excluded."title",
+          "context_fingerprint" = excluded."context_fingerprint",
+          "messages" = excluded."messages",
+          "status" = excluded."status",
+          "processing_started_at" = excluded."processing_started_at",
+          "error" = excluded."error",
+          "created_at" = excluded."created_at"
+      `)
+      .run(
+        conversation.id,
+        conversation.assistant,
+        conversation.title,
+        conversation.contextFingerprint,
+        encode(conversation.messages),
+        conversation.status,
+        conversation.processingStartedAt?.toISOString() ?? null,
+        conversation.error ? JSON.stringify(conversation.error) : null,
+        conversation.createdAt.toISOString(),
+      );
+  }
+
+  async delete(id: ConversationId): Promise<ConversationId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async exists(id: ConversationId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: ConversationId): Promise<ConversationEntity | null> {
+    const conversation = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoConversation | undefined;
+    return conversation ? toEntity(conversation) : null;
+  }
+
+  async findAll(): Promise<ConversationEntity[]> {
+    const conversations = (await this.db
+      .prepare(`SELECT * FROM "${table}" ORDER BY "created_at" DESC`)
+      .all()) as TursoConversation[];
+    return conversations.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoConversationTextSearchIndex.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoConversationTextSearchIndex.ts
@@ -1,0 +1,123 @@
+import type { ConversationId } from "@superego/backend";
+import type { ConversationTextSearchIndex } from "@superego/executing-backend";
+import { Document as FlexsearchDocument } from "flexsearch";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoConversationTextSearchText from "../types/TursoConversationTextSearchText.js";
+
+const table = "conversation_text_search_texts";
+
+type FlexsearchDocumentData = {
+  id: ConversationId;
+  text: string;
+};
+
+export interface SearchTextIndexState {
+  index: FlexsearchDocument<FlexsearchDocumentData>;
+  isLoaded: boolean;
+}
+
+export default class TursoConversationTextSearchIndex implements ConversationTextSearchIndex {
+  constructor(
+    private db: TursoDatabase,
+    private searchTextIndexState: SearchTextIndexState,
+    private onTransactionSucceeded: (callback: () => void) => void,
+  ) {}
+
+  async upsert(
+    conversationId: ConversationId,
+    textChunks: { title: string[]; messages: string[] },
+  ): Promise<void> {
+    const text = [...textChunks.title, ...textChunks.messages].join(" | ");
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("conversation_id", "text")
+        VALUES
+          (?, ?)
+      `)
+      .run(conversationId, text);
+
+    this.onTransactionSucceeded(() => {
+      this.searchTextIndexState.index.remove(conversationId);
+      this.searchTextIndexState.index.add({ id: conversationId, text });
+    });
+  }
+
+  async remove(conversationId: ConversationId): Promise<void> {
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "conversation_id" = ?`)
+      .run(conversationId);
+
+    this.onTransactionSucceeded(() =>
+      this.searchTextIndexState.index.remove(conversationId),
+    );
+  }
+
+  async search(
+    query: string,
+    options: { limit: number },
+  ): Promise<
+    {
+      conversationId: ConversationId;
+      matchedText: string;
+    }[]
+  > {
+    if (query === "") {
+      const rows = (await this.db
+        .prepare(`SELECT * FROM "${table}" LIMIT ?`)
+        .all(options.limit)) as TursoConversationTextSearchText[];
+      return rows.map((row) => ({
+        conversationId: row.conversation_id,
+        matchedText: "",
+      }));
+    }
+
+    await this.loadIndex();
+
+    const results = this.searchTextIndexState.index.search(query, {
+      limit: options.limit,
+      merge: true,
+      enrich: true,
+      highlight: {
+        template: "«$1»",
+        boundary: 128,
+      },
+    });
+
+    return results.map(({ id, highlight }) => ({
+      conversationId: id as ConversationId,
+      matchedText: highlight!.text,
+    }));
+  }
+
+  private async loadIndex(): Promise<void> {
+    if (this.searchTextIndexState.isLoaded) {
+      return;
+    }
+
+    const conversationTextSearchTexts = (await this.db
+      .prepare(`SELECT * FROM "${table}"`)
+      .all()) as TursoConversationTextSearchText[];
+
+    for (const { conversation_id, text } of conversationTextSearchTexts) {
+      this.searchTextIndexState.index.add({ id: conversation_id, text: text });
+    }
+
+    this.searchTextIndexState.isLoaded = true;
+  }
+
+  static getSearchTextIndexState(): SearchTextIndexState {
+    return {
+      index: new FlexsearchDocument<FlexsearchDocumentData>({
+        document: {
+          id: "id",
+          index: ["text"],
+          store: ["text"],
+        },
+        tokenize: "forward",
+        context: true,
+      }),
+      isLoaded: false,
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoDocumentRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoDocumentRepository.ts
@@ -1,0 +1,98 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type {
+  DocumentEntity,
+  DocumentRepository,
+} from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoDocument from "../types/TursoDocument.js";
+import { toEntity } from "../types/TursoDocument.js";
+
+const table = "documents";
+
+export default class TursoDocumentRepository implements DocumentRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(document: DocumentEntity): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT INTO "${table}"
+          (
+            "id",
+            "collection_id",
+            "created_at"
+          )
+        VALUES
+          (?, ?, ?)
+      `)
+      .run(
+        document.id,
+        document.collectionId,
+        document.createdAt.toISOString(),
+      );
+  }
+
+  async replace(document: DocumentEntity): Promise<void> {
+    await this.db
+      .prepare(`
+          UPDATE "${table}"
+          SET
+            "collection_id" = ?,
+            "created_at" = ?
+          WHERE "id" = ?
+        `)
+      .run(
+        document.collectionId,
+        document.createdAt.toISOString(),
+        document.id,
+      );
+  }
+
+  async delete(id: DocumentId): Promise<DocumentId> {
+    await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`).run(id);
+    return id;
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentId[]> {
+    const result = (await this.db
+      .prepare(`SELECT "id" FROM "${table}" WHERE "collection_id" = ?`)
+      .all(collectionId)) as { id: DocumentId }[];
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "collection_id" = ?`)
+      .run(collectionId);
+    return result.map(({ id }) => id);
+  }
+
+  async exists(id: DocumentId): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async oneExistsWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<boolean> {
+    const result = (await this.db
+      .prepare(`SELECT 1 FROM "${table}" WHERE "collection_id" = ?`)
+      .get(collectionId)) as 1 | undefined;
+    return result !== undefined;
+  }
+
+  async find(id: DocumentId): Promise<DocumentEntity | null> {
+    const document = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as TursoDocument | undefined;
+    return document ? toEntity(document) : null;
+  }
+
+  async findAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentEntity[]> {
+    const documents = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "collection_id" = ?`)
+      .all(collectionId)) as TursoDocument[];
+    return documents.map(toEntity);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoDocumentTextSearchIndex.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoDocumentTextSearchIndex.ts
@@ -1,0 +1,153 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type { DocumentTextSearchIndex } from "@superego/executing-backend";
+import type { TextChunks } from "@superego/schema";
+import { Document as FlexsearchDocument } from "flexsearch";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoDocumentTextSearchText from "../types/TursoDocumentTextSearchText.js";
+
+const table = "document_text_search_texts";
+
+type FlexsearchDocumentData = {
+  id: DocumentId;
+  collectionId: CollectionId;
+  text: string;
+};
+
+export interface SearchTextIndexState {
+  index: FlexsearchDocument<FlexsearchDocumentData>;
+  isLoaded: boolean;
+}
+
+export default class TursoDocumentTextSearchIndex implements DocumentTextSearchIndex {
+  constructor(
+    private db: TursoDatabase,
+    private searchTextIndexState: SearchTextIndexState,
+    private onTransactionSucceeded: (callback: () => void) => void,
+  ) {}
+
+  async upsert(
+    collectionId: CollectionId,
+    documentId: DocumentId,
+    textChunks: TextChunks,
+  ): Promise<void> {
+    const text = Object.values(textChunks).flat().join(" | ");
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("document_id", "collection_id", "text")
+        VALUES
+          (?, ?, ?)
+      `)
+      .run(documentId, collectionId, text);
+
+    this.onTransactionSucceeded(() => {
+      this.searchTextIndexState.index.remove(documentId);
+      this.searchTextIndexState.index.add({
+        id: documentId,
+        collectionId,
+        text,
+      });
+    });
+  }
+
+  async remove(
+    _collectionId: CollectionId,
+    documentId: DocumentId,
+  ): Promise<void> {
+    await this.db
+      .prepare(`DELETE FROM "${table}" WHERE "document_id" = ?`)
+      .run(documentId);
+
+    this.onTransactionSucceeded(() =>
+      this.searchTextIndexState.index.remove(documentId),
+    );
+  }
+
+  async search(
+    collectionId: CollectionId | null,
+    query: string,
+    options: { limit: number },
+  ): Promise<
+    {
+      collectionId: CollectionId;
+      documentId: DocumentId;
+      matchedText: string;
+    }[]
+  > {
+    if (query === "") {
+      const rows = (await this.db
+        .prepare(
+          collectionId
+            ? `SELECT * FROM "${table}" WHERE "collection_id" = ? LIMIT ?`
+            : `SELECT * FROM "${table}" LIMIT ?`,
+        )
+        .all(
+          ...(collectionId ? [collectionId, options.limit] : [options.limit]),
+        )) as TursoDocumentTextSearchText[];
+      return rows.map((row) => ({
+        collectionId: row.collection_id,
+        documentId: row.document_id,
+        matchedText: "",
+      }));
+    }
+
+    await this.loadIndex();
+
+    const results = this.searchTextIndexState.index.search(query, {
+      tag: collectionId ? { collectionId } : undefined,
+      limit: options.limit,
+      merge: true,
+      enrich: true,
+      highlight: {
+        template: "«$1»",
+        boundary: 128,
+      },
+    });
+
+    return results.map(({ id, doc, highlight }) => ({
+      collectionId: doc!.collectionId,
+      documentId: id as DocumentId,
+      matchedText: highlight!.text,
+    }));
+  }
+
+  private async loadIndex(): Promise<void> {
+    if (this.searchTextIndexState.isLoaded) {
+      return;
+    }
+
+    const documentTextSearchTexts = (await this.db
+      .prepare(`SELECT * FROM "${table}"`)
+      .all()) as TursoDocumentTextSearchText[];
+
+    for (const {
+      document_id,
+      collection_id,
+      text,
+    } of documentTextSearchTexts) {
+      this.searchTextIndexState.index.add({
+        id: document_id,
+        collectionId: collection_id,
+        text: text,
+      });
+    }
+
+    this.searchTextIndexState.isLoaded = true;
+  }
+
+  static getSearchTextIndexState(): SearchTextIndexState {
+    return {
+      index: new FlexsearchDocument<FlexsearchDocumentData>({
+        document: {
+          id: "id",
+          index: ["text"],
+          tag: ["collectionId"],
+          store: ["collectionId", "text"],
+        },
+        tokenize: "forward",
+        context: true,
+      }),
+      isLoaded: false,
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoDocumentVersionRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoDocumentVersionRepository.ts
@@ -1,0 +1,326 @@
+import type {
+  CollectionId,
+  CollectionVersionId,
+  DocumentId,
+  DocumentVersionId,
+} from "@superego/backend";
+import type {
+  DocumentVersionEntity,
+  DocumentVersionRepository,
+  MinimalDocumentVersionEntity,
+} from "@superego/executing-backend";
+import { memoize } from "es-toolkit";
+import { create } from "jsondiffpatch";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoDocumentVersion from "../types/TursoDocumentVersion.js";
+import { toEntity, toMinimalEntity } from "../types/TursoDocumentVersion.js";
+
+const documentVersionsTable = "document_versions";
+const documentVersionContentBlockingKeysTable =
+  "document_version_content_blocking_keys";
+
+const jdp = create({ omitRemovedValues: true });
+
+export default class TursoDocumentVersionRepository implements DocumentVersionRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insert(documentVersion: DocumentVersionEntity): Promise<void> {
+    const previousDocumentVersion = await this.findLatestWhereDocumentIdEq(
+      documentVersion.documentId,
+    );
+    if (previousDocumentVersion) {
+      await this.db
+        .prepare(`
+          UPDATE "${documentVersionsTable}"
+          SET "is_latest" = 0, "content_snapshot" = null
+          WHERE "document_id" = ? AND "is_latest" = 1
+        `)
+        .run(documentVersion.documentId);
+    }
+    await this.db
+      .prepare(`
+        INSERT INTO "${documentVersionsTable}"
+          (
+            "id",
+            "previous_version_id",
+            "collection_id",
+            "document_id",
+            "collection_version_id",
+            "conversation_id",
+            "content_delta",
+            "content_snapshot",
+            "content_blocking_keys",
+            "content_summary",
+            "referenced_documents",
+            "created_by",
+            "created_at",
+            "is_latest"
+          )
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        documentVersion.id,
+        documentVersion.previousVersionId,
+        documentVersion.collectionId,
+        documentVersion.documentId,
+        documentVersion.collectionVersionId,
+        documentVersion.conversationId,
+        JSON.stringify(
+          jdp.diff(previousDocumentVersion?.content, documentVersion.content),
+        ) ?? null,
+        JSON.stringify(documentVersion.content),
+        documentVersion.contentBlockingKeys
+          ? JSON.stringify(documentVersion.contentBlockingKeys)
+          : null,
+        JSON.stringify(documentVersion.contentSummary),
+        JSON.stringify(documentVersion.referencedDocuments),
+        documentVersion.createdBy,
+        documentVersion.createdAt.toISOString(),
+        1,
+      );
+    // Insert blocking keys into the "index" table.
+    await this.insertContentBlockingKeys(
+      documentVersion.collectionId,
+      documentVersion.id,
+      documentVersion.contentBlockingKeys,
+    );
+    // Delete content blocking keys of previous versions from the index table.
+    // We only need to keep blocking keys for the latest version of each
+    // document.
+    if (previousDocumentVersion) {
+      await this.deleteContentBlockingKeys(previousDocumentVersion.id);
+    }
+  }
+
+  async updateContentBlockingKeys(
+    id: DocumentVersionId,
+    contentBlockingKeys: DocumentVersionEntity["contentBlockingKeys"],
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE "${documentVersionsTable}" SET "content_blocking_keys" = ? WHERE "id" = ?`,
+      )
+      .run(
+        contentBlockingKeys ? JSON.stringify(contentBlockingKeys) : null,
+        id,
+      );
+
+    // Only update the index table for the latest version.
+    const documentVersion = (await this.db
+      .prepare(
+        `SELECT "collection_id" FROM "${documentVersionsTable}" WHERE "id" = ? AND "is_latest" = 1`,
+      )
+      .get(id)) as { collection_id: CollectionId } | undefined;
+    if (!documentVersion) {
+      return;
+    }
+    await this.deleteContentBlockingKeys(id);
+    await this.insertContentBlockingKeys(
+      documentVersion.collection_id,
+      id,
+      contentBlockingKeys,
+    );
+  }
+
+  async updateContentSummary(
+    id: DocumentVersionId,
+    contentSummary: DocumentVersionEntity["contentSummary"],
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `UPDATE "${documentVersionsTable}" SET "content_summary" = ? WHERE "id" = ?`,
+      )
+      .run(JSON.stringify(contentSummary), id);
+  }
+
+  async deleteAllWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentVersionId[]> {
+    const result = (await this.db
+      .prepare(
+        `SELECT "id" FROM "${documentVersionsTable}" WHERE "collection_id" = ?`,
+      )
+      .all(collectionId)) as { id: DocumentVersionId }[];
+    await this.db
+      .prepare(
+        `DELETE FROM "${documentVersionsTable}" WHERE "collection_id" = ?`,
+      )
+      .run(collectionId);
+    // documentVersionContentBlockingKeysTable rows are deleted ON CASCADE.
+    return result.map(({ id }) => id);
+  }
+
+  async deleteAllWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<DocumentVersionId[]> {
+    const result = (await this.db
+      .prepare(
+        `SELECT "id" FROM "${documentVersionsTable}" WHERE "document_id" = ?`,
+      )
+      .all(documentId)) as { id: DocumentVersionId }[];
+    await this.db
+      .prepare(`DELETE FROM "${documentVersionsTable}" WHERE "document_id" = ?`)
+      .run(documentId);
+    // documentVersionContentBlockingKeysTable rows are deleted ON CASCADE.
+    return result.map(({ id }) => id);
+  }
+
+  async find(id: DocumentVersionId): Promise<DocumentVersionEntity | null> {
+    const documentVersion = (await this.db
+      .prepare(`SELECT * FROM "${documentVersionsTable}" WHERE "id" = ?`)
+      .get(id)) as TursoDocumentVersion | undefined;
+    if (!documentVersion) {
+      return null;
+    }
+    if (documentVersion.is_latest === 1) {
+      return toEntity(documentVersion);
+    }
+    const allDocumentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ?`,
+      )
+      .all(documentVersion.document_id)) as TursoDocumentVersion[];
+    return toEntity(documentVersion, allDocumentVersions, jdp);
+  }
+
+  async findLatestWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<DocumentVersionEntity | null> {
+    const documentVersion = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ? AND "is_latest" = 1`,
+      )
+      .get(documentId)) as
+      | (TursoDocumentVersion & { is_latest: 1 })
+      | undefined;
+    return documentVersion ? toEntity(documentVersion) : null;
+  }
+
+  async findAllWhereDocumentIdEq(
+    documentId: DocumentId,
+  ): Promise<MinimalDocumentVersionEntity[]> {
+    const allDocumentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ? ORDER BY "created_at" DESC`,
+      )
+      .all(documentId)) as TursoDocumentVersion[];
+    return allDocumentVersions.map(toMinimalEntity);
+  }
+
+  async findAllWhereCollectionVersionIdEq(
+    collectionVersionId: CollectionVersionId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "collection_version_id" = ?`,
+      )
+      .all(collectionVersionId)) as TursoDocumentVersion[];
+
+    const findAllByDocumentIdStatement = await this.db.prepare(
+      `SELECT * FROM "${documentVersionsTable}" WHERE "document_id" = ?`,
+    );
+    const getAllVersionsForDocument = memoize(
+      async (documentId: string) =>
+        (await findAllByDocumentIdStatement.all(
+          documentId,
+        )) as TursoDocumentVersion[],
+    );
+
+    return Promise.all(
+      documentVersions.map(async (documentVersion) =>
+        documentVersion.is_latest === 1
+          ? toEntity(documentVersion)
+          : toEntity(
+              documentVersion,
+              await getAllVersionsForDocument(documentVersion.document_id),
+              jdp,
+            ),
+      ),
+    );
+  }
+
+  async findAllLatestsWhereCollectionIdEq(
+    collectionId: CollectionId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(
+        `SELECT * FROM "${documentVersionsTable}" WHERE "collection_id" = ? AND "is_latest" = 1`,
+      )
+      .all(collectionId)) as (TursoDocumentVersion & { is_latest: 1 })[];
+    return documentVersions.map(toEntity);
+  }
+
+  async findAllLatestWhereReferencedDocumentsContains(
+    collectionId: CollectionId,
+    documentId: DocumentId,
+  ): Promise<DocumentVersionEntity[]> {
+    const documentVersions = (await this.db
+      .prepare(`
+        SELECT * FROM "${documentVersionsTable}"
+        WHERE "is_latest" = 1
+        AND EXISTS (
+          SELECT 1 FROM json_each("referenced_documents")
+          WHERE json_extract(value, '$.collectionId') = ?
+          AND json_extract(value, '$.documentId') = ?
+        )
+      `)
+      .all(collectionId, documentId)) as (TursoDocumentVersion & {
+      is_latest: 1;
+    })[];
+    return documentVersions.map(toEntity);
+  }
+
+  async findAnyLatestWhereCollectionIdEqAndContentBlockingKeysOverlap(
+    collectionId: CollectionId,
+    contentBlockingKeys: string[],
+  ): Promise<DocumentVersionEntity | null> {
+    if (contentBlockingKeys.length === 0) {
+      return null;
+    }
+    const placeholders = contentBlockingKeys.map(() => "?").join(", ");
+    const documentVersion = (await this.db
+      .prepare(`
+        SELECT dv.* FROM "${documentVersionsTable}" dv
+        JOIN "${documentVersionContentBlockingKeysTable}" dvcbk
+          ON dv."id" = dvcbk."document_version_id"
+        WHERE dvcbk."collection_id" = ?
+        AND dvcbk."blocking_key" IN (${placeholders})
+        AND dv."is_latest" = 1
+        LIMIT 1
+      `)
+      .get(collectionId, ...contentBlockingKeys)) as
+      | (TursoDocumentVersion & { is_latest: 1 })
+      | undefined;
+    return documentVersion ? toEntity(documentVersion) : null;
+  }
+
+  private async insertContentBlockingKeys(
+    collectionId: CollectionId,
+    documentVersionId: DocumentVersionId,
+    contentBlockingKeys: string[] | null,
+  ): Promise<void> {
+    if (contentBlockingKeys === null) {
+      return;
+    }
+    const insertBlockingKey = await this.db.prepare(`
+      INSERT INTO "${documentVersionContentBlockingKeysTable}"
+        ("collection_id", "document_version_id", "blocking_key")
+      VALUES
+        (?, ?, ?)
+    `);
+    for (const blockingKey of contentBlockingKeys) {
+      await insertBlockingKey.run(collectionId, documentVersionId, blockingKey);
+    }
+  }
+
+  private async deleteContentBlockingKeys(
+    documentVersionId: DocumentVersionId,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        `DELETE FROM "${documentVersionContentBlockingKeysTable}" WHERE "document_version_id" = ?`,
+      )
+      .run(documentVersionId);
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoFileRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoFileRepository.ts
@@ -1,0 +1,199 @@
+import type { FileId } from "@superego/backend";
+import type { FileEntity, FileRepository } from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoFile from "../types/TursoFile.js";
+import { toEntity } from "../types/TursoFile.js";
+
+const table = "files";
+
+export default class TursoFileRepository implements FileRepository {
+  constructor(private db: TursoDatabase) {}
+
+  async insertAll(
+    filesWithContent: (FileEntity & { content: Uint8Array<ArrayBuffer> })[],
+  ): Promise<void> {
+    const insert = await this.db.prepare(`
+      INSERT INTO "${table}"
+        (
+          "id",
+          "referenced_by",
+          "created_at",
+          "content"
+        )
+      VALUES
+        (?, ?, ?, ?)
+    `);
+    for (const file of filesWithContent) {
+      await insert.run(
+        file.id,
+        JSON.stringify(file.referencedBy),
+        file.createdAt.toISOString(),
+        file.content,
+      );
+    }
+  }
+
+  async addReferenceToAll(
+    ids: FileId[],
+    reference: FileEntity.Reference,
+  ): Promise<void> {
+    if (ids.length === 0) {
+      return;
+    }
+    const placeholders = ids.map(() => "?").join(", ");
+    const files = (await this.db
+      .prepare(
+        `SELECT "id", "referenced_by" FROM "${table}" WHERE "id" IN (${placeholders})`,
+      )
+      .all(...ids)) as Pick<TursoFile, "id" | "referenced_by">[];
+    const update = await this.db.prepare(
+      `UPDATE "${table}" SET "referenced_by" = ? WHERE "id" = ?`,
+    );
+    for (const file of files) {
+      const references = TursoFileRepository.parseReferences(
+        file.referenced_by,
+      );
+      if (!TursoFileRepository.referencesIncludes(references, reference)) {
+        references.push(reference);
+        await update.run(JSON.stringify(references), file.id);
+      }
+    }
+  }
+
+  async deleteReferenceFromAll(
+    reference:
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">
+      | FileEntity.ConversationReference,
+  ): Promise<void> {
+    const files = (await this.db
+      .prepare(`SELECT "id", "referenced_by" FROM "${table}"`)
+      .all()) as Pick<TursoFile, "id" | "referenced_by">[];
+    const update = await this.db.prepare(
+      `UPDATE "${table}" SET "referenced_by" = ? WHERE "id" = ?`,
+    );
+    const del = await this.db.prepare(`DELETE FROM "${table}" WHERE "id" = ?`);
+    for (const file of files) {
+      const references = TursoFileRepository.parseReferences(
+        file.referenced_by,
+      );
+      const updatedReferences = references.filter(
+        (ref) =>
+          !TursoFileRepository.matchesReferenceForDeletion(ref, reference),
+      );
+      if (updatedReferences.length === 0) {
+        await del.run(file.id);
+      } else if (updatedReferences.length !== references.length) {
+        await update.run(JSON.stringify(updatedReferences), file.id);
+      }
+    }
+  }
+
+  async find(id: FileId): Promise<FileEntity | null> {
+    const file = (await this.db
+      .prepare(`
+        SELECT
+          "id",
+          "referenced_by",
+          "created_at"
+        FROM "${table}"
+        WHERE "id" = ?;
+      `)
+      .get(id)) as Omit<TursoFile, "content"> | undefined;
+    return file ? toEntity(file) : null;
+  }
+
+  async findAllWhereIdIn(ids: FileId[]): Promise<FileEntity[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+    const placeholders = ids.map(() => "?").join(", ");
+    const files = (await this.db
+      .prepare(`
+        SELECT
+          "id",
+          "referenced_by",
+          "created_at"
+        FROM "${table}"
+        WHERE "id" IN (${placeholders})
+      `)
+      .all(...ids)) as Omit<TursoFile, "content">[];
+    return files.map(toEntity);
+  }
+
+  async getContent(id: FileId): Promise<Uint8Array<ArrayBuffer> | null> {
+    const result = (await this.db
+      .prepare(`SELECT "content" FROM "${table}" WHERE "id" = ?`)
+      .get(id)) as { content: Uint8Array<ArrayBuffer> } | undefined;
+    return result ? new Uint8Array(result.content) : null;
+  }
+
+  private static parseReferences(json: string): FileEntity.Reference[] {
+    return JSON.parse(json) as FileEntity.Reference[];
+  }
+
+  private static referencesIncludes(
+    references: FileEntity.Reference[],
+    reference: FileEntity.Reference,
+  ): boolean {
+    return references.some((ref) =>
+      TursoFileRepository.referencesAreEqual(ref, reference),
+    );
+  }
+
+  private static referencesAreEqual(
+    a: FileEntity.Reference,
+    b: FileEntity.Reference,
+  ): boolean {
+    if (
+      TursoFileRepository.isConversationReference(a) &&
+      TursoFileRepository.isConversationReference(b)
+    ) {
+      return a.conversationId === b.conversationId;
+    }
+    if (
+      TursoFileRepository.isDocumentVersionReference(a) &&
+      TursoFileRepository.isDocumentVersionReference(b)
+    ) {
+      return (
+        a.collectionId === b.collectionId &&
+        a.documentId === b.documentId &&
+        a.documentVersionId === b.documentVersionId
+      );
+    }
+    return false;
+  }
+
+  private static matchesReferenceForDeletion(
+    reference: FileEntity.Reference,
+    target:
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">
+      | FileEntity.ConversationReference,
+  ): boolean {
+    if (TursoFileRepository.isConversationReference(target)) {
+      return (
+        TursoFileRepository.isConversationReference(reference) &&
+        reference.conversationId === target.conversationId
+      );
+    }
+    return (
+      TursoFileRepository.isDocumentVersionReference(reference) &&
+      reference.collectionId === target.collectionId &&
+      reference.documentId === target.documentId
+    );
+  }
+
+  private static isConversationReference(
+    reference:
+      | FileEntity.Reference
+      | FileEntity.ConversationReference
+      | Omit<FileEntity.DocumentVersionReference, "documentVersionId">,
+  ): reference is FileEntity.ConversationReference {
+    return Object.hasOwn(reference, "conversationId");
+  }
+
+  private static isDocumentVersionReference(
+    reference: FileEntity.Reference,
+  ): reference is FileEntity.DocumentVersionReference {
+    return Object.hasOwn(reference, "collectionId");
+  }
+}

--- a/packages/data/turso-data-repositories/src/repositories/TursoGlobalSettingsRepository.ts
+++ b/packages/data/turso-data-repositories/src/repositories/TursoGlobalSettingsRepository.ts
@@ -1,0 +1,96 @@
+import {
+  AssistantName,
+  type GlobalSettings,
+  type InferenceOptions,
+  type InferenceProvider,
+} from "@superego/backend";
+import type { GlobalSettingsRepository } from "@superego/executing-backend";
+import type TursoDatabase from "../TursoDatabase.js";
+import type TursoGlobalSettings from "../types/TursoGlobalSettings.js";
+import { toEntity } from "../types/TursoGlobalSettings.js";
+import type DeepPartial from "../utils/DeepPartial.js";
+
+const table = "singleton__global_settings";
+
+export default class TursoGlobalSettingsRepository implements GlobalSettingsRepository {
+  constructor(
+    private db: TursoDatabase,
+    private defaultGlobalSettings: GlobalSettings,
+  ) {}
+
+  async replace(globalSettings: GlobalSettings): Promise<void> {
+    await this.db
+      .prepare(`
+        INSERT OR REPLACE INTO "${table}"
+          ("id", "value")
+        VALUES
+          (?, ?)
+      `)
+      .run("singleton", JSON.stringify(globalSettings));
+  }
+
+  async get(): Promise<GlobalSettings> {
+    const settings = (await this.db
+      .prepare(`SELECT * FROM "${table}" WHERE "id" = ?`)
+      .get("singleton")) as TursoGlobalSettings | undefined;
+    return this.mergeDefaults(settings ? toEntity(settings) : {});
+  }
+
+  // The settings retrieved from Turso could be either missing, or they could
+  // have been saved by a previous version of Superego and been missing some
+  // properties. This function merges them with the default settings, ensuring
+  // that the returned object respects the GlobalSettings interface.
+  private mergeDefaults(settings: DeepPartial<GlobalSettings>): GlobalSettings {
+    return {
+      appearance: {
+        theme:
+          settings?.appearance?.theme ??
+          this.defaultGlobalSettings.appearance.theme,
+      },
+      inference: {
+        providers:
+          (settings.inference?.providers as InferenceProvider[]) ??
+          this.defaultGlobalSettings.inference.providers,
+        defaultInferenceOptions: {
+          completion:
+            (settings.inference?.defaultInferenceOptions
+              ?.completion as InferenceOptions["completion"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .completion,
+          transcription:
+            (settings.inference?.defaultInferenceOptions
+              ?.transcription as InferenceOptions["transcription"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .transcription,
+          fileInspection:
+            (settings.inference?.defaultInferenceOptions
+              ?.fileInspection as InferenceOptions["fileInspection"]) ??
+            this.defaultGlobalSettings.inference.defaultInferenceOptions
+              .fileInspection,
+        },
+      },
+      assistants: {
+        userInfo:
+          settings.assistants?.userInfo ??
+          this.defaultGlobalSettings.assistants.userInfo,
+        userPreferences:
+          settings.assistants?.userPreferences ??
+          this.defaultGlobalSettings.assistants.userPreferences,
+        developerPrompts: {
+          [AssistantName.CollectionCreator]:
+            settings.assistants?.developerPrompts?.[
+              AssistantName.CollectionCreator
+            ] ??
+            this.defaultGlobalSettings.assistants.developerPrompts[
+              AssistantName.CollectionCreator
+            ],
+          [AssistantName.Factotum]:
+            settings.assistants?.developerPrompts?.[AssistantName.Factotum] ??
+            this.defaultGlobalSettings.assistants.developerPrompts[
+              AssistantName.Factotum
+            ],
+        },
+      },
+    };
+  }
+}

--- a/packages/data/turso-data-repositories/src/toTursoLockedError.ts
+++ b/packages/data/turso-data-repositories/src/toTursoLockedError.ts
@@ -1,0 +1,20 @@
+export default function toTursoLockedError(error: unknown): unknown {
+  if (!isTursoLockedError(error)) {
+    return error;
+  }
+  return new Error("Turso database is locked.", { cause: error });
+}
+
+function isTursoLockedError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const message = "message" in error ? String(error.message) : "";
+  const code = "code" in error ? String(error.code) : "";
+  return (
+    code === "SQLITE_BUSY" ||
+    code === "SQLITE_LOCKED" ||
+    message.includes("database is locked") ||
+    message.includes("database table is locked")
+  );
+}

--- a/packages/data/turso-data-repositories/src/types/TursoApp.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoApp.ts
@@ -1,0 +1,20 @@
+import type { AppId, AppType } from "@superego/backend";
+import type { AppEntity } from "@superego/executing-backend";
+
+type TursoApp = {
+  id: AppId;
+  type: AppType;
+  name: string;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default TursoApp;
+
+export function toEntity(app: TursoApp): AppEntity {
+  return {
+    id: app.id,
+    type: app.type,
+    name: app.name,
+    createdAt: new Date(app.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoAppVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoAppVersion.ts
@@ -1,0 +1,30 @@
+import { decode } from "@msgpack/msgpack";
+import type { AppId, AppVersionId } from "@superego/backend";
+import type { AppVersionEntity } from "@superego/executing-backend";
+
+type TursoAppVersion = {
+  id: AppVersionId;
+  previous_version_id: AppVersionId | null;
+  app_id: AppId;
+  /** MessagePack */
+  target_collections: Uint8Array<ArrayBuffer>;
+  /** MessagePack */
+  files: Uint8Array<ArrayBuffer>;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+};
+export default TursoAppVersion;
+
+export function toEntity(appVersion: TursoAppVersion): AppVersionEntity {
+  return {
+    id: appVersion.id,
+    previousVersionId: appVersion.previous_version_id,
+    appId: appVersion.app_id,
+    targetCollections: decode(
+      appVersion.target_collections,
+    ) as AppVersionEntity["targetCollections"],
+    files: decode(appVersion.files) as AppVersionEntity["files"],
+    createdAt: new Date(appVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoBackgroundJob.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoBackgroundJob.ts
@@ -1,0 +1,42 @@
+import type {
+  BackgroundJobId,
+  BackgroundJobName,
+  BackgroundJobStatus,
+} from "@superego/backend";
+import type { BackgroundJobEntity } from "@superego/executing-backend";
+
+type TursoBackgroundJob = {
+  id: BackgroundJobId;
+  name: BackgroundJobName;
+  /** JSON */
+  input: string;
+  status: BackgroundJobStatus;
+  /** ISO 8601 */
+  enqueued_at: string;
+  /** ISO 8601 */
+  started_processing_at: string | null;
+  /** ISO 8601 */
+  finished_processing_at: string | null;
+  /** JSON */
+  error: string | null;
+};
+export default TursoBackgroundJob;
+
+export function toEntity(
+  backgroundJob: TursoBackgroundJob,
+): BackgroundJobEntity {
+  return {
+    id: backgroundJob.id,
+    name: backgroundJob.name,
+    input: JSON.parse(backgroundJob.input),
+    status: backgroundJob.status,
+    enqueuedAt: new Date(backgroundJob.enqueued_at),
+    startedProcessingAt: backgroundJob.started_processing_at
+      ? new Date(backgroundJob.started_processing_at)
+      : null,
+    finishedProcessingAt: backgroundJob.finished_processing_at
+      ? new Date(backgroundJob.finished_processing_at)
+      : null,
+    error: backgroundJob.error ? JSON.parse(backgroundJob.error) : null,
+  } as BackgroundJobEntity;
+}

--- a/packages/data/turso-data-repositories/src/types/TursoCollection.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoCollection.ts
@@ -1,0 +1,19 @@
+import type { CollectionId } from "@superego/backend";
+import type { CollectionEntity } from "@superego/executing-backend";
+
+type TursoCollection = {
+  id: CollectionId;
+  /** JSON */
+  settings: string;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default TursoCollection;
+
+export function toEntity(collection: TursoCollection): CollectionEntity {
+  return {
+    id: collection.id,
+    settings: JSON.parse(collection.settings),
+    createdAt: new Date(collection.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoCollectionCategory.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoCollectionCategory.ts
@@ -1,0 +1,24 @@
+import type { CollectionCategoryId } from "@superego/backend";
+import type { CollectionCategoryEntity } from "@superego/executing-backend";
+
+type TursoCollectionCategory = {
+  id: CollectionCategoryId;
+  name: string;
+  icon: string | null;
+  parent_id: CollectionCategoryId | null;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default TursoCollectionCategory;
+
+export function toEntity(
+  collectionCategory: TursoCollectionCategory,
+): CollectionCategoryEntity {
+  return {
+    id: collectionCategory.id,
+    name: collectionCategory.name,
+    icon: collectionCategory.icon,
+    parentId: collectionCategory.parent_id,
+    createdAt: new Date(collectionCategory.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoCollectionVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoCollectionVersion.ts
@@ -1,0 +1,34 @@
+import type { CollectionId, CollectionVersionId } from "@superego/backend";
+import type { CollectionVersionEntity } from "@superego/executing-backend";
+
+type TursoCollectionVersion = {
+  id: CollectionVersionId;
+  previous_version_id: CollectionVersionId | null;
+  collection_id: CollectionId;
+  /** JSON */
+  schema: string;
+  /** JSON */
+  settings: string;
+  /** JSON */
+  migration: string | null;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+};
+export default TursoCollectionVersion;
+
+export function toEntity(
+  collectionVersion: TursoCollectionVersion,
+): CollectionVersionEntity {
+  return {
+    id: collectionVersion.id,
+    previousVersionId: collectionVersion.previous_version_id,
+    collectionId: collectionVersion.collection_id,
+    schema: JSON.parse(collectionVersion.schema),
+    settings: JSON.parse(collectionVersion.settings),
+    migration: collectionVersion.migration
+      ? JSON.parse(collectionVersion.migration)
+      : null,
+    createdAt: new Date(collectionVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoConversation.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoConversation.ts
@@ -1,0 +1,41 @@
+import { decode } from "@msgpack/msgpack";
+import type {
+  AssistantName,
+  ConversationId,
+  ConversationStatus,
+  Message,
+} from "@superego/backend";
+import type { ConversationEntity } from "@superego/executing-backend";
+
+type TursoConversation = {
+  id: ConversationId;
+  assistant: AssistantName;
+  title: string | null;
+  context_fingerprint: string;
+  /** MessagePack */
+  messages: Uint8Array<ArrayBuffer>;
+  status: ConversationStatus;
+  /** ISO 8601 */
+  processing_started_at: string | null;
+  /** JSON */
+  error: string | null;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default TursoConversation;
+
+export function toEntity(conversation: TursoConversation): ConversationEntity {
+  return {
+    id: conversation.id,
+    assistant: conversation.assistant,
+    title: conversation.title,
+    contextFingerprint: conversation.context_fingerprint,
+    messages: decode(conversation.messages) as Message[],
+    status: conversation.status,
+    processingStartedAt: conversation.processing_started_at
+      ? new Date(conversation.processing_started_at)
+      : null,
+    error: conversation.error ? JSON.parse(conversation.error) : null,
+    createdAt: new Date(conversation.created_at),
+  } as ConversationEntity;
+}

--- a/packages/data/turso-data-repositories/src/types/TursoConversationTextSearchText.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoConversationTextSearchText.ts
@@ -1,0 +1,7 @@
+import type { ConversationId } from "@superego/backend";
+
+type TursoConversationTextSearchText = {
+  conversation_id: ConversationId;
+  text: string;
+};
+export default TursoConversationTextSearchText;

--- a/packages/data/turso-data-repositories/src/types/TursoDocument.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoDocument.ts
@@ -1,0 +1,18 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+import type { DocumentEntity } from "@superego/executing-backend";
+
+type TursoDocument = {
+  id: DocumentId;
+  collection_id: CollectionId;
+  /** ISO 8601 */
+  created_at: string;
+};
+export default TursoDocument;
+
+export function toEntity(document: TursoDocument): DocumentEntity {
+  return {
+    id: document.id,
+    collectionId: document.collection_id,
+    createdAt: new Date(document.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoDocumentTextSearchText.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoDocumentTextSearchText.ts
@@ -1,0 +1,8 @@
+import type { CollectionId, DocumentId } from "@superego/backend";
+
+type TursoDocumentTextSearchText = {
+  document_id: DocumentId;
+  collection_id: CollectionId;
+  text: string;
+};
+export default TursoDocumentTextSearchText;

--- a/packages/data/turso-data-repositories/src/types/TursoDocumentVersion.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoDocumentVersion.ts
@@ -1,0 +1,130 @@
+import type {
+  CollectionId,
+  CollectionVersionId,
+  ConversationId,
+  DocumentId,
+  DocumentVersion,
+  DocumentVersionCreator,
+  DocumentVersionId,
+} from "@superego/backend";
+import type {
+  DocumentVersionEntity,
+  MinimalDocumentVersionEntity,
+} from "@superego/executing-backend";
+import type { DiffPatcher } from "jsondiffpatch";
+
+type TursoDocumentVersion = {
+  id: DocumentVersionId;
+  previous_version_id: DocumentVersionId | null;
+  collection_id: CollectionId;
+  document_id: DocumentId;
+  collection_version_id: CollectionVersionId;
+  conversation_id: ConversationId | null;
+  /**
+   * JSON. It's a jsondiffpatch delta or `null` when there is no delta from the
+   * previous version.
+   */
+  content_delta: string | null;
+  /** JSON. Array of contentBlockingKeys. */
+  content_blocking_keys: string | null;
+  /** JSON. Content summary result. */
+  content_summary: string;
+  /** JSON. Array of DocumentRef objects. */
+  referenced_documents: string;
+  created_by: DocumentVersionCreator;
+  /** ISO 8601 */
+  created_at: string;
+  is_latest: 0 | 1;
+} & (
+  | {
+      is_latest: 0;
+      content_snapshot: null;
+    }
+  | {
+      is_latest: 1;
+      /** JSON */
+      content_snapshot: string;
+    }
+);
+export default TursoDocumentVersion;
+
+export function toEntity(
+  documentVersion: TursoDocumentVersion & { is_latest: 1 },
+): DocumentVersionEntity;
+export function toEntity(
+  documentVersion: TursoDocumentVersion & { is_latest: 0 },
+  allDocumentVersions: TursoDocumentVersion[],
+  jdp: DiffPatcher,
+): DocumentVersionEntity;
+export function toEntity(
+  documentVersion: TursoDocumentVersion,
+  allDocumentVersions?: TursoDocumentVersion[],
+  jdp?: DiffPatcher,
+): DocumentVersionEntity {
+  return {
+    id: documentVersion.id,
+    previousVersionId: documentVersion.previous_version_id,
+    collectionId: documentVersion.collection_id,
+    documentId: documentVersion.document_id,
+    collectionVersionId: documentVersion.collection_version_id,
+    conversationId: documentVersion.conversation_id,
+    content:
+      documentVersion.is_latest === 1
+        ? JSON.parse(documentVersion.content_snapshot)
+        : makeContent(documentVersion.id, allDocumentVersions!, jdp!),
+    contentBlockingKeys: documentVersion.content_blocking_keys
+      ? JSON.parse(documentVersion.content_blocking_keys)
+      : null,
+    contentSummary: JSON.parse(
+      documentVersion.content_summary,
+    ) as DocumentVersion["contentSummary"],
+    referencedDocuments: JSON.parse(documentVersion.referenced_documents),
+    createdBy: documentVersion.created_by,
+    createdAt: new Date(documentVersion.created_at),
+  } as DocumentVersionEntity;
+}
+
+/** Makes the specified DocumentVersion content by applying all deltas. */
+function makeContent(
+  id: DocumentVersionId,
+  allDocumentVersions: TursoDocumentVersion[],
+  jdp: DiffPatcher,
+): any {
+  const documentVersionsById: Record<DocumentVersionId, TursoDocumentVersion> =
+    {};
+  for (const documentVersion of allDocumentVersions) {
+    documentVersionsById[documentVersion.id] = documentVersion;
+  }
+
+  const deltas: any[] = [];
+  let currentDocumentVersion = documentVersionsById[id]!;
+  for (;;) {
+    if (currentDocumentVersion.content_delta !== null) {
+      deltas.push(JSON.parse(currentDocumentVersion.content_delta));
+    }
+    if (currentDocumentVersion.previous_version_id) {
+      currentDocumentVersion =
+        documentVersionsById[currentDocumentVersion.previous_version_id]!;
+    } else {
+      break;
+    }
+  }
+
+  return deltas.reduceRight((content, delta) => jdp.patch(content, delta), {});
+}
+
+export function toMinimalEntity(
+  documentVersion: TursoDocumentVersion,
+): MinimalDocumentVersionEntity {
+  return {
+    id: documentVersion.id,
+    previousVersionId: documentVersion.previous_version_id,
+    collectionId: documentVersion.collection_id,
+    documentId: documentVersion.document_id,
+    collectionVersionId: documentVersion.collection_version_id,
+    conversationId: documentVersion.conversation_id,
+    referencedDocuments: JSON.parse(documentVersion.referenced_documents),
+    createdBy: documentVersion.created_by,
+    createdAt: new Date(documentVersion.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoDocumentVersionBlockingKey.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoDocumentVersionBlockingKey.ts
@@ -1,0 +1,9 @@
+import type { CollectionId, DocumentVersionId } from "@superego/backend";
+
+type TursoDocumentVersionBlockingKey = {
+  id: number;
+  collection_id: CollectionId;
+  document_version_id: DocumentVersionId;
+  blocking_key: string;
+};
+export default TursoDocumentVersionBlockingKey;

--- a/packages/data/turso-data-repositories/src/types/TursoFile.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoFile.ts
@@ -1,0 +1,20 @@
+import type { FileId } from "@superego/backend";
+import type { FileEntity } from "@superego/executing-backend";
+
+type TursoFile = {
+  id: FileId;
+  /** JSON */
+  referenced_by: string;
+  /** ISO 8601 */
+  created_at: string;
+  content: Uint8Array<ArrayBuffer>;
+};
+export default TursoFile;
+
+export function toEntity(file: Omit<TursoFile, "content">): FileEntity {
+  return {
+    id: file.id,
+    referencedBy: JSON.parse(file.referenced_by),
+    createdAt: new Date(file.created_at),
+  };
+}

--- a/packages/data/turso-data-repositories/src/types/TursoGlobalSettings.ts
+++ b/packages/data/turso-data-repositories/src/types/TursoGlobalSettings.ts
@@ -1,0 +1,15 @@
+import type { GlobalSettings } from "@superego/backend";
+import type DeepPartial from "../utils/DeepPartial.js";
+
+type TursoGlobalSettings = {
+  id: "singleton";
+  /** JSON */
+  value: string;
+};
+export default TursoGlobalSettings;
+
+export function toEntity(
+  settings: TursoGlobalSettings,
+): DeepPartial<GlobalSettings> {
+  return JSON.parse(settings.value);
+}

--- a/packages/data/turso-data-repositories/src/utils/DeepPartial.ts
+++ b/packages/data/turso-data-repositories/src/utils/DeepPartial.ts
@@ -1,0 +1,4 @@
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+export default DeepPartial;

--- a/packages/data/turso-data-repositories/tsconfig.json
+++ b/packages/data/turso-data-repositories/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../../tsconfig.common.json"]
+}

--- a/packages/data/turso-data-repositories/vitest.config.ts
+++ b/packages/data/turso-data-repositories/vitest.config.ts
@@ -1,0 +1,21 @@
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  server: {
+    headers: {
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Opener-Policy": "same-origin",
+    },
+  },
+  test: {
+    testTimeout: 120_000,
+    browser: {
+      provider: playwright(),
+      enabled: true,
+      headless: true,
+      screenshotFailures: false,
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,13 +1698,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.11.2":
+"@emnapi/core@npm:1.11.2, @emnapi/core@npm:^1.5.0":
   version: 1.11.2
   resolution: "@emnapi/core@npm:1.11.2"
   dependencies:
     "@emnapi/wasi-threads": "npm:1.2.2"
     tslib: "npm:^2.4.0"
   checksum: 10c0/424ca1607f498e524eb58db1095e6cc2082986edfd84a74b116d4e2c6e43b5e9d557ea7f0d7b9adf7f6d5023e25ac2ed6bd08caf0043d3d8602598d79579c2cd
+  languageName: node
+  linkType: hard
+
+"@emnapi/core@npm:1.8.1":
+  version: 1.8.1
+  resolution: "@emnapi/core@npm:1.8.1"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.1.0"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
   languageName: node
   linkType: hard
 
@@ -1727,7 +1737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.11.2, @emnapi/runtime@npm:^1.11.1":
+"@emnapi/runtime@npm:1.11.2, @emnapi/runtime@npm:^1.11.1, @emnapi/runtime@npm:^1.5.0":
   version: 1.11.2
   resolution: "@emnapi/runtime@npm:1.11.2"
   dependencies:
@@ -1736,7 +1746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.0":
+"@emnapi/runtime@npm:1.8.1, @emnapi/runtime@npm:^1.7.0":
   version: 1.8.1
   resolution: "@emnapi/runtime@npm:1.8.1"
   dependencies:
@@ -1751,6 +1761,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/750edca117e0363ab2de10622f8ee60e57d8690c2f29c49704813da5cd627c641798d7f3cb0d953c62fdc71688e02e333ddbf2c1204f38b47e3e40657332a6f5
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@emnapi/wasi-threads@npm:1.1.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
   languageName: node
   linkType: hard
 
@@ -3677,6 +3696,17 @@ __metadata:
   version: 3.1.3
   resolution: "@msgpack/msgpack@npm:3.1.3"
   checksum: 10c0/1fa9a760a58e64e121561d17977b680198ff24d83e951df3896f8639d06824f2cba20af92a19940461e0d5d6dc696bd01222bd901164759432eadd0f482d0816
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@napi-rs/wasm-runtime@npm:1.0.7"
+  dependencies:
+    "@emnapi/core": "npm:^1.5.0"
+    "@emnapi/runtime": "npm:^1.5.0"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/2d8635498136abb49d6dbf7395b78c63422292240963bf055f307b77aeafbde57ae2c0ceaaef215601531b36d6eb92a2cdd6f5ba90ed2aa8127c27aff9c4ae55
   languageName: node
   linkType: hard
 
@@ -7039,6 +7069,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@superego/turso-data-repositories@workspace:packages/data/turso-data-repositories":
+  version: 0.0.0-use.local
+  resolution: "@superego/turso-data-repositories@workspace:packages/data/turso-data-repositories"
+  dependencies:
+    "@msgpack/msgpack": "npm:^3.1.3"
+    "@superego/backend": "workspace:*"
+    "@superego/executing-backend": "workspace:*"
+    "@superego/schema": "workspace:*"
+    "@tursodatabase/database-wasm": "npm:0.7.0"
+    "@vitest/browser": "npm:^4.1.10"
+    "@vitest/browser-playwright": "npm:^4.1.10"
+    es-toolkit: "npm:^1.49.0"
+    flexsearch: "npm:^0.8.212"
+    jsondiffpatch: "npm:^0.7.6"
+    playwright: "npm:^1.61.1"
+    typescript: "npm:^6.0.3"
+    vitest: "npm:^4.1.10"
+  languageName: unknown
+  linkType: soft
+
 "@superego/vitest-registered@workspace:*, @superego/vitest-registered@workspace:packages/misc/vitest-registered":
   version: 0.0.0-use.local
   resolution: "@superego/vitest-registered@workspace:packages/misc/vitest-registered"
@@ -8144,6 +8194,34 @@ __metadata:
     rbush: "npm:^3.0.1"
     tslib: "npm:^2.8.1"
   checksum: 10c0/9ef6bc23b07098ee3a95ce2f00e1066dfe91cf8cbfe0b5a84858c754ad43cdd10528200a9085ad87991688c1932c18627c27e643d94d74c6641ff78230239371
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-common@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@tursodatabase/database-common@npm:0.7.0"
+  checksum: 10c0/7af0b242baf98e269889c9a522e839ef293c4b13e3307972c44a614e6d86b46adf0389bc2bd461ce79575cd1b31e9e884f411aed14ea7a45fc79bc62d71c8d72
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-wasm-common@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@tursodatabase/database-wasm-common@npm:0.7.0"
+  dependencies:
+    "@emnapi/core": "npm:1.8.1"
+    "@emnapi/runtime": "npm:1.8.1"
+    "@napi-rs/wasm-runtime": "npm:1.0.7"
+  checksum: 10c0/64bf8783983227114f8ee7414510c509c5d0fad5d3b357de85c9d4f737ba5e08bb5819a7402e9c7112ad5d873c4e434b5b03ac6983da84bff868331bf8b8a50a
+  languageName: node
+  linkType: hard
+
+"@tursodatabase/database-wasm@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@tursodatabase/database-wasm@npm:0.7.0"
+  dependencies:
+    "@tursodatabase/database-common": "npm:^0.7.0"
+    "@tursodatabase/database-wasm-common": "npm:^0.7.0"
+  checksum: 10c0/80294824f217ff5acfb8de6b83e4acc6a4dd89423664454135d8223d3865af7a71ac52e428129876fd3ed9a29e1d72fa642d3932fe976a0ab886bd790d697b80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- add `@superego/turso-data-repositories`, modeled on the existing SQLite implementation
- use `@tursodatabase/database-wasm` 0.7.0 through its self-contained bundle and persist databases in OPFS
- port all repositories, migrations, text-search indexes, serializable transactions, and savepoints to Turso's asynchronous API
- add connection pooling and serialized WASM operations for reliable concurrent transactions
- provide logical OPFS database export and overwrite support because Turso's JavaScript backup/serialization APIs are not implemented yet
- run the data-repository conformance suite in Chromium and add export-specific coverage

## Why

This provides an additional embedded database implementation that can run in a browser or Electron renderer without native addon compilation or separate WASM/worker asset-copy steps.

## Validation

- `yarn test`
- `yarn check-types`
- `yarn check-linting`
- `yarn check-formatting`
- `yarn workspace @superego/turso-data-repositories test --run` — 158 tests passed