### PR TITLE
Add versioned app specifications

### DIFF
--- a/packages/apps/browser-app/src/business-logic/backend/hooks.ts
+++ b/packages/apps/browser-app/src/business-logic/backend/hooks.ts
@@ -297,6 +297,12 @@ export const useDeleteConversation = makeUseBackendMutation(
 
 export const useStt = makeUseBackendMutation("inference", "stt", () => []);
 
+export const useImplementApp = makeUseBackendMutation(
+  "inference",
+  "implementApp",
+  () => [],
+);
+
 export const useImplementTypescriptModule = makeUseBackendMutation(
   "inference",
   "implementTypescriptModule",

--- a/packages/apps/browser-app/src/components/routes/CreateApp/CreateAppForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/CreateApp/CreateAppForm.tsx
@@ -22,6 +22,7 @@ interface FormValues {
   name: string;
   appVersion: {
     targetCollectionIds: CollectionId[];
+    spec: string;
     files: RHFAppVersionFiles;
   };
 }
@@ -48,6 +49,7 @@ export default function CreateAppForm({
     defaultValues: {
       appVersion: {
         targetCollectionIds: initialTargetCollections.map(({ id }) => id),
+        spec: "",
         files: forms.defaults.collectionViewAppFiles(initialTargetCollections),
       },
     },
@@ -60,6 +62,7 @@ export default function CreateAppForm({
             v.array(valibotSchemas.id.collection()),
             v.minLength(1),
           ),
+          spec: v.string(),
           files: forms.schemas.rhfAppVersionFiles(intl),
         }),
       }),
@@ -71,6 +74,7 @@ export default function CreateAppForm({
       type: AppType.CollectionView,
       name,
       targetCollectionIds: appVersion.targetCollectionIds,
+      spec: appVersion.spec,
       files: RHFAppVersionFilesUtils.fromRhfAppVersionFiles(appVersion.files),
     });
     if (success) {

--- a/packages/apps/browser-app/src/components/routes/EditApp/CreateNewAppVersionForm.tsx
+++ b/packages/apps/browser-app/src/components/routes/EditApp/CreateNewAppVersionForm.tsx
@@ -20,6 +20,7 @@ import * as cs from "./EditApp.css.js";
 interface FormValues {
   appVersion: {
     targetCollectionIds: CollectionId[];
+    spec: string;
     files: RHFAppVersionFiles;
   };
 }
@@ -52,6 +53,7 @@ export default function CreateNewAppVersionForm({
     defaultValues: {
       appVersion: {
         targetCollectionIds: validTargetCollectionIds,
+        spec: app.latestVersion.spec,
         files: RHFAppVersionFilesUtils.toRhfAppVersionFiles(
           app.latestVersion.files,
         ),
@@ -65,6 +67,7 @@ export default function CreateNewAppVersionForm({
             v.array(valibotSchemas.id.collection()),
             v.minLength(1),
           ),
+          spec: v.string(),
           files: forms.schemas.rhfAppVersionFiles(intl),
         }),
       }),
@@ -76,6 +79,7 @@ export default function CreateNewAppVersionForm({
       app.id,
       appVersion.targetCollectionIds,
       RHFAppVersionFilesUtils.fromRhfAppVersionFiles(appVersion.files),
+      appVersion.spec,
     );
     if (success) {
       reset(
@@ -84,6 +88,7 @@ export default function CreateNewAppVersionForm({
             targetCollectionIds: data.latestVersion.targetCollections.map(
               ({ id }) => id,
             ),
+            spec: data.latestVersion.spec,
             files: RHFAppVersionFilesUtils.toRhfAppVersionFiles(
               data.latestVersion.files,
             ),

--- a/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/EagerRHFAppVersionField.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/EagerRHFAppVersionField.tsx
@@ -13,6 +13,7 @@ import toasts from "../../../business-logic/toasts/toasts.js";
 import ToastType from "../../../business-logic/toasts/ToastType.js";
 import CollectionUtils from "../../../utils/CollectionUtils.js";
 import useUndoRedo from "../CodeInput/common-hooks/useUndoRedo.js";
+import RHFMarkdownField from "../RHFMarkdownField/RHFMarkdownField.js";
 import RHFTypescriptModuleField from "../RHFTypescriptModuleField/RHFTypescriptModuleField.js";
 import UserMessageContentInput from "../UserMessageContentInput/UserMessageContentInput.js";
 import EditingToolbar from "./EditingToolbar.js";
@@ -35,6 +36,8 @@ export default function EagerRHFAppVersionField({
   const intl = useIntl();
 
   const [activeView, setActiveView] = useState(View.Preview);
+
+  const { field: specField } = useController({ control, name: `${name}.spec` });
 
   const filesFieldName = `${name}.files./main__DOT__tsx`;
   const { field: filesField } = useController({
@@ -59,6 +62,7 @@ export default function EagerRHFAppVersionField({
   const { isPending, mutate } = useSttAndImplement(
     targetCollections,
     mainTsx,
+    specField.value,
     typescriptLibs,
   );
 
@@ -74,7 +78,8 @@ export default function EagerRHFAppVersionField({
       inferenceOptions,
     );
     if (success) {
-      filesField.onChange(data);
+      filesField.onChange(data.files["/main.tsx"]);
+      specField.onChange(data.spec);
     } else {
       console.error(error);
       toasts.add({
@@ -98,9 +103,9 @@ export default function EagerRHFAppVersionField({
     <div className={cs.EagerRHFAppVersionField.root}>
       <EditingToolbar
         onUndo={undoRedo.undo}
-        isUndoDisabled={!undoRedo.canUndo}
+        isUndoDisabled={activeView === View.Spec || !undoRedo.canUndo}
         onRedo={undoRedo.redo}
-        isRedoDisabled={!undoRedo.canRedo}
+        isRedoDisabled={activeView === View.Spec || !undoRedo.canRedo}
         onActivateView={setActiveView}
         activeView={activeView}
         collections={collections}
@@ -126,6 +131,19 @@ export default function EagerRHFAppVersionField({
             ]
           }
         />
+        <div hidden={activeView !== View.Spec}>
+          <RHFMarkdownField
+            control={control}
+            name={`${name}.spec`}
+            label={intl.formatMessage({ defaultMessage: "App specification" })}
+            description={intl.formatMessage({
+              defaultMessage:
+                "Describe the app’s requirements, expected behavior, constraints, and rationale.",
+            })}
+            isReadOnly={isPending}
+            showToolbar={true}
+          />
+        </div>
         <RHFTypescriptModuleField
           control={control}
           name={filesFieldName}

--- a/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/EditingToolbar.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/EditingToolbar.tsx
@@ -5,6 +5,7 @@ import {
   PiArrowUDownLeft,
   PiArrowUDownRight,
   PiCode,
+  PiFileText,
   PiPresentationChart,
 } from "react-icons/pi";
 import { useIntl } from "react-intl";
@@ -97,6 +98,16 @@ export default function EditingToolbar({
         />
         <SelectOptions options={collectionOptions} />
       </Select>
+      <IconButton
+        variant="invisible"
+        label={intl.formatMessage({ defaultMessage: "App specification" })}
+        onPress={() =>
+          onActivateView(activeView === View.Spec ? View.Preview : View.Spec)
+        }
+        className={cs.EditingToolbar.button}
+      >
+        <PiFileText />
+      </IconButton>
       <IconButton
         variant="invisible"
         label={

--- a/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/Preview.tsx
+++ b/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/Preview.tsx
@@ -60,6 +60,7 @@ function getApp(
         type: AppType.CollectionView,
         name: "New App Preview",
         latestVersion: {
+          spec: "",
           id: Id.generate.appVersion(),
           targetCollections: targetCollections.map((collection) => ({
             id: collection.id,

--- a/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/View.ts
+++ b/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/View.ts
@@ -1,5 +1,6 @@
 enum View {
   Preview = "Preview",
   Code = "Code",
+  Spec = "Spec",
 }
 export default View;

--- a/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/useSttAndImplement.ts
+++ b/packages/apps/browser-app/src/components/widgets/RHFAppVersionField/useSttAndImplement.ts
@@ -1,5 +1,6 @@
 import {
   type ArgumentsNotValid,
+  type AppVersion,
   type Collection,
   type InferenceOptions,
   type InferenceOptionsNotValid,
@@ -15,7 +16,7 @@ import {
 import type { ResultPromise } from "@superego/global-types";
 import { assertInferenceOptionsHas } from "@superego/shared-utils";
 import {
-  useImplementTypescriptModule,
+  useImplementApp,
   useStt,
 } from "../../../business-logic/backend/hooks.js";
 import forms from "../../../business-logic/forms/forms.js";
@@ -28,7 +29,7 @@ interface UseSttAndImplement {
     >,
     inferenceOptions: InferenceOptions<"completion">,
   ) => ResultPromise<
-    TypescriptModule,
+    Pick<AppVersion, "files" | "spec">,
     | ArgumentsNotValid
     | InferenceOptionsNotValid
     | WriteTypescriptModuleToolNotCalled
@@ -39,15 +40,14 @@ interface UseSttAndImplement {
 export default function useSttAndImplement(
   targetCollections: Collection[],
   mainTsx: TypescriptModule,
+  spec: string,
   typescriptLibs: TypescriptFile[],
 ): UseSttAndImplement {
   const { isPending: isSttPending, mutate: stt } = useStt();
-  const {
-    isPending: isImplementTypescriptModulePending,
-    mutate: implementTypescriptModule,
-  } = useImplementTypescriptModule();
+  const { isPending: isImplementAppPending, mutate: implementApp } =
+    useImplementApp();
 
-  const isPending = isSttPending || isImplementTypescriptModulePending;
+  const isPending = isSttPending || isImplementAppPending;
 
   const mutate = async (
     messageContent: NonEmptyArray<
@@ -55,7 +55,7 @@ export default function useSttAndImplement(
     >,
     inferenceOptions: InferenceOptions<"completion">,
   ): ResultPromise<
-    TypescriptModule,
+    Pick<AppVersion, "files" | "spec">,
     | ArgumentsNotValid
     | InferenceOptionsNotValid
     | WriteTypescriptModuleToolNotCalled
@@ -91,8 +91,9 @@ export default function useSttAndImplement(
       })
       .join("\n");
 
-    return implementTypescriptModule(
+    return implementApp(
       {
+        spec,
         description: `
 This module implements and default-exports a single-file React app for
 visualizing the documents in the following collections:

--- a/packages/apps/browser-app/src/translations/compiled/en.json
+++ b/packages/apps/browser-app/src/translations/compiled/en.json
@@ -1380,10 +1380,22 @@
       "value": "What do you want to build?"
     }
   ],
+  "EagerRHFAppVersionField.tsx_N8wZn2": [
+    {
+      "type": 0,
+      "value": "Describe the app’s requirements, expected behavior, constraints, and rationale."
+    }
+  ],
   "EagerRHFAppVersionField.tsx_Yhz0gl": [
     {
       "type": 0,
       "value": "An error occurred generating the app"
+    }
+  ],
+  "EagerRHFAppVersionField.tsx_i+LJdj": [
+    {
+      "type": 0,
+      "value": "App specification"
     }
   ],
   "EagerTiptapInput.tsx_0he+1r": [
@@ -1452,6 +1464,12 @@
     {
       "type": 0,
       "value": "Undo"
+    }
+  ],
+  "EditingToolbar.tsx_i+LJdj": [
+    {
+      "type": 0,
+      "value": "App specification"
     }
   ],
   "EditingToolbar.tsx_ou7tYh": [

--- a/packages/apps/browser-app/src/translations/compiled/it.json
+++ b/packages/apps/browser-app/src/translations/compiled/it.json
@@ -1372,10 +1372,22 @@
       "value": "Cosa vuoi creare?"
     }
   ],
+  "EagerRHFAppVersionField.tsx_N8wZn2": [
+    {
+      "type": 0,
+      "value": "Descrivi i requisiti dell’app, il comportamento atteso, i vincoli e le motivazioni."
+    }
+  ],
   "EagerRHFAppVersionField.tsx_Yhz0gl": [
     {
       "type": 0,
       "value": "Si è verificato un errore durante la generazione dell'app"
+    }
+  ],
+  "EagerRHFAppVersionField.tsx_i+LJdj": [
+    {
+      "type": 0,
+      "value": "Specifica dell’app"
     }
   ],
   "EagerTiptapInput.tsx_0he+1r": [
@@ -1444,6 +1456,12 @@
     {
       "type": 0,
       "value": "Annulla"
+    }
+  ],
+  "EditingToolbar.tsx_i+LJdj": [
+    {
+      "type": 0,
+      "value": "Specifica dell’app"
     }
   ],
   "EditingToolbar.tsx_ou7tYh": [

--- a/packages/apps/browser-app/src/translations/en.json
+++ b/packages/apps/browser-app/src/translations/en.json
@@ -560,8 +560,14 @@
   "EagerRHFAppVersionField.tsx_4rTNK7": {
     "defaultMessage": "What do you want to build?"
   },
+  "EagerRHFAppVersionField.tsx_N8wZn2": {
+    "defaultMessage": "Describe the app’s requirements, expected behavior, constraints, and rationale."
+  },
   "EagerRHFAppVersionField.tsx_Yhz0gl": {
     "defaultMessage": "An error occurred generating the app"
+  },
+  "EagerRHFAppVersionField.tsx_i+LJdj": {
+    "defaultMessage": "App specification"
   },
   "EagerTiptapInput.tsx_0he+1r": {
     "defaultMessage": "Write..."
@@ -592,6 +598,9 @@
   },
   "EditingToolbar.tsx_JkS37H": {
     "defaultMessage": "Undo"
+  },
+  "EditingToolbar.tsx_i+LJdj": {
+    "defaultMessage": "App specification"
   },
   "EditingToolbar.tsx_ou7tYh": {
     "defaultMessage": "Target collections"

--- a/packages/apps/browser-app/src/translations/it.json
+++ b/packages/apps/browser-app/src/translations/it.json
@@ -566,6 +566,12 @@
   "EagerRHFAppVersionField.tsx_4rTNK7": {
     "defaultMessage": "Cosa vuoi creare?"
   },
+  "EagerRHFAppVersionField.tsx_N8wZn2": {
+    "defaultMessage": "Descrivi i requisiti dell’app, il comportamento atteso, i vincoli e le motivazioni."
+  },
+  "EagerRHFAppVersionField.tsx_i+LJdj": {
+    "defaultMessage": "Specifica dell’app"
+  },
   "EagerRHFAppVersionField.tsx_Yhz0gl": {
     "defaultMessage": "Si è verificato un errore durante la generazione dell'app"
   },
@@ -598,6 +604,9 @@
   },
   "EditingToolbar.tsx_JkS37H": {
     "defaultMessage": "Annulla"
+  },
+  "EditingToolbar.tsx_i+LJdj": {
+    "defaultMessage": "Specifica dell’app"
   },
   "EditingToolbar.tsx_ou7tYh": {
     "defaultMessage": "Collezioni di destinazione"

--- a/packages/apps/cli/src/commands/apps/checkout/checkout.ts
+++ b/packages/apps/cli/src/commands/apps/checkout/checkout.ts
@@ -54,6 +54,7 @@ export default useMarkdownHelp(
         app.latestVersion.files["/main.tsx"].source,
         targetCollections,
         buildLock(app),
+        app.latestVersion.spec,
       );
       return { path: projectPath, appId: app.id };
     });

--- a/packages/apps/cli/src/commands/apps/commit/createApp.ts
+++ b/packages/apps/cli/src/commands/apps/commit/createApp.ts
@@ -1,6 +1,7 @@
 import { resolveLatestTargetCollections } from "../common/commandUtils.js";
 import { compileApp } from "../common/compile.js";
 import { buildLock, writeLock } from "../common/lock.js";
+import { readSpec } from "../common/spec.js";
 import type { CommitContext, CommitResult } from "./types.js";
 
 export default async function createApp({
@@ -17,6 +18,7 @@ export default async function createApp({
     type: manifest.type,
     name: manifest.name,
     targetCollectionIds: manifest.targetCollectionIds,
+    spec: readSpec(path),
     files: { "/main.tsx": mainModule },
   });
   if (!result.success) {

--- a/packages/apps/cli/src/commands/apps/commit/createAppVersion.ts
+++ b/packages/apps/cli/src/commands/apps/commit/createAppVersion.ts
@@ -7,16 +7,19 @@ export default async function createAppVersion({
   app,
   manifest,
   mainModule,
+  spec,
 }: {
   backend: CliBackend;
   app: App;
   manifest: AppManifest;
   mainModule: TypescriptModule;
+  spec: string;
 }): Promise<App> {
   const result = await backend.apps.createNewVersion(
     app.id,
     manifest.targetCollectionIds,
     { "/main.tsx": mainModule },
+    spec,
   );
   if (!result.success) {
     throw new Error(JSON.stringify(result.error));

--- a/packages/apps/cli/src/commands/apps/commit/getAppChanges.test.ts
+++ b/packages/apps/cli/src/commands/apps/commit/getAppChanges.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type App, AppType } from "@superego/backend";
+import { Id } from "@superego/shared-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliBackend } from "../common/commandUtils.js";
+import { compileApp } from "../common/compile.js";
+import getAppChanges from "./getAppChanges.js";
+
+vi.mock("../common/compile.js", () => ({ compileApp: vi.fn() }));
+
+describe("getAppChanges", () => {
+  let path: string;
+  beforeEach(() => {
+    path = mkdtempSync(join(tmpdir(), "superego-app-changes-"));
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    rmSync(path, { recursive: true, force: true });
+  });
+
+  it.each([undefined, "", "# New intent"])(
+    "detects spec changes without compiling unchanged source: %s",
+    async (spec) => {
+      // Setup SUT
+      const app: App = {
+        id: Id.generate.app(),
+        type: AppType.CollectionView,
+        name: "App",
+        createdAt: new Date(),
+        latestVersion: {
+          id: Id.generate.appVersion(),
+          createdAt: new Date(),
+          targetCollections: [],
+          spec: "# Existing intent",
+          files: {
+            "/main.tsx": {
+              source: "export default 1;",
+              compiled: "export default 1;",
+            },
+          },
+        },
+      };
+      writeFileSync(
+        join(path, "main.tsx"),
+        app.latestVersion.files["/main.tsx"].source,
+      );
+      if (spec !== undefined) {
+        writeFileSync(join(path, "spec.md"), spec);
+      }
+
+      // Exercise
+      const changes = await getAppChanges({
+        backend: {} as CliBackend,
+        path,
+        app,
+        manifest: { name: app.name, type: app.type, targetCollectionIds: [] },
+      });
+
+      // Verify
+      expect(changes).toEqual({
+        spec: spec ?? app.latestVersion.spec,
+        specChanged: spec !== undefined,
+        sourceChanged: false,
+        targetCollectionsChanged: false,
+        mainModule: null,
+      });
+      expect(compileApp).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/apps/cli/src/commands/apps/commit/getAppChanges.ts
+++ b/packages/apps/cli/src/commands/apps/commit/getAppChanges.ts
@@ -6,6 +6,7 @@ import {
 } from "../common/commandUtils.js";
 import { compileApp } from "../common/compile.js";
 import { readMainSource } from "../common/mainSource.js";
+import { readSpec } from "../common/spec.js";
 import type { AppManifest } from "../common/types.js";
 import getTargetCollectionIds from "./getTargetCollectionIds.js";
 import type { AppChanges } from "./types.js";
@@ -22,6 +23,8 @@ export default async function getAppChanges({
   app: App;
 }): Promise<AppChanges> {
   const targetCollectionIds = getTargetCollectionIds(app);
+  const spec = readSpec(path, app.latestVersion.spec);
+  const specChanged = spec !== app.latestVersion.spec;
   const source = readMainSource(path);
   const sourceChanged = source !== app.latestVersion.files["/main.tsx"].source;
   const targetCollectionsChanged = !sameArray(
@@ -39,5 +42,11 @@ export default async function getAppChanges({
         )
       : null;
 
-  return { sourceChanged, targetCollectionsChanged, mainModule };
+  return {
+    sourceChanged,
+    targetCollectionsChanged,
+    mainModule,
+    spec,
+    specChanged,
+  };
 }

--- a/packages/apps/cli/src/commands/apps/commit/types.ts
+++ b/packages/apps/cli/src/commands/apps/commit/types.ts
@@ -13,6 +13,8 @@ export interface ExistingAppCommitContext extends CommitContext {
 }
 
 export interface AppChanges {
+  spec: string;
+  specChanged: boolean;
   sourceChanged: boolean;
   targetCollectionsChanged: boolean;
   mainModule: TypescriptModule | null;

--- a/packages/apps/cli/src/commands/apps/commit/updateApp.ts
+++ b/packages/apps/cli/src/commands/apps/commit/updateApp.ts
@@ -23,12 +23,17 @@ export default async function updateApp({
     operations.push("updated name");
   }
 
-  if (changes.sourceChanged || changes.targetCollectionsChanged) {
+  if (
+    changes.sourceChanged ||
+    changes.targetCollectionsChanged ||
+    changes.specChanged
+  ) {
     app = await createAppVersion({
       backend,
       app,
       manifest,
-      mainModule: changes.mainModule!,
+      mainModule: changes.mainModule ?? app.latestVersion.files["/main.tsx"],
+      spec: changes.spec,
     });
     operations.push("created new version");
   }

--- a/packages/apps/cli/src/commands/apps/common/agent-files/AGENTS.md
+++ b/packages/apps/cli/src/commands/apps/common/agent-files/AGENTS.md
@@ -4,6 +4,8 @@ Durable files:
 
 - `app.json`: editable app manifest.
 - `main.tsx`: app source committed to Superego.
+- `spec.md`: current Markdown specification, committed with the app
+  implementation.
 
 Generated files:
 
@@ -12,6 +14,11 @@ Generated files:
 
 Rules:
 
+- Read `spec.md` before editing. Initialize it from the user request for a new
+  app.
+- Update `spec.md` when requirements, behavior, constraints, or rationale
+  change. Preserve still-relevant requirements; keep a current specification,
+  not a changelog.
 - Do not edit generated files directly.
 - Use `superego apps check` before committing.
 - Use `superego apps commit` to write durable changes to Superego.

--- a/packages/apps/cli/src/commands/apps/common/agent-files/writing-superego-apps.md
+++ b/packages/apps/cli/src/commands/apps/common/agent-files/writing-superego-apps.md
@@ -63,3 +63,15 @@ Recovering stale checkouts:
   elsewhere.
 - Reapply the local edits to the refreshed checkout, run `superego apps check`,
   then `superego apps commit`.
+
+## App specifications
+
+App projects include `spec.md`, the current Markdown description of the app's
+requirements, expected behavior, constraints, and rationale. Read it before
+editing and update it alongside behavior changes. For a new app, initialize it
+from the user's request. Keep it as a current specification, not a changelog.
+
+`superego apps checkout` retrieves the stored spec. `apps status` and
+`apps diff` include spec changes, and `apps commit` saves them even when code is
+unchanged. An absent `spec.md` in an older checkout preserves the stored spec;
+an empty file clears it. Specs are versioned together with the implementation.

--- a/packages/apps/cli/src/commands/apps/common/spec.test.ts
+++ b/packages/apps/cli/src/commands/apps/common/spec.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readSpec } from "./spec.js";
+
+describe("readSpec", () => {
+  let path: string;
+  beforeEach(() => {
+    path = mkdtempSync(join(tmpdir(), "superego-spec-"));
+  });
+  afterEach(() => {
+    rmSync(path, { recursive: true, force: true });
+  });
+
+  it("defaults new projects to an empty specification", () => {
+    // Exercise
+    const spec = readSpec(path);
+    // Verify
+    expect(spec).toBe("");
+  });
+  it("preserves the stored specification for legacy checkouts", () => {
+    // Exercise
+    const spec = readSpec(path, "# Existing intent");
+    // Verify
+    expect(spec).toBe("# Existing intent");
+  });
+  it.each(["", "# Intent\n\n- Preserve **Markdown** and caffè.\n"])(
+    "reads an explicit specification verbatim: %s",
+    (content) => {
+      // Setup SUT
+      writeFileSync(join(path, "spec.md"), content);
+      // Exercise
+      const spec = readSpec(path, "# Existing intent");
+      // Verify
+      expect(spec).toBe(content);
+    },
+  );
+  it("does not hide read errors as a missing specification", () => {
+    // Setup SUT
+    mkdirSync(join(path, "spec.md"));
+    // Exercise
+    const read = () => readSpec(path, "# Existing intent");
+    // Verify
+    expect(read).toThrow();
+  });
+});

--- a/packages/apps/cli/src/commands/apps/common/spec.ts
+++ b/packages/apps/cli/src/commands/apps/common/spec.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Missing files in older checkouts preserve the stored specification. */
+export function readSpec(path: string, previousSpec = ""): string {
+  try {
+    return readFileSync(join(path, "spec.md"), "utf-8");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return previousSpec;
+    }
+    throw error;
+  }
+}

--- a/packages/apps/cli/src/commands/apps/common/writeAppProject.ts
+++ b/packages/apps/cli/src/commands/apps/common/writeAppProject.ts
@@ -10,6 +10,7 @@ export default async function writeAppProject(
   mainSource: string,
   targetCollections: TargetCollection[],
   lock: AppLock | null,
+  spec: string,
 ): Promise<void> {
   await mkdir(path, { recursive: true });
   await writeJson(join(path, "app.json"), manifest);
@@ -17,5 +18,6 @@ export default async function writeAppProject(
     await writeJson(join(path, "app.lock.json"), lock);
   }
   await writeFile(join(path, "main.tsx"), mainSource, "utf-8");
+  await writeFile(join(path, "spec.md"), spec, "utf-8");
   await regenerateGeneratedFiles(path, targetCollections);
 }

--- a/packages/apps/cli/src/commands/apps/diff/diff.ts
+++ b/packages/apps/cli/src/commands/apps/diff/diff.ts
@@ -5,6 +5,7 @@ import { getLockedApp, runAppCommand } from "../common/commandUtils.js";
 import { readLock } from "../common/lock.js";
 import { readMainSource } from "../common/mainSource.js";
 import { readManifest } from "../common/manifest.js";
+import { readSpec } from "../common/spec.js";
 import getStatus from "./getStatus.js";
 import makeArrayFieldDiff from "./makeArrayFieldDiff.js";
 import makeFieldDiff from "./makeFieldDiff.js";
@@ -39,12 +40,15 @@ export default useMarkdownHelp(
           manifest.targetCollectionIds,
           remoteManifest.targetCollectionIds,
         );
+        const spec = readSpec(path, app.latestVersion.spec);
+        const specChanged = spec !== app.latestVersion.spec;
         const sourceChanged = source !== remoteSource;
         const stale = lock.latestAppVersionId !== app.latestVersion.id;
         const status = getStatus({
           metadataChanged:
             name.changed || type.changed || targetCollectionIds.changed,
           sourceChanged,
+          specChanged,
           stale,
         });
 
@@ -58,6 +62,17 @@ export default useMarkdownHelp(
             name,
             type,
             targetCollectionIds,
+          },
+          spec: {
+            changed: specChanged,
+            diff: specChanged
+              ? makeUnifiedDiff(
+                  "remote/spec.md",
+                  app.latestVersion.spec,
+                  "local/spec.md",
+                  spec,
+                )
+              : null,
           },
           source: {
             changed: sourceChanged,

--- a/packages/apps/cli/src/commands/apps/diff/getStatus.ts
+++ b/packages/apps/cli/src/commands/apps/diff/getStatus.ts
@@ -1,10 +1,12 @@
 export default function getStatus({
   metadataChanged,
   sourceChanged,
+  specChanged,
   stale,
 }: {
   metadataChanged: boolean;
   sourceChanged: boolean;
+  specChanged: boolean;
   stale: boolean;
 }): string[] {
   const status: string[] = [];
@@ -13,6 +15,9 @@ export default function getStatus({
   }
   if (sourceChanged) {
     status.push("source changed");
+  }
+  if (specChanged) {
+    status.push("spec changed");
   }
   if (stale) {
     status.push("checkout stale");

--- a/packages/apps/cli/src/commands/apps/init/init.ts
+++ b/packages/apps/cli/src/commands/apps/init/init.ts
@@ -46,6 +46,7 @@ export default useMarkdownHelp(
         getInitialMainSource(targetCollections),
         targetCollections,
         null,
+        "",
       );
       return {
         path: projectPath,

--- a/packages/apps/cli/src/commands/apps/status/status.ts
+++ b/packages/apps/cli/src/commands/apps/status/status.ts
@@ -9,6 +9,7 @@ import {
 import { readLock } from "../common/lock.js";
 import { readMainSource } from "../common/mainSource.js";
 import { readManifest } from "../common/manifest.js";
+import { readSpec } from "../common/spec.js";
 
 export default useMarkdownHelp(
   new Command("status")
@@ -25,6 +26,9 @@ export default useMarkdownHelp(
         const backend = await createBackend();
         const app = await getLockedApp(backend, lock.appId);
         const status: string[] = [];
+        if (readSpec(path, app.latestVersion.spec) !== app.latestVersion.spec) {
+          status.push("spec changed");
+        }
         if (
           manifest.name !== app.name ||
           !sameArray(

--- a/packages/apps/electron-app/src/ipc-proxies/BackendIPCProxyClient.ts
+++ b/packages/apps/electron-app/src/ipc-proxies/BackendIPCProxyClient.ts
@@ -89,6 +89,7 @@ export default class BackendIPCProxyClient implements Backend {
 
     this.inference = {
       stt: this.makeMainIpcCall("inference.stt"),
+      implementApp: this.makeMainIpcCall("inference.implementApp"),
       implementTypescriptModule: this.makeMainIpcCall(
         "inference.implementTypescriptModule",
       ),

--- a/packages/apps/website/src/content/docs/getting-started/cli.md
+++ b/packages/apps/website/src/content/docs/getting-started/cli.md
@@ -22,3 +22,15 @@ superego agents install-skill --agent claude
 
 You can then ask your agent to do almost everything Superego allows you to do
 (you can run `superego --help` to see all available commands).
+
+## App specifications
+
+App projects include `spec.md`, the current Markdown description of the app's
+requirements, expected behavior, constraints, and rationale. Read it before
+editing and update it alongside behavior changes. For a new app, initialize it
+from the user's request. Keep it as a current specification, not a changelog.
+
+`superego apps checkout` retrieves the stored spec. `apps status` and
+`apps diff` include spec changes, and `apps commit` saves them even when code is
+unchanged. An absent `spec.md` in an older checkout preserves the stored spec;
+an empty file clears it. Specs are versioned together with the implementation.

--- a/packages/core/backend/src/Backend.ts
+++ b/packages/core/backend/src/Backend.ts
@@ -519,6 +519,20 @@ export default interface Backend {
   };
 
   inference: {
+    implementApp(
+      request: Parameters<
+        Backend["inference"]["implementTypescriptModule"]
+      >[0] & { spec: string },
+      inferenceOptions: InferenceOptions<"completion">,
+    ): ResultPromise<
+      { files: AppVersion["files"]; spec: string },
+      | InferenceOptionsNotValid
+      | WriteTypescriptModuleToolNotCalled
+      | TooManyFailedImplementationAttempts
+      | ArgumentsNotValid
+      | UnexpectedError
+    >;
+
     stt(
       audio: AudioContent,
       inferenceOptions: InferenceOptions<"transcription">,
@@ -568,6 +582,8 @@ export default interface Backend {
       id: AppId,
       targetCollectionIds: CollectionId[],
       files: AppVersion["files"],
+      /** Omit to preserve the previous spec; pass an empty string to clear it. */
+      spec?: string,
     ): ResultPromise<
       App,
       AppNotFound | CollectionNotFound | ArgumentsNotValid | UnexpectedError

--- a/packages/core/backend/src/types/AppDefinition.ts
+++ b/packages/core/backend/src/types/AppDefinition.ts
@@ -11,5 +11,7 @@ export default interface AppDefinition<
   targetCollectionIds: (AllowProtoCollectionIds extends true
     ? ProtoCollectionId | CollectionId
     : CollectionId)[];
+  /** Defaults to an empty specification when omitted. */
+  spec?: string;
   files: AppVersion["files"];
 }

--- a/packages/core/backend/src/types/AppVersion.ts
+++ b/packages/core/backend/src/types/AppVersion.ts
@@ -9,6 +9,8 @@ export default interface AppVersion {
     id: CollectionId;
     versionId: CollectionVersionId;
   }[];
+  /** Current Markdown specification, versioned with the implementation. */
+  spec: string;
   files: {
     "/main.tsx": TypescriptModule;
   };

--- a/packages/core/backend/src/types/ToolCall.ts
+++ b/packages/core/backend/src/types/ToolCall.ts
@@ -109,6 +109,7 @@ namespace ToolCall {
     ToolName.WriteTypescriptModule,
     {
       source: string;
+      spec?: string;
     }
   >;
 }

--- a/packages/core/executing-backend/src/ExecutingBackend.ts
+++ b/packages/core/executing-backend/src/ExecutingBackend.ts
@@ -61,6 +61,7 @@ import DocumentsSearch from "./usecases/documents/Search.js";
 import FilesGetContent from "./usecases/files/GetContent.js";
 import GlobalSettingsGet from "./usecases/global-settings/Get.js";
 import GlobalSettingsUpdate from "./usecases/global-settings/Update.js";
+import InferenceImplementApp from "./usecases/inference/ImplementApp.js";
 import InferenceImplementTypescriptModule from "./usecases/inference/ImplementTypescriptModule.js";
 import InferenceStt from "./usecases/inference/Stt.js";
 import PacksInstall from "./usecases/packs/Install.js";
@@ -172,6 +173,7 @@ export default class ExecutingBackend implements Backend {
     };
 
     this.inference = {
+      implementApp: this.makeUsecase(InferenceImplementApp, false),
       stt: this.makeUsecase(InferenceStt, false),
       implementTypescriptModule: this.makeUsecase(
         InferenceImplementTypescriptModule,

--- a/packages/core/executing-backend/src/entities/AppVersionEntity.ts
+++ b/packages/core/executing-backend/src/entities/AppVersionEntity.ts
@@ -5,6 +5,8 @@ export default interface AppVersionEntity {
   previousVersionId: AppVersionId | null;
   appId: AppId;
   targetCollections: AppVersion["targetCollections"];
+  /** Current Markdown specification, versioned with the implementation. */
+  spec: string;
   files: AppVersion["files"];
   createdAt: Date;
 }

--- a/packages/core/executing-backend/src/makers/makeAppVersion.ts
+++ b/packages/core/executing-backend/src/makers/makeAppVersion.ts
@@ -7,6 +7,7 @@ export default function makeAppVersion(
   return {
     id: appVersion.id,
     targetCollections: appVersion.targetCollections,
+    spec: appVersion.spec,
     files: appVersion.files,
     createdAt: appVersion.createdAt,
   };

--- a/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/app-versions.ts
+++ b/packages/core/executing-backend/src/requirements/data-repositories-tests/suites/app-versions.ts
@@ -19,7 +19,10 @@ const targetCollections: AppVersionEntity["targetCollections"] = [
 ];
 
 export default rd<GetDependencies>("App versions", (deps) => {
-  it("inserting", async () => {
+  it.each([
+    "",
+    "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
+  ])("inserting spec %s", async (spec) => {
     // Setup SUT
     const { dataRepositoriesManager } = deps();
 
@@ -29,6 +32,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
       previousVersionId: null,
       appId: Id.generate.app(),
       targetCollections: targetCollections,
+      spec,
       files: appVersionFiles,
       createdAt: new Date(),
     };
@@ -61,6 +65,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
         previousVersionId: null,
         appId,
         targetCollections: targetCollections,
+        spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
         files: appVersionFiles,
         createdAt: new Date(),
       };
@@ -69,6 +74,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
         previousVersionId: appVersion1.id,
         appId,
         targetCollections: targetCollections,
+        spec: "# Revised specification",
         files: appVersionFiles,
         createdAt: new Date(appVersion1.createdAt.getTime() + 1),
       };
@@ -121,6 +127,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
       previousVersionId: null,
       appId: app1Id,
       targetCollections: targetCollections,
+      spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
       files: appVersionFiles,
       createdAt: new Date(),
     };
@@ -129,6 +136,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
       previousVersionId: appVersion1.id,
       appId: app1Id,
       targetCollections: targetCollections,
+      spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
       files: appVersionFiles,
       createdAt: new Date(),
     };
@@ -137,6 +145,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
       previousVersionId: null,
       appId: app2Id,
       targetCollections: targetCollections,
+      spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
       files: appVersionFiles,
       createdAt: new Date(),
     };
@@ -196,6 +205,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
         previousVersionId: null,
         appId: app1Id,
         targetCollections: targetCollections,
+        spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
         files: appVersionFiles,
         createdAt: new Date(),
       };
@@ -204,6 +214,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
         previousVersionId: appVersion1.id,
         appId: app1Id,
         targetCollections: targetCollections,
+        spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
         files: appVersionFiles,
         createdAt: new Date(),
       };
@@ -212,6 +223,7 @@ export default rd<GetDependencies>("App versions", (deps) => {
         previousVersionId: null,
         appId: app2Id,
         targetCollections: targetCollections,
+        spec: "# App specification\n\nPreserve **Markdown** and Unicode: caffè.",
         files: appVersionFiles,
         createdAt: new Date(),
       };

--- a/packages/core/executing-backend/src/structural-schemas/backend/types/app.ts
+++ b/packages/core/executing-backend/src/structural-schemas/backend/types/app.ts
@@ -23,6 +23,7 @@ export function appVersion(): v.GenericSchema<unknown, AppVersion> {
         versionId: collectionVersionId(),
       }),
     ),
+    spec: v.string(),
     files: v.strictObject({
       "/main.tsx": typescriptModule(),
     }),
@@ -48,6 +49,7 @@ export function appDefinition(): v.GenericSchema<
     type: v.picklist(Object.values(AppType)),
     name: v.string(),
     targetCollectionIds: v.array(collectionId()),
+    spec: v.optional(v.string(), ""),
     files: v.strictObject({
       "/main.tsx": typescriptModule(),
     }),
@@ -64,6 +66,7 @@ export function protoAppDefinition(): v.GenericSchema<
     targetCollectionIds: v.array(
       v.union([protoCollectionId(), collectionId()]),
     ),
+    spec: v.optional(v.string(), ""),
     files: v.strictObject({
       "/main.tsx": typescriptModule(),
     }),

--- a/packages/core/executing-backend/src/usecases/apps/Create.ts
+++ b/packages/core/executing-backend/src/usecases/apps/Create.ts
@@ -42,7 +42,7 @@ export default class AppsCreate extends BackendUsecase<
   );
 
   async exec(
-    { type, name, targetCollectionIds, files }: AppDefinition,
+    { type, name, targetCollectionIds, files, spec = "" }: AppDefinition,
     options: AppsCreateOptions = {},
   ): ResultPromise<
     App,
@@ -90,6 +90,7 @@ export default class AppsCreate extends BackendUsecase<
       previousVersionId: null,
       appId: app.id,
       targetCollections: targetCollections,
+      spec,
       files: files,
       createdAt: now,
     };

--- a/packages/core/executing-backend/src/usecases/apps/CreateNewVersion.ts
+++ b/packages/core/executing-backend/src/usecases/apps/CreateNewVersion.ts
@@ -13,6 +13,7 @@ import {
   makeSuccessfulResult,
   makeUnsuccessfulResult,
 } from "@superego/shared-utils";
+import { isEqual } from "es-toolkit";
 import * as v from "valibot";
 import type AppVersionEntity from "../../entities/AppVersionEntity.js";
 import makeApp from "../../makers/makeApp.js";
@@ -31,6 +32,7 @@ export default class AppsCreateNewVersion extends BackendUsecase<
     v.strictObject({
       "/main.tsx": structuralSchemas.backend.types.typescriptModule(),
     }),
+    v.optional(v.string()),
   ]);
   resultSchema = structuralSchemas.global.result(
     structuralSchemas.backend.types.app(),
@@ -45,6 +47,7 @@ export default class AppsCreateNewVersion extends BackendUsecase<
     id: AppId,
     targetCollectionIds: CollectionId[],
     files: AppVersionEntity["files"],
+    spec?: string,
   ): ResultPromise<App, AppNotFound | CollectionNotFound | UnexpectedError> {
     const app = await this.repos.app.find(id);
     if (!app) {
@@ -58,13 +61,28 @@ export default class AppsCreateNewVersion extends BackendUsecase<
     );
     assertAppVersionExists(app.id, previousVersion);
 
+    // Updating intent alone must not rebind unchanged code to newer schemas.
+    const isSpecOnlyUpdate =
+      spec !== undefined &&
+      spec !== previousVersion.spec &&
+      isEqual(files, previousVersion.files) &&
+      isEqual(
+        targetCollectionIds,
+        previousVersion.targetCollections.map(({ id }) => id),
+      );
+
     const targetCollections: AppVersionEntity["targetCollections"] = [];
-    for (const collectionId of targetCollectionIds) {
+    for (const [index, collectionId] of targetCollectionIds.entries()) {
       const collection = await this.repos.collection.find(collectionId);
       if (!collection) {
         return makeUnsuccessfulResult(
           makeResultError("CollectionNotFound", { collectionId }),
         );
+      }
+
+      if (isSpecOnlyUpdate) {
+        targetCollections.push(previousVersion.targetCollections[index]!);
+        continue;
       }
 
       const latestCollectionVersion =
@@ -83,6 +101,7 @@ export default class AppsCreateNewVersion extends BackendUsecase<
       previousVersionId: previousVersion.id,
       appId: app.id,
       targetCollections,
+      spec: spec ?? previousVersion.spec,
       files: files,
       createdAt: new Date(),
     };

--- a/packages/core/executing-backend/src/usecases/inference/GenerateTypescriptModule.ts
+++ b/packages/core/executing-backend/src/usecases/inference/GenerateTypescriptModule.ts
@@ -1,0 +1,396 @@
+import {
+  type Backend,
+  type InferenceOptions,
+  type InferenceOptionsNotValid,
+  type Message,
+  MessageContentPartType,
+  MessageRole,
+  type ToolCall,
+  ToolName,
+  type ToolResult,
+  type TooManyFailedImplementationAttempts,
+  type TypescriptFile,
+  type TypescriptModule,
+  type UnexpectedError,
+  type WriteTypescriptModuleToolNotCalled,
+} from "@superego/backend";
+import type { ResultPromise } from "@superego/global-types";
+import {
+  Id,
+  makeSuccessfulResult,
+  makeUnsuccessfulResult,
+  validateInferenceOptions,
+} from "@superego/shared-utils";
+import { compact } from "es-toolkit";
+import makeResultError from "../../makers/makeResultError.js";
+import InferenceService from "../../requirements/InferenceService.js";
+import isEmpty from "../../utils/isEmpty.js";
+import Usecase from "../../utils/Usecase.js";
+
+const MAX_ATTEMPTS = 5;
+
+export default class GenerateTypescriptModule extends Usecase {
+  async exec(
+    {
+      description,
+      rules,
+      additionalInstructions,
+      template,
+      libs,
+      startingPoint,
+      userRequest,
+      spec,
+    }: Parameters<Backend["inference"]["implementTypescriptModule"]>[0] & {
+      spec?: string;
+    },
+    inferenceOptions: InferenceOptions<"completion">,
+  ): ResultPromise<
+    { module: TypescriptModule; spec: string },
+    | InferenceOptionsNotValid
+    | TooManyFailedImplementationAttempts
+    | WriteTypescriptModuleToolNotCalled
+    | UnexpectedError
+  > {
+    const globalSettings = await this.repos.globalSettings.get();
+
+    const inferenceOptionsIssues = validateInferenceOptions(
+      inferenceOptions,
+      globalSettings.inference,
+    );
+    if (!isEmpty(inferenceOptionsIssues)) {
+      return makeUnsuccessfulResult(
+        makeResultError("InferenceOptionsNotValid", {
+          issues: inferenceOptionsIssues,
+        }),
+      );
+    }
+
+    const inferenceService = this.inferenceServiceFactory.create(
+      globalSettings.inference,
+    );
+
+    return this.attemptImplementation(
+      inferenceService,
+      inferenceOptions,
+      description,
+      rules,
+      additionalInstructions,
+      template,
+      libs,
+      startingPoint,
+      userRequest,
+      spec,
+      1,
+    );
+  }
+
+  private async attemptImplementation(
+    inferenceService: InferenceService,
+    inferenceOptions: InferenceOptions<"completion">,
+    description: string,
+    rules: string | null,
+    additionalInstructions: string | null,
+    template: string,
+    libs: TypescriptFile[],
+    startingPoint: TypescriptFile,
+    userRequest: string,
+    spec: string | undefined,
+    attemptNumber: number,
+    previousAttempt?: Message.ToolCallAssistant | undefined,
+    previousAttemptResponse?: Message.Tool | undefined,
+  ): ResultPromise<
+    { module: TypescriptModule; spec: string },
+    | WriteTypescriptModuleToolNotCalled
+    | TooManyFailedImplementationAttempts
+    | UnexpectedError
+  > {
+    const shouldReattempt = attemptNumber < MAX_ATTEMPTS;
+
+    const message = await inferenceService.generateNextMessage(
+      [
+        GenerateTypescriptModule.getDeveloperMessage(
+          description,
+          rules,
+          additionalInstructions,
+          template,
+          libs,
+          spec !== undefined,
+        ),
+        GenerateTypescriptModule.getUserContextMessage(
+          startingPoint,
+          userRequest,
+          spec,
+        ),
+        previousAttempt ?? null,
+        previousAttemptResponse ?? null,
+      ].filter((message) => message !== null),
+      [WriteTypescriptModuleTool.get(spec !== undefined)],
+      inferenceOptions,
+    );
+
+    if (
+      !(
+        "toolCalls" in message &&
+        message.toolCalls[0] &&
+        WriteTypescriptModuleTool.is(message.toolCalls[0]) &&
+        message.toolCalls[0].input !== null &&
+        typeof message.toolCalls[0].input === "object" &&
+        typeof message.toolCalls[0].input.source === "string" &&
+        (spec === undefined ||
+          typeof message.toolCalls[0].input.spec === "string")
+      )
+    ) {
+      return shouldReattempt
+        ? this.attemptImplementation(
+            inferenceService,
+            inferenceOptions,
+            description,
+            rules,
+            additionalInstructions,
+            template,
+            libs,
+            startingPoint,
+            userRequest,
+            spec,
+            attemptNumber + 1,
+            previousAttempt,
+            previousAttemptResponse,
+          )
+        : makeUnsuccessfulResult(
+            makeResultError("WriteTypescriptModuleToolNotCalled", {
+              generatedMessage: message,
+            }),
+          );
+    }
+
+    const toolCall = message.toolCalls[0];
+
+    const compileResult = await this.typescriptCompiler.compile(
+      { path: startingPoint.path, source: toolCall.input.source },
+      libs,
+    );
+
+    if (!compileResult.success) {
+      return compileResult.error.name === "UnexpectedError"
+        ? makeUnsuccessfulResult(compileResult.error)
+        : shouldReattempt
+          ? this.attemptImplementation(
+              inferenceService,
+              inferenceOptions,
+              description,
+              rules,
+              additionalInstructions,
+              template,
+              libs,
+              startingPoint,
+              userRequest,
+              spec,
+              attemptNumber + 1,
+              message,
+              {
+                id: Id.generate.message(),
+                role: MessageRole.Tool,
+                toolResults: [
+                  {
+                    tool: ToolName.WriteTypescriptModule,
+                    toolCallId: toolCall.id,
+                    output: makeUnsuccessfulResult(compileResult.error),
+                  } satisfies ToolResult.WriteTypescriptModule,
+                ],
+                createdAt: new Date(),
+              },
+            )
+          : makeUnsuccessfulResult(
+              makeResultError("TooManyFailedImplementationAttempts", {
+                failedAttemptsCount: attemptNumber,
+              }),
+            );
+    }
+
+    return makeSuccessfulResult({
+      spec: toolCall.input.spec ?? "",
+      module: {
+        source: toolCall.input.source.replace(
+          `// filename: ${startingPoint.path}\n`,
+          "",
+        ),
+        compiled: compileResult.data,
+      },
+    });
+  }
+
+  private static getDeveloperMessage(
+    description: string,
+    rules: string | null,
+    additionalInstructions: string | null,
+    template: string,
+    libs: TypescriptFile[],
+    includeSpec: boolean,
+  ): Message.Developer {
+    const availableLibs = slimDownLibs(libs)
+      .flatMap((lib) => [
+        "```ts",
+        `// filename: ${lib.path}`,
+        lib.source,
+        "```",
+        "",
+      ])
+      .join("\n");
+    return {
+      role: MessageRole.Developer,
+      content: [
+        {
+          type: MessageContentPartType.Text,
+          text: `
+You are a TypeScript code generator. When asked to implement code, you MUST call
+${ToolName.WriteTypescriptModule}. Do not write any response text - only return
+the tool call.
+
+Starting from the user-supplied TypeScript starting point, implement the
+**entire** module to satisfy the user request.
+
+## Module description
+
+${description}
+
+## Implementation rules
+
+- The module’s default export **must match exactly** the type specified in the
+  template below.
+- The module can import and use the TypeScript files provided below.
+- The implemented module MUST compile without errors and have no type errors.
+  When you receive compiler diagnostics, correct them and call the tool again.
+- Solve all pending TODOs.
+- Only make the changes necessary to satisfy the user request - preserve
+  existing working code in the starting point.
+- Use clear, descriptive variable names and add comments for complex logic.
+${rules ?? ""}
+${
+  includeSpec
+    ? `
+- Return the complete current Markdown app specification in the tool's spec field.
+- Initialize an empty specification from the user request. Describe requirements,
+  expected behavior, constraints, and relevant rationale.
+- Revise the specification when the request changes those requirements. Preserve
+  still-relevant intent, and keep it unchanged for implementation-only fixes.
+- The specification is the current source of truth, not a changelog. Do not invent
+  requirements or record compiler retry history. Code and spec must agree.
+`
+    : ""
+}
+
+${additionalInstructions ? "## Additional instructions" : ""}
+
+${additionalInstructions ? additionalInstructions : ""}
+
+## Module template
+
+\`\`\`ts
+${template}
+\`\`\`
+
+## Available libs
+
+${availableLibs}
+          `
+            .replace(/\n{3,}/g, "\n\n")
+            .trim(),
+        },
+      ],
+    };
+  }
+
+  private static getUserContextMessage(
+    startingPoint: TypescriptFile,
+    userRequest: string,
+    spec: string | undefined,
+  ): Message.UserContext {
+    return {
+      role: MessageRole.UserContext,
+      content: [
+        {
+          type: MessageContentPartType.Text,
+          text: `
+## Starting point
+
+\`\`\`ts
+// filename: ${startingPoint.path}
+${startingPoint.source}
+\`\`\`
+
+${spec !== undefined ? `## Current app specification\n\n${spec}` : ""}
+
+## User request
+
+${userRequest}
+          `.trim(),
+        },
+      ],
+    };
+  }
+}
+
+const WriteTypescriptModuleTool = {
+  is(toolCall: ToolCall): toolCall is ToolCall.WriteTypescriptModule {
+    return toolCall.tool === ToolName.WriteTypescriptModule;
+  },
+
+  get(includeSpec: boolean): InferenceService.FunctionTool {
+    return {
+      type: InferenceService.ToolType.Function,
+      name: ToolName.WriteTypescriptModule,
+      description: "Returns the implemented TypeScript module to the user.",
+      inputSchema: {
+        type: "object",
+        required: includeSpec ? ["source", "spec"] : ["source"],
+        properties: {
+          ...(includeSpec
+            ? {
+                spec: {
+                  type: "string",
+                  description:
+                    "Complete current Markdown specification of the app, without fences.",
+                },
+              }
+            : {}),
+          source: {
+            description:
+              "Source code of the entire TypeScript module that was implemented. Source only. No fences.",
+            type: "string",
+          },
+        },
+      },
+    };
+  },
+};
+
+/** Slims down libs to avoid a huge and largely useless context. */
+function slimDownLibs(libs: TypescriptFile[]): TypescriptFile[] {
+  return compact([
+    ...libs.filter(
+      (lib) =>
+        !(
+          lib.path.startsWith("/node_modules/react") ||
+          lib.path.startsWith("/node_modules/echarts")
+        ),
+    ),
+    libs.some((lib) => lib.path.startsWith("/node_modules/react"))
+      ? {
+          path: "/node_modules/react/index.d.ts",
+          source: [
+            "// Full type definitions omitted. Use standard APIs",
+            'declare module "react";',
+          ].join("\n"),
+        }
+      : null,
+    libs.some((lib) => lib.path.startsWith("/node_modules/echarts"))
+      ? {
+          path: "/node_modules/echarts/index.d.ts",
+          source: [
+            "// Full type definitions omitted. Use standard APIs",
+            'declare module "echarts";',
+          ].join("\n"),
+        }
+      : null,
+  ]);
+}

--- a/packages/core/executing-backend/src/usecases/inference/ImplementApp.ts
+++ b/packages/core/executing-backend/src/usecases/inference/ImplementApp.ts
@@ -5,11 +5,12 @@ import * as structuralSchemas from "../../structural-schemas/index.js";
 import BackendUsecase from "../../utils/BackendUsecase.js";
 import GenerateTypescriptModule from "./GenerateTypescriptModule.js";
 
-export default class InferenceImplementTypescriptModule extends BackendUsecase<
-  Backend["inference"]["implementTypescriptModule"]
+export default class InferenceImplementApp extends BackendUsecase<
+  Backend["inference"]["implementApp"]
 > {
   argumentsSchema = v.tuple([
     v.strictObject({
+      spec: v.string(),
       description: v.string(),
       rules: v.nullable(v.string()),
       additionalInstructions: v.nullable(v.string()),
@@ -21,7 +22,12 @@ export default class InferenceImplementTypescriptModule extends BackendUsecase<
     structuralSchemas.backend.types.inferenceOptions("completion"),
   ]);
   resultSchema = structuralSchemas.global.result(
-    structuralSchemas.backend.types.typescriptModule(),
+    v.strictObject({
+      files: v.strictObject({
+        "/main.tsx": structuralSchemas.backend.types.typescriptModule(),
+      }),
+      spec: v.string(),
+    }),
     [
       structuralSchemas.backend.errors.inferenceOptionsNotValid(),
       structuralSchemas.backend.errors.tooManyFailedImplementationAttempts(),
@@ -31,13 +37,18 @@ export default class InferenceImplementTypescriptModule extends BackendUsecase<
   );
 
   async exec(
-    request: Parameters<Backend["inference"]["implementTypescriptModule"]>[0],
+    request: Parameters<Backend["inference"]["implementApp"]>[0],
     inferenceOptions: InferenceOptions<"completion">,
   ) {
     const result = await this.sub(GenerateTypescriptModule).exec(
       request,
       inferenceOptions,
     );
-    return result.success ? makeSuccessfulResult(result.data.module) : result;
+    return result.success
+      ? makeSuccessfulResult({
+          files: { "/main.tsx": result.data.module },
+          spec: result.data.spec,
+        })
+      : result;
   }
 }

--- a/packages/core/executing-backend/src/usecases/packs/Install.ts
+++ b/packages/core/executing-backend/src/usecases/packs/Install.ts
@@ -226,6 +226,7 @@ export default class PacksInstall extends BackendUsecase<
           targetCollectionIds: definition.targetCollectionIds.map((id) =>
             Id.is.protoCollection(id) ? collectionIdMapping.get(id)! : id,
           ),
+          spec: definition.spec ?? "",
           files: PacksInstall.replaceProtoCollectionIdsInAppFiles(
             definition.files,
             collectionIdMapping,

--- a/packages/data/demo-data-repositories/src/DemoDataRepositoriesManager.ts
+++ b/packages/data/demo-data-repositories/src/DemoDataRepositoriesManager.ts
@@ -53,6 +53,10 @@ export default class DemoDataRepositoriesManager implements DataRepositoriesMana
       conversationTextSearchTexts: {},
       globalSettings: { value: this.defaultGlobalSettings },
     };
+    // Older IndexedDB snapshots predate app specifications.
+    for (const appVersion of Object.values(transactionData.appVersions)) {
+      appVersion.spec ??= "";
+    }
     const initialVersion = transactionData.version;
     const onWrite = () => {
       transactionData.version = crypto.randomUUID();

--- a/packages/data/sqlite-data-repositories/src/migrations/0012.sql
+++ b/packages/data/sqlite-data-repositories/src/migrations/0012.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app_versions"
+ADD COLUMN "spec" TEXT NOT NULL DEFAULT '';

--- a/packages/data/sqlite-data-repositories/src/migrations/migrate.ts
+++ b/packages/data/sqlite-data-repositories/src/migrations/migrate.ts
@@ -11,6 +11,7 @@ import m0008 from "./0008.sql?raw";
 import m0009 from "./0009.sql?raw";
 import m0010 from "./0010.sql?raw";
 import m0011 from "./0011.sql?raw";
+import m0012 from "./0012.sql?raw";
 
 const migrationFiles = {
   "0000.sql": m0000,
@@ -25,6 +26,7 @@ const migrationFiles = {
   "0009.sql": m0009,
   "0010.sql": m0010,
   "0011.sql": m0011,
+  "0012.sql": m0012,
 };
 const table = "migrations";
 

--- a/packages/data/sqlite-data-repositories/src/repositories/SqliteAppVersionRepository.ts
+++ b/packages/data/sqlite-data-repositories/src/repositories/SqliteAppVersionRepository.ts
@@ -30,11 +30,12 @@ export default class SqliteAppVersionRepository implements AppVersionRepository 
             "app_id",
             "target_collections",
             "files",
+            "spec",
             "created_at",
             "is_latest"
           )
         VALUES
-          (?, ?, ?, ?, ?, ?, ?)
+          (?, ?, ?, ?, ?, ?, ?, ?)
       `)
       .run(
         appVersion.id,
@@ -42,6 +43,7 @@ export default class SqliteAppVersionRepository implements AppVersionRepository 
         appVersion.appId,
         encode(appVersion.targetCollections),
         encode(appVersion.files),
+        appVersion.spec,
         appVersion.createdAt.toISOString(),
         1,
       );

--- a/packages/data/sqlite-data-repositories/src/types/SqliteAppVersion.ts
+++ b/packages/data/sqlite-data-repositories/src/types/SqliteAppVersion.ts
@@ -8,6 +8,7 @@ type SqliteAppVersion = {
   app_id: AppId;
   /** MessagePack */
   target_collections: Buffer;
+  spec: string;
   /** MessagePack */
   files: Buffer;
   /** ISO 8601 */
@@ -24,6 +25,7 @@ export function toEntity(appVersion: SqliteAppVersion): AppVersionEntity {
     targetCollections: decode(
       appVersion.target_collections,
     ) as AppVersionEntity["targetCollections"],
+    spec: appVersion.spec,
     files: decode(appVersion.files) as AppVersionEntity["files"],
     createdAt: new Date(appVersion.created_at),
   };

--- a/packages/tests/backend-e2e-tests/src/suites/apps.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/apps.ts
@@ -125,6 +125,7 @@ export default rd<GetDependencies>("Apps", (deps) => {
           type: AppType.CollectionView,
           name: "name",
           latestVersion: {
+            spec: "",
             id: expect.any(String),
             targetCollections: [
               {
@@ -146,6 +147,214 @@ export default rd<GetDependencies>("Apps", (deps) => {
         error: null,
       });
     });
+  });
+
+  describe("spec-only collection bindings", () => {
+    it("keeps the collection versions that match unchanged code", async () => {
+      // Setup SUT
+      const { backend } = deps();
+      const collection = await backend.collections.create({
+        settings: {
+          name: "Items",
+          icon: null,
+          collectionCategoryId: null,
+          defaultCollectionViewAppId: null,
+          description: null,
+          assistantInstructions: null,
+          redirectToCollectionAfterDocumentCreation: false,
+        },
+        schema: {
+          types: { Root: { dataType: DataType.Struct, properties: {} } },
+          rootType: "Root",
+        },
+        versionSettings: {
+          contentBlockingKeysGetter: null,
+          contentSummaryGetter: {
+            source: "",
+            compiled:
+              "export default function getContentSummary() { return {}; }",
+          },
+          defaultDocumentViewUiOptions: null,
+        },
+      });
+      assert(collection.success);
+      const files = {
+        "/main.tsx": {
+          source: "export default 1;",
+          compiled: "export default 1;",
+        },
+      };
+      const app = await backend.apps.create({
+        type: AppType.CollectionView,
+        name: "App",
+        targetCollectionIds: [collection.data.id],
+        files,
+        spec: "Original intent",
+      });
+      assert(app.success);
+      const newCollectionVersion = await backend.collections.createNewVersion(
+        collection.data.id,
+        collection.data.latestVersion.id,
+        collection.data.latestVersion.schema,
+        collection.data.latestVersion.settings,
+        {
+          source: "",
+          compiled:
+            "export default function migrate(content) { return content; }",
+        },
+      );
+      assert(newCollectionVersion.success);
+      expect(newCollectionVersion.data.latestVersion.id).not.toBe(
+        collection.data.latestVersion.id,
+      );
+
+      // Exercise
+      const updated = await backend.apps.createNewVersion(
+        app.data.id,
+        [collection.data.id],
+        files,
+        "Revised intent",
+      );
+
+      // Verify
+      assert(updated.success);
+      expect(updated.data.latestVersion.targetCollections).toEqual(
+        app.data.latestVersion.targetCollections,
+      );
+      expect(updated.data.latestVersion.files).toEqual(files);
+      expect(updated.data.latestVersion.spec).toBe("Revised intent");
+    });
+  });
+
+  describe("specifications", () => {
+    const files = {
+      "/main.tsx": {
+        source: "export default 1;",
+        compiled: "export default 1;",
+      },
+    };
+    const initialSpec =
+      "# Intent\n\nPreserve **Markdown**, whitespace, and caffè.\n";
+
+    it.each([undefined, initialSpec, ""])(
+      "creates and lists spec %s",
+      async (spec) => {
+        // Setup SUT
+        const { backend } = deps();
+
+        // Exercise
+        const created = await backend.apps.create({
+          type: AppType.CollectionView,
+          name: "App",
+          targetCollectionIds: [],
+          files,
+          ...(spec === undefined ? {} : { spec }),
+        });
+        const listed = await backend.apps.list();
+
+        // Verify
+        assert(created.success);
+        expect(created.data.latestVersion.spec).toBe(spec ?? "");
+        assert(listed.success);
+        expect(listed.data).toEqual([created.data]);
+      },
+    );
+
+    it.each([undefined, "# Revised intent", ""])(
+      "creates a spec-only version with %s",
+      async (spec) => {
+        // Setup SUT
+        const { backend } = deps();
+        const created = await backend.apps.create({
+          type: AppType.CollectionView,
+          name: "App",
+          targetCollectionIds: [],
+          files,
+          spec: initialSpec,
+        });
+        assert(created.success);
+
+        // Exercise
+        const updated = await backend.apps.createNewVersion(
+          created.data.id,
+          [],
+          files,
+          spec,
+        );
+        const listed = await backend.apps.list();
+
+        // Verify
+        assert(updated.success);
+        expect(updated.data.latestVersion.spec).toBe(spec ?? initialSpec);
+        expect(updated.data.latestVersion.files).toEqual(files);
+        expect(updated.data.latestVersion.id).not.toBe(
+          created.data.latestVersion.id,
+        );
+        expect(created.data.latestVersion.spec).toBe(initialSpec);
+        assert(listed.success);
+        expect(listed.data).toEqual([updated.data]);
+      },
+    );
+
+    it("preserves the spec when older callers omit the fourth argument", async () => {
+      // Setup SUT
+      const { backend } = deps();
+      const created = await backend.apps.create({
+        type: AppType.CollectionView,
+        name: "App",
+        targetCollectionIds: [],
+        files,
+        spec: initialSpec,
+      });
+      assert(created.success);
+
+      // Exercise
+      const updated = await backend.apps.createNewVersion(
+        created.data.id,
+        [],
+        files,
+      );
+
+      // Verify
+      assert(updated.success);
+      expect(updated.data.latestVersion.spec).toBe(initialSpec);
+    });
+
+    it.each([null, 42, {}])(
+      "rejects invalid specs without changing the app: %s",
+      async (spec) => {
+        // Setup SUT
+        const { backend } = deps();
+        const definition = {
+          type: AppType.CollectionView,
+          name: "App",
+          targetCollectionIds: [],
+          files,
+          spec: initialSpec,
+        };
+        const created = await backend.apps.create(definition);
+        assert(created.success);
+
+        // Exercise
+        const invalidCreate = await backend.apps.create({
+          ...definition,
+          spec: spec as any,
+        });
+        const invalidUpdate = await backend.apps.createNewVersion(
+          created.data.id,
+          [],
+          files,
+          spec as any,
+        );
+        const listed = await backend.apps.list();
+
+        // Verify
+        expect(invalidCreate.error?.name).toBe("ArgumentsNotValid");
+        expect(invalidUpdate.error?.name).toBe("ArgumentsNotValid");
+        assert(listed.success);
+        expect(listed.data).toEqual([created.data]);
+      },
+    );
   });
 
   describe("updateName", () => {
@@ -387,6 +596,7 @@ export default rd<GetDependencies>("Apps", (deps) => {
           type: AppType.CollectionView,
           name: "name",
           latestVersion: {
+            spec: "",
             id: expect.any(String),
             targetCollections: [
               {

--- a/packages/tests/backend-e2e-tests/src/suites/inference.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/inference.ts
@@ -365,4 +365,104 @@ export default rd<GetDependencies>("Inference", (deps) => {
       },
     );
   });
+  describe("implementApp", () => {
+    const request = {
+      description: "An app",
+      rules: null,
+      additionalInstructions: null,
+      template: "export default function App(): number;",
+      libs: [],
+      startingPoint: {
+        path: "/main.tsx" as const,
+        source: "export default function App() { return 1; }",
+      },
+      userRequest: "Display two",
+      spec: "# App\nDisplay one.",
+    };
+
+    it
+      .skipIf(typeof window !== "undefined")
+      .each([
+        "missing",
+        "invalid",
+        "compile failure",
+        "retry",
+        "success",
+        "initial",
+      ])("handles %s", async (scenario) => {
+      // Setup mocks
+      let attempts = 0;
+      const inferenceService: InferenceService = {
+        generateNextMessage: async (messages, tools, inferenceOptions) => {
+          attempts += 1;
+          expect(JSON.stringify(messages)).toContain("Display two");
+          expect(JSON.stringify(messages)).toContain(
+            "Current app specification",
+          );
+          expect(tools[0]?.inputSchema.required).toEqual(["source", "spec"]);
+          const source =
+            scenario === "compile failure" ||
+            (scenario === "retry" && attempts === 1)
+              ? "const value: number = 'wrong';"
+              : "export default function App() { return 2; }";
+          return {
+            id: Id.generate.message(),
+            role: MessageRole.Assistant,
+            toolCalls: [
+              {
+                id: "call-1",
+                tool: ToolName.WriteTypescriptModule,
+                input: {
+                  source,
+                  ...(scenario === "missing"
+                    ? {}
+                    : {
+                        spec:
+                          scenario === "invalid"
+                            ? (42 as any)
+                            : "# App\nDisplay two.",
+                      }),
+                },
+              },
+            ],
+            reasoning: {},
+            inferenceOptions,
+            generationStats: {
+              timeTaken: 0,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            createdAt: new Date(),
+          };
+        },
+        stt: async () => "Mock",
+        inspectFile: async () => "Mock",
+      };
+      // Setup SUT
+      const { backend } = deps({ inferenceService });
+
+      // Exercise
+      const result = await backend.inference.implementApp(
+        { ...request, spec: scenario === "initial" ? "" : request.spec },
+        validInferenceOptions,
+      );
+
+      // Verify
+      if (scenario === "missing" || scenario === "invalid") {
+        expect(result.error?.name).toBe("WriteTypescriptModuleToolNotCalled");
+        expect(attempts).toBe(5);
+      } else if (scenario === "compile failure") {
+        expect(result.error?.name).toBe("TooManyFailedImplementationAttempts");
+        expect(attempts).toBe(5);
+      } else {
+        assert(result.success);
+        expect(result.data.spec).toBe("# App\nDisplay two.");
+        expect(result.data.files["/main.tsx"].source).toContain("return 2");
+        expect(result.data.files["/main.tsx"].compiled).toContain("return 2");
+        expect(attempts).toBe(scenario === "retry" ? 2 : 1);
+      }
+      expect(request.spec).toBe("# App\nDisplay one.");
+    });
+  });
 });

--- a/packages/tests/backend-e2e-tests/src/suites/packs.ts
+++ b/packages/tests/backend-e2e-tests/src/suites/packs.ts
@@ -605,75 +605,80 @@ export default rd<GetDependencies>("Packs", (deps) => {
       expect(listResult.data).toHaveLength(1);
     });
 
-    it("success: installs pack with apps referencing collections", async () => {
-      // Setup SUT
-      const { backend } = deps();
+    it.each([undefined, "# App requirements"])(
+      "success: installs pack apps with spec %s",
+      async (spec) => {
+        // Setup SUT
+        const { backend } = deps();
 
-      // Exercise
-      const result = await backend.packs.install({
-        id: "Pack_com.example.test",
-        info: {
-          name: "Test Pack",
-          shortDescription: "A test pack",
-          longDescription: "A test pack for testing",
-          screenshots: [],
-        },
-        collectionCategories: [],
-        collections: [
-          {
-            settings: {
-              name: "My Collection",
-              icon: null,
-              collectionCategoryId: null,
-              defaultCollectionViewAppId: null,
-              description: null,
-              assistantInstructions: null,
-              redirectToCollectionAfterDocumentCreation: false,
-            },
-            schema: {
-              types: {
-                Root: {
-                  dataType: DataType.Struct,
-                  properties: { title: { dataType: DataType.String } },
+        // Exercise
+        const result = await backend.packs.install({
+          id: "Pack_com.example.test",
+          info: {
+            name: "Test Pack",
+            shortDescription: "A test pack",
+            longDescription: "A test pack for testing",
+            screenshots: [],
+          },
+          collectionCategories: [],
+          collections: [
+            {
+              settings: {
+                name: "My Collection",
+                icon: null,
+                collectionCategoryId: null,
+                defaultCollectionViewAppId: null,
+                description: null,
+                assistantInstructions: null,
+                redirectToCollectionAfterDocumentCreation: false,
+              },
+              schema: {
+                types: {
+                  Root: {
+                    dataType: DataType.Struct,
+                    properties: { title: { dataType: DataType.String } },
+                  },
                 },
+                rootType: "Root",
               },
-              rootType: "Root",
-            },
-            versionSettings: {
-              contentBlockingKeysGetter: null,
-              contentSummaryGetter: {
-                source: "",
-                compiled:
-                  "export default function getContentSummary() { return {}; }",
+              versionSettings: {
+                contentBlockingKeysGetter: null,
+                contentSummaryGetter: {
+                  source: "",
+                  compiled:
+                    "export default function getContentSummary() { return {}; }",
+                },
+                defaultDocumentViewUiOptions: null,
               },
-              defaultDocumentViewUiOptions: null,
             },
-          },
-        ],
-        apps: [
-          {
-            type: AppType.CollectionView,
-            name: "My App",
-            targetCollectionIds: [Id.generate.protoCollection(0)],
-            files: { "/main.tsx": { source: "", compiled: "" } },
-          },
-        ],
-        documents: [],
-      });
+          ],
+          apps: [
+            {
+              type: AppType.CollectionView,
+              name: "My App",
+              ...(spec === undefined ? {} : { spec }),
+              targetCollectionIds: [Id.generate.protoCollection(0)],
+              files: { "/main.tsx": { source: "", compiled: "" } },
+            },
+          ],
+          documents: [],
+        });
 
-      // Verify
-      expect(result.success).toBe(true);
-      assert.isTrue(result.success);
-      expect(result.data.collections).toHaveLength(1);
-      expect(result.data.apps).toHaveLength(1);
-      expect(result.data.apps[0]!.name).toBe("My App");
-      expect(result.data.apps[0]!.latestVersion.targetCollections[0]!.id).toBe(
-        result.data.collections[0]!.id,
-      );
-      const listResult = await backend.apps.list();
-      assert.isTrue(listResult.success);
-      expect(listResult.data).toHaveLength(1);
-    });
+        // Verify
+        expect(result.success).toBe(true);
+        assert.isTrue(result.success);
+        expect(result.data.collections).toHaveLength(1);
+        expect(result.data.apps).toHaveLength(1);
+        expect(result.data.apps[0]!.name).toBe("My App");
+        expect(result.data.apps[0]!.latestVersion.spec).toBe(spec ?? "");
+        expect(
+          result.data.apps[0]!.latestVersion.targetCollections[0]!.id,
+        ).toBe(result.data.collections[0]!.id);
+        const listResult = await backend.apps.list();
+        assert.isTrue(listResult.success);
+        expect(listResult.data).toHaveLength(1);
+      },
+    );
 
     it("success: installs pack with documents", async () => {
       // Setup SUT


### PR DESCRIPTION
Apps now keep a Markdown specification alongside each implementation version, so users and coding agents can preserve requirements, behavior, constraints, and rationale across edits. The browser editor exposes a Spec view, integrated generation returns code and spec together, and CLI projects round-trip the specification through `spec.md`.

Creation defaults an omitted spec to an empty string. Updates preserve an omitted spec and allow an explicit empty string to clear it. SQLite migration, older demo snapshots, and pack installation retain compatibility. Spec-only versions preserve the existing code and collection-version bindings; the CLI detects and diffs these edits without recompiling unchanged source and retains stale-checkout protection.

Validation:

- `yarn test` passed across the repository, including 13 browser app e2e scenarios. After the final collection-binding fix, the complete backend e2e suite passed again: 555 passed, 9 skipped.
- `yarn check-types`, `yarn check-linting`, `yarn check-formatting`, and `yarn check-translations` passed.
- Built the CLI and verified init, create, checkout, status, diff, spec-only commit, stale checkout rejection, missing-file preservation, and explicit clearing against a disposable SQLite database.
- Verified migration of a pre-spec SQLite app version and manually saved/reloaded a spec-only edit in the browser. Inference tests use mocked model responses, including malformed output and compilation retries.

Closes #168
